### PR TITLE
Rewrite README hero section for 30-second clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ flowchart LR
 
 ```python
 from chainweaver import Tool, Flow, FlowStep, FlowRegistry, FlowExecutor
+# (NumberInput, ValueOutput, double_fn defined in full example below)
 
 # 1. Wrap any function as a schema-validated Tool
 double = Tool(name="double", description="Doubles a number.",


### PR DESCRIPTION
## What changed

Rewrites the top of `README.md` as a compact hero section so first-time visitors understand ChainWeaver in under 30 seconds — within a single browser viewport.

### Hero section (new, lines 1–42)
- **One-line tagline**: "Compile deterministic MCP tool chains into LLM-free executable flows."
- **Badges**: PyPI version, CI status, Python versions, license
- **Mermaid diagram**: before/after showing N LLM calls → 0 LLM calls
- **Minimal quickstart snippet**: ≤10 lines of runnable code
- **Navigation links**: Installation · Why ChainWeaver? · Quick Start · Architecture · Roadmap

### Content reorganization
- Merged "The Problem" + "The Solution" into a new **"Why ChainWeaver?"** section below the fold
- Moved the detailed comparison table into "Why ChainWeaver?" and removed the duplicate at the bottom
- Promoted **Installation** to a top-level `##` section (was nested under Quick Start)

### Bug fix (adjacent)
- Fixed Architecture tree: `logging.py` → `log_utils.py` (the actual filename)

## Why

Resolves #66 — the README was thorough but dense; a first-time visitor had to scroll through multiple sections before understanding what ChainWeaver does.

## How verified

```
ruff check chainweaver/ tests/ examples/     → All checks passed
ruff format --check chainweaver/ tests/ examples/ → 13 files already formatted
python -m mypy chainweaver/                  → no issues found in 7 source files
python -m pytest tests/ -v                   → 46 passed
python examples/simple_linear_flow.py        → runs correctly, output verified
```

## Tradeoffs / risks

- Mermaid diagram uses GitHub-compatible syntax; may not render in all Markdown viewers
- No code changes — only README.md touched

## Scope notes

- All existing content is preserved (reorganized, not deleted)
- The `logging.py` → `log_utils.py` fix in the Architecture section corrects a factual error
- No changes needed to AGENTS.md or copilot-instructions.md (verified anchor links still resolve)