### PR TITLE
docs: add PR template, YAML issue forms, and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug Report
+description: Report a bug in ChainWeaver
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Create a flow with ...
+        2. Run ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python Version
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+    validations:
+      required: true
+
+  - type: input
+    id: chainweaver-version
+    attributes:
+      label: ChainWeaver Version
+      placeholder: e.g. 0.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (logs, screenshots, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context or screenshots.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+
+## Changes
+
+- 
+
+## Testing
+
+- [ ] All existing tests pass (`pytest`)
+- [ ] New tests added for new functionality
+- [ ] Linting passes (`ruff check`)
+- [ ] Type checking passes (`mypy`)
+
+## Related Issues
+
+
+## Checklist
+- [ ] Code follows project conventions (see `.github/copilot-instructions.md`)
+- [ ] Public API changes are documented
+- [ ] No secrets or credentials included

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to ChainWeaver
+
+Thank you for your interest in contributing to ChainWeaver! This guide covers how to get started.
+
+## Getting Started
+
+1. **Fork** the repository and clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/ChainWeaver.git
+   cd ChainWeaver
+   ```
+
+2. **Install dependencies** (requires Python 3.10+):
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+3. **Create a branch** from `main`:
+   ```bash
+   git checkout -b your-feature-branch
+   ```
+
+## Development Workflow
+
+### Code Style
+
+- Follow existing project conventions (see `.github/copilot-instructions.md`)
+- Use [ruff](https://github.com/astral-sh/ruff) for linting: `ruff check .`
+- Use [mypy](https://mypy-lang.org/) for type checking: `mypy .`
+
+### Testing
+
+- Run the test suite before submitting:
+  ```bash
+  pytest
+  ```
+- Add tests for any new functionality
+- Ensure all existing tests still pass
+
+### Commit Messages
+
+Use clear, descriptive commit messages:
+- `fix: resolve edge case in flow compilation`
+- `feat: add retry logic to tool execution`
+- `docs: update quickstart guide`
+
+## Submitting a Pull Request
+
+1. Push your branch to your fork
+2. Open a PR against `main` on the upstream repository
+3. Fill out the PR template completely
+4. Link any related issues (e.g., `Closes #41`)
+5. Wait for CI checks to pass and a maintainer review
+
+## Reporting Issues
+
+- Use the **Bug Report** or **Feature Request** issue templates
+- Include reproduction steps and version information
+- Search existing issues before creating a new one
+
+## Code of Conduct
+
+Be respectful and constructive. We're all here to build something great together.
+
+---
+
+Thank you for contributing! 🎉


### PR DESCRIPTION
## Summary

Adds structured templates and contributor guide as described in #41.

## Changes

- Added `.github/pull_request_template.md` with testing checklist and conventions
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` (YAML form with Python/ChainWeaver version fields)
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` (YAML form)
- Added `CONTRIBUTING.md` with setup, workflow, commit, and PR guidelines

## Testing

- [x] All files are valid YAML/Markdown (validated locally)
- [x] No code changes — docs only

## Related Issues

Closes #41

## Checklist
- [x] No secrets or credentials included
- [x] Public API changes are documented (N/A — docs only)