### PR TITLE
Add @tool decorator for zero-boilerplate tool definition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Use these terms consistently in code, docs, comments, and PR descriptions.
 ```text
 chainweaver/
 ├── __init__.py        Public API surface; all exports in __all__
+├── decorators.py      @tool decorator for zero-boilerplate tool definition
 ├── tools.py           Tool class: named callable with Pydantic I/O schemas
 ├── flow.py            FlowStep + Flow: ordered step definitions (Pydantic models)
 ├── registry.py        FlowRegistry: in-memory catalogue of named flows

--- a/README.md
+++ b/README.md
@@ -205,6 +205,63 @@ You can also run the bundled example directly:
 python examples/simple_linear_flow.py
 ```
 
+### With the `@tool` decorator
+
+The `@tool` decorator eliminates boilerplate by introspecting type hints to
+auto-generate input schemas:
+
+```python
+from pydantic import BaseModel
+from chainweaver import tool, Flow, FlowStep, FlowRegistry, FlowExecutor
+
+class ValueOutput(BaseModel):
+    value: int
+
+class FormattedOutput(BaseModel):
+    result: str
+
+@tool(description="Doubles a number.")
+def double(number: int) -> ValueOutput:
+    return {"value": number * 2}
+
+@tool(description="Adds ten.")
+def add_ten(value: int) -> ValueOutput:
+    return {"value": value + 10}
+
+@tool(description="Formats the result.")
+def format_result(value: int) -> FormattedOutput:
+    return {"result": f"Final value: {value}"}
+
+flow = Flow(
+    name="double_add_format",
+    description="Doubles a number, adds 10, and formats the result.",
+    steps=[
+        FlowStep(tool_name="double",        input_mapping={"number": "number"}),
+        FlowStep(tool_name="add_ten",       input_mapping={"value": "value"}),
+        FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+    ],
+)
+
+registry = FlowRegistry()
+registry.register_flow(flow)
+
+executor = FlowExecutor(registry=registry)
+executor.register_tool(double)
+executor.register_tool(add_ten)
+executor.register_tool(format_result)
+
+result = executor.execute_flow("double_add_format", {"number": 5})
+print(result.final_output)  # {'number': 5, 'value': 20, 'result': 'Final value: 20'}
+```
+
+Decorated tools are also directly callable:
+
+```python
+print(double(number=5))  # {'value': 10}
+```
+
+See `examples/decorator_tool.py` for a runnable before/after comparison.
+
 ---
 
 ## Architecture
@@ -212,6 +269,7 @@ python examples/simple_linear_flow.py
 ```
 chainweaver/
 ├── __init__.py       # Public API
+├── decorators.py     # @tool decorator for zero-boilerplate tool definition
 ├── tools.py          # Tool — named callable with Pydantic schemas
 ├── flow.py           # FlowStep + Flow — ordered step definitions
 ├── registry.py       # FlowRegistry — in-memory flow catalogue

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ All errors are typed and traceable:
 | `SchemaValidationError` | Input or output fails Pydantic validation |
 | `InputMappingError` | A mapping key is not present in the context |
 | `FlowExecutionError` | The tool callable raises an unexpected exception |
+| `ToolDefinitionError` | The `@tool` decorator cannot build a tool from a function |
 
 All exceptions inherit from `ChainWeaverError`.
 

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -14,6 +14,7 @@ Public API
         SchemaValidationError,
         InputMappingError,
         FlowExecutionError,
+        ToolDefinitionError,
     )
 """
 
@@ -29,6 +30,7 @@ from chainweaver.exceptions import (
     FlowNotFoundError,
     InputMappingError,
     SchemaValidationError,
+    ToolDefinitionError,
     ToolNotFoundError,
 )
 from chainweaver.executor import ExecutionResult, FlowExecutor, StepRecord
@@ -56,6 +58,7 @@ __all__ = [
     "SchemaValidationError",
     "StepRecord",
     "Tool",
+    "ToolDefinitionError",
     "ToolNotFoundError",
     "tool",
 ]

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 
+from chainweaver.decorators import tool
 from chainweaver.exceptions import (
     ChainWeaverError,
     FlowAlreadyExistsError,
@@ -56,4 +57,5 @@ __all__ = [
     "StepRecord",
     "Tool",
     "ToolNotFoundError",
+    "tool",
 ]

--- a/chainweaver/decorators.py
+++ b/chainweaver/decorators.py
@@ -93,6 +93,15 @@ def _build_tool(
     # -- Build input schema fields ------------------------------------------
     fields: dict[str, Any] = {}
     for param_name, param in sig.parameters.items():
+        # Positional-only parameters cannot be passed as keyword arguments,
+        # but the adapter always calls the function via **kwargs.
+        if param.kind is inspect.Parameter.POSITIONAL_ONLY:
+            raise ChainWeaverError(
+                f"Function '{fn.__name__}' uses positional-only parameters, "
+                f"which are not supported by the @tool decorator. "
+                f"Use the explicit Tool() constructor instead."
+            )
+
         if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
             raise ChainWeaverError(
                 f"Function '{fn.__name__}' uses *args or **kwargs, "

--- a/chainweaver/decorators.py
+++ b/chainweaver/decorators.py
@@ -1,0 +1,188 @@
+"""Decorator for zero-boilerplate tool definition.
+
+The :func:`tool` decorator creates a :class:`~chainweaver.tools.Tool` from a
+type-annotated Python function, eliminating the need to manually define
+Pydantic input/output schemas and the ``Tool()`` constructor call.
+
+Example::
+
+    from chainweaver import tool
+
+    class ValueOutput(BaseModel):
+        value: int
+
+    @tool(description="Doubles a number.")
+    def double(number: int) -> ValueOutput:
+        return {"value": number * 2}
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any, get_type_hints, overload
+
+from pydantic import BaseModel, create_model
+
+from chainweaver.exceptions import ChainWeaverError
+from chainweaver.tools import Tool
+
+
+class _DecoratedTool(Tool):
+    """A Tool created via the ``@tool`` decorator that is also directly callable.
+
+    Behaves exactly like a :class:`~chainweaver.tools.Tool` but additionally
+    supports calling with the original function signature.
+    """
+
+    def __init__(
+        self,
+        *,
+        original_fn: Callable[..., Any],
+        name: str,
+        description: str,
+        input_schema: type[BaseModel],
+        output_schema: type[BaseModel],
+        fn: Callable[[Any], dict[str, Any]],
+    ) -> None:
+        super().__init__(
+            name=name,
+            description=description,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            fn=fn,
+        )
+        self._original_fn = original_fn
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Call the original function directly, bypassing schema validation."""
+        return self._original_fn(*args, **kwargs)
+
+
+def _build_tool(
+    fn: Callable[..., Any],
+    *,
+    name: str | None,
+    description: str | None,
+) -> _DecoratedTool:
+    """Build a :class:`_DecoratedTool` from a type-annotated function."""
+    tool_name = name if name is not None else fn.__name__
+    tool_description = description if description is not None else (fn.__doc__ or "").strip()
+
+    hints = get_type_hints(fn, include_extras=True)
+    sig = inspect.signature(fn)
+
+    # -- Validate return type -----------------------------------------------
+    return_type = hints.get("return")
+    if return_type is None:
+        raise ChainWeaverError(
+            f"Function '{fn.__name__}' is missing a return type annotation. "
+            f"The return type must be a BaseModel subclass. "
+            f"Use the explicit Tool() constructor for functions without full type hints."
+        )
+
+    if not (isinstance(return_type, type) and issubclass(return_type, BaseModel)):
+        raise ChainWeaverError(
+            f"Function '{fn.__name__}' return type must be a BaseModel subclass, "
+            f"got '{return_type}'. "
+            f"Use the explicit Tool() constructor for functions without full type hints."
+        )
+
+    output_schema = return_type
+
+    # -- Build input schema fields ------------------------------------------
+    fields: dict[str, Any] = {}
+    for param_name, param in sig.parameters.items():
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            raise ChainWeaverError(
+                f"Function '{fn.__name__}' uses *args or **kwargs, "
+                f"which cannot be introspected into a schema. "
+                f"Use the explicit Tool() constructor instead."
+            )
+
+        if param_name not in hints:
+            raise ChainWeaverError(
+                f"Parameter '{param_name}' of function '{fn.__name__}' "
+                f"is missing a type annotation. "
+                f"Use the explicit Tool() constructor for functions "
+                f"without full type hints."
+            )
+
+        param_type = hints[param_name]
+        if param.default is inspect.Parameter.empty:
+            fields[param_name] = (param_type, ...)
+        else:
+            fields[param_name] = (param_type, param.default)
+
+    input_schema: type[BaseModel] = create_model(f"{tool_name}_input", **fields)
+
+    # -- Create adapter for Tool.fn signature --------------------------------
+    def _adapter(inp: Any) -> dict[str, Any]:
+        return fn(**inp.model_dump())  # type: ignore[no-any-return]
+
+    return _DecoratedTool(
+        original_fn=fn,
+        name=tool_name,
+        description=tool_description,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        fn=_adapter,
+    )
+
+
+@overload
+def tool(fn: Callable[..., Any], /) -> _DecoratedTool: ...
+
+
+@overload
+def tool(
+    *,
+    name: str | None = ...,
+    description: str | None = ...,
+) -> Callable[[Callable[..., Any]], _DecoratedTool]: ...
+
+
+def tool(
+    fn: Callable[..., Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> _DecoratedTool | Callable[[Callable[..., Any]], _DecoratedTool]:
+    """Create a :class:`~chainweaver.tools.Tool` from a type-annotated function.
+
+    Can be used as a bare decorator or as a decorator factory with keyword
+    arguments:
+
+    .. code-block:: python
+
+        @tool
+        def greet(name: str) -> GreetOutput:
+            \"\"\"Say hello.\"\"\"
+            return {"message": f"Hello, {name}!"}
+
+        @tool(name="custom_double", description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+    Args:
+        fn: The function to wrap (used when the decorator is applied without
+            parentheses).
+        name: Override the tool name.  Defaults to the function name.
+        description: Tool description.  Falls back to the function's docstring
+            if not provided.
+
+    Returns:
+        A :class:`~chainweaver.tools.Tool` that is also directly callable with
+        the original function's signature.
+
+    Raises:
+        ChainWeaverError: When type hints are missing or the return type is not
+            a :class:`~pydantic.BaseModel` subclass.
+    """
+    if fn is not None:
+        return _build_tool(fn, name=name, description=description)
+
+    def _decorator(fn: Callable[..., Any]) -> _DecoratedTool:
+        return _build_tool(fn, name=name, description=description)
+
+    return _decorator

--- a/chainweaver/decorators.py
+++ b/chainweaver/decorators.py
@@ -24,7 +24,7 @@ from typing import Any, get_type_hints, overload
 
 from pydantic import BaseModel, create_model
 
-from chainweaver.exceptions import ChainWeaverError
+from chainweaver.exceptions import ToolDefinitionError
 from chainweaver.tools import Tool
 
 
@@ -72,27 +72,29 @@ def _build_tool(
     try:
         hints = get_type_hints(fn, include_extras=True)
     except (NameError, TypeError) as exc:
-        raise ChainWeaverError(
-            f"Failed to resolve type hints for function '{fn.__name__}': {exc}. "
+        raise ToolDefinitionError(
+            fn.__name__,
+            f"Failed to resolve type hints: {exc}. "
             f"Ensure all annotations are importable and any forward references "
-            f"are either quoted or resolvable in the tool's module."
+            f"are either quoted or resolvable in the tool's module.",
         ) from exc
     sig = inspect.signature(fn)
 
     # -- Validate return type -----------------------------------------------
     return_type = hints.get("return")
     if return_type is None:
-        raise ChainWeaverError(
-            f"Function '{fn.__name__}' is missing a return type annotation. "
-            f"The return type must be a BaseModel subclass. "
-            f"Use the explicit Tool() constructor for functions without full type hints."
+        raise ToolDefinitionError(
+            fn.__name__,
+            "Missing a return type annotation. "
+            "The return type must be a BaseModel subclass. "
+            "Use the explicit Tool() constructor for functions without full type hints.",
         )
 
     if not (isinstance(return_type, type) and issubclass(return_type, BaseModel)):
-        raise ChainWeaverError(
-            f"Function '{fn.__name__}' return type must be a BaseModel subclass, "
-            f"got '{return_type}'. "
-            f"Use the explicit Tool() constructor for functions without full type hints."
+        raise ToolDefinitionError(
+            fn.__name__,
+            f"Return type must be a BaseModel subclass, got '{return_type}'. "
+            f"Use the explicit Tool() constructor for functions without full type hints.",
         )
 
     output_schema = return_type
@@ -103,25 +105,27 @@ def _build_tool(
         # Positional-only parameters cannot be passed as keyword arguments,
         # but the adapter always calls the function via **kwargs.
         if param.kind is inspect.Parameter.POSITIONAL_ONLY:
-            raise ChainWeaverError(
-                f"Function '{fn.__name__}' uses positional-only parameters, "
-                f"which are not supported by the @tool decorator. "
-                f"Use the explicit Tool() constructor instead."
+            raise ToolDefinitionError(
+                fn.__name__,
+                "Uses positional-only parameters, "
+                "which are not supported by the @tool decorator. "
+                "Use the explicit Tool() constructor instead.",
             )
 
         if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
-            raise ChainWeaverError(
-                f"Function '{fn.__name__}' uses *args or **kwargs, "
-                f"which cannot be introspected into a schema. "
-                f"Use the explicit Tool() constructor instead."
+            raise ToolDefinitionError(
+                fn.__name__,
+                "Uses *args or **kwargs, "
+                "which cannot be introspected into a schema. "
+                "Use the explicit Tool() constructor instead.",
             )
 
         if param_name not in hints:
-            raise ChainWeaverError(
-                f"Parameter '{param_name}' of function '{fn.__name__}' "
-                f"is missing a type annotation. "
+            raise ToolDefinitionError(
+                fn.__name__,
+                f"Parameter '{param_name}' is missing a type annotation. "
                 f"Use the explicit Tool() constructor for functions "
-                f"without full type hints."
+                f"without full type hints.",
             )
 
         param_type = hints[param_name]
@@ -192,8 +196,8 @@ def tool(
         the original function's signature.
 
     Raises:
-        ChainWeaverError: When type hints are missing or the return type is not
-            a :class:`~pydantic.BaseModel` subclass.
+        ToolDefinitionError: When type hints are missing or the return type is
+            not a :class:`~pydantic.BaseModel` subclass.
     """
     if fn is not None:
         return _build_tool(fn, name=name, description=description)

--- a/chainweaver/decorators.py
+++ b/chainweaver/decorators.py
@@ -69,7 +69,14 @@ def _build_tool(
     tool_name = name if name is not None else fn.__name__
     tool_description = description if description is not None else (fn.__doc__ or "").strip()
 
-    hints = get_type_hints(fn, include_extras=True)
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+    except (NameError, TypeError) as exc:
+        raise ChainWeaverError(
+            f"Failed to resolve type hints for function '{fn.__name__}': {exc}. "
+            f"Ensure all annotations are importable and any forward references "
+            f"are either quoted or resolvable in the tool's module."
+        ) from exc
     sig = inspect.signature(fn)
 
     # -- Validate return type -----------------------------------------------

--- a/chainweaver/exceptions.py
+++ b/chainweaver/exceptions.py
@@ -71,3 +71,12 @@ class FlowExecutionError(ChainWeaverError):
         self.step_index = step_index
         self.detail = detail
         super().__init__(f"Execution error in tool '{tool_name}' at step {step_index}: {detail}")
+
+
+class ToolDefinitionError(ChainWeaverError):
+    """Raised when the ``@tool`` decorator cannot build a tool from a function."""
+
+    def __init__(self, function_name: str, detail: str) -> None:
+        self.function_name = function_name
+        self.detail = detail
+        super().__init__(f"Cannot define tool from function '{function_name}': {detail}")

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -21,6 +21,7 @@ and tools, the same flow produces the same output every time.
 
 | Module | Responsibility | Key constraint |
 |--------|---------------|----------------|
+| `decorators.py` | `@tool` decorator for zero-boilerplate tool definition | Returns a `Tool` subclass; introspects type hints |
 | `tools.py` | Define `Tool`: name + callable + Pydantic I/O schemas | Tool functions must be `fn(BaseModel) -> dict[str, Any]` |
 | `flow.py` | Define `FlowStep` and `Flow` as Pydantic models | Pure data definitions; no execution logic |
 | `registry.py` | Store and retrieve flows by name | In-memory; intentionally simple for later wrapping |

--- a/examples/decorator_tool.py
+++ b/examples/decorator_tool.py
@@ -1,0 +1,156 @@
+"""Decorator-based tool definition example for ChainWeaver.
+
+This script demonstrates the ``@tool`` decorator, which eliminates boilerplate
+by introspecting type hints to auto-generate Pydantic input schemas.
+
+**Before** (explicit ``Tool()`` constructor — 8+ lines per tool)::
+
+    class NumberInput(BaseModel):
+        number: int
+
+    class ValueOutput(BaseModel):
+        value: int
+
+    def double_fn(inp: NumberInput) -> dict:
+        return {"value": inp.number * 2}
+
+    double_tool = Tool(
+        name="double",
+        description="Doubles a number.",
+        input_schema=NumberInput,
+        output_schema=ValueOutput,
+        fn=double_fn,
+    )
+
+**After** (``@tool`` decorator — 3 lines per tool)::
+
+    @tool(description="Doubles a number.")
+    def double(number: int) -> ValueOutput:
+        return {"value": number * 2}
+
+Both approaches produce identical ``Tool`` instances that work with
+``FlowExecutor``.
+
+Run this script from the repository root with::
+
+    python examples/decorator_tool.py
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from chainweaver import Flow, FlowExecutor, FlowRegistry, FlowStep, tool
+
+# Configure logging so that ChainWeaver step logs are visible when running
+# this example directly.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+
+
+# ---------------------------------------------------------------------------
+# Output schemas (still required — they define the tool's output contract)
+# ---------------------------------------------------------------------------
+
+
+class ValueOutput(BaseModel):
+    """Output schema carrying a single integer value."""
+
+    value: int
+
+
+class FormattedOutput(BaseModel):
+    """Output schema for the final formatting tool."""
+
+    result: str
+
+
+# ---------------------------------------------------------------------------
+# Define tools using the @tool decorator
+# ---------------------------------------------------------------------------
+
+
+@tool(description="Takes a number and returns its double.")
+def double(number: int) -> ValueOutput:
+    """Double the input number."""
+    return {"value": number * 2}
+
+
+@tool(description="Takes a value and returns value + 10.")
+def add_ten(value: int) -> ValueOutput:
+    """Add 10 to the input value."""
+    return {"value": value + 10}
+
+
+@tool(description="Formats a numeric value into a human-readable result string.")
+def format_result(value: int) -> FormattedOutput:
+    """Format the input value as a human-readable string."""
+    return {"result": f"Final value: {value}"}
+
+
+# ---------------------------------------------------------------------------
+# Decorated tools are also directly callable
+# ---------------------------------------------------------------------------
+
+print("--- Direct calls ---")
+print(f"double(number=5)       = {double(number=5)}")
+print(f"add_ten(value=10)      = {add_ten(value=10)}")
+print(f"format_result(value=20) = {format_result(value=20)}")
+
+
+# ---------------------------------------------------------------------------
+# Define a flow and execute it (identical to the explicit Tool() approach)
+# ---------------------------------------------------------------------------
+
+flow = Flow(
+    name="double_add_format",
+    description="Doubles a number, adds 10, and formats the result.",
+    steps=[
+        FlowStep(tool_name="double", input_mapping={"number": "number"}),
+        FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+        FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+    ],
+)
+
+
+def main() -> None:
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+
+    executor = FlowExecutor(registry=registry)
+    executor.register_tool(double)
+    executor.register_tool(add_ten)
+    executor.register_tool(format_result)
+
+    initial_input = {"number": 5}
+    print(f"\nExecuting flow '{flow.name}' with input: {initial_input}\n")
+
+    result = executor.execute_flow("double_add_format", initial_input)
+
+    print("\n--- Execution Summary ---")
+    print(f"Flow      : {result.flow_name}")
+    print(f"Success   : {result.success}")
+    print(f"Output    : {result.final_output}")
+    print("\n--- Step Log ---")
+    for record in result.execution_log:
+        status = "OK" if record.success else "FAIL"
+        print(
+            f"  [{status}] Step {record.step_index} | {record.tool_name} | "
+            f"inputs={record.inputs} → outputs={record.outputs}"
+        )
+
+    assert result.success, "Flow execution failed!"
+    assert result.final_output is not None
+    assert result.final_output.get("result") == "Final value: 20", (
+        f"Unexpected result: {result.final_output}"
+    )
+    print("\n✓ Result verified: 'Final value: 20'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -179,6 +179,13 @@ class TestMissingHints:
             def bad(x: int, /) -> ValueOutput:
                 return {"value": x}
 
+    def test_unresolvable_forward_ref(self) -> None:
+        with pytest.raises(ChainWeaverError, match="Failed to resolve type hints"):
+
+            @tool(description="Bad.")
+            def bad(x: NoSuchType) -> ValueOutput:  # type: ignore[name-defined]  # noqa: F821
+                return {"value": 0}
+
 
 # ---------------------------------------------------------------------------
 # Default parameter values

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -172,6 +172,13 @@ class TestMissingHints:
             def bad(**kwargs: int) -> ValueOutput:
                 return {"value": 0}
 
+    def test_positional_only_rejected(self) -> None:
+        with pytest.raises(ChainWeaverError, match="positional-only parameters"):
+
+            @tool(description="Bad.")
+            def bad(x: int, /) -> ValueOutput:
+                return {"value": x}
+
 
 # ---------------------------------------------------------------------------
 # Default parameter values

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from chainweaver import tool
-from chainweaver.exceptions import ChainWeaverError
+from chainweaver.exceptions import ToolDefinitionError
 from chainweaver.executor import FlowExecutor
 from chainweaver.flow import Flow, FlowStep
 from chainweaver.registry import FlowRegistry
@@ -138,49 +138,51 @@ class TestDirectCallable:
 
 class TestMissingHints:
     def test_missing_return_type(self) -> None:
-        with pytest.raises(ChainWeaverError, match="missing a return type"):
+        with pytest.raises(ToolDefinitionError, match="Missing a return type") as exc_info:
 
             @tool(description="Bad.")
             def bad(x: int):  # type: ignore[no-untyped-def]
                 return {"value": x}
 
+        assert exc_info.value.function_name == "bad"
+
     def test_non_basemodel_return_type(self) -> None:
-        with pytest.raises(ChainWeaverError, match="must be a BaseModel subclass"):
+        with pytest.raises(ToolDefinitionError, match="must be a BaseModel subclass"):
 
             @tool(description="Bad.")
             def bad(x: int) -> dict:  # type: ignore[type-arg]
                 return {"value": x}
 
     def test_missing_param_annotation(self) -> None:
-        with pytest.raises(ChainWeaverError, match="missing a type annotation"):
+        with pytest.raises(ToolDefinitionError, match="missing a type annotation"):
 
             @tool(description="Bad.")
             def bad(x) -> ValueOutput:  # type: ignore[no-untyped-def]
                 return {"value": x}
 
     def test_var_positional_rejected(self) -> None:
-        with pytest.raises(ChainWeaverError, match="\\*args or \\*\\*kwargs"):
+        with pytest.raises(ToolDefinitionError, match="\\*args or \\*\\*kwargs"):
 
             @tool(description="Bad.")
             def bad(*args: int) -> ValueOutput:
                 return {"value": 0}
 
     def test_var_keyword_rejected(self) -> None:
-        with pytest.raises(ChainWeaverError, match="\\*args or \\*\\*kwargs"):
+        with pytest.raises(ToolDefinitionError, match="\\*args or \\*\\*kwargs"):
 
             @tool(description="Bad.")
             def bad(**kwargs: int) -> ValueOutput:
                 return {"value": 0}
 
     def test_positional_only_rejected(self) -> None:
-        with pytest.raises(ChainWeaverError, match="positional-only parameters"):
+        with pytest.raises(ToolDefinitionError, match="positional-only parameters"):
 
             @tool(description="Bad.")
             def bad(x: int, /) -> ValueOutput:
                 return {"value": x}
 
     def test_unresolvable_forward_ref(self) -> None:
-        with pytest.raises(ChainWeaverError, match="Failed to resolve type hints"):
+        with pytest.raises(ToolDefinitionError, match="Failed to resolve type hints"):
 
             @tool(description="Bad.")
             def bad(x: NoSuchType) -> ValueOutput:  # type: ignore[name-defined]  # noqa: F821

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,287 @@
+"""Tests for the @tool decorator."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, Field
+
+from chainweaver import tool
+from chainweaver.exceptions import ChainWeaverError
+from chainweaver.executor import FlowExecutor
+from chainweaver.flow import Flow, FlowStep
+from chainweaver.registry import FlowRegistry
+from chainweaver.tools import Tool
+
+# ---------------------------------------------------------------------------
+# Shared output schemas for decorator tests
+# ---------------------------------------------------------------------------
+
+
+class ValueOutput(BaseModel):
+    value: int
+
+
+class GreetOutput(BaseModel):
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Basic usage
+# ---------------------------------------------------------------------------
+
+
+class TestBasicUsage:
+    def test_creates_valid_tool(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert isinstance(double, Tool)
+        assert double.name == "double"
+        assert double.description == "Doubles a number."
+
+    def test_tool_run_validates_and_returns(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        result = double.run({"number": 5})
+        assert result == {"value": 10}
+
+    def test_repr(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert repr(double) == "Tool(name='double')"
+
+
+# ---------------------------------------------------------------------------
+# Custom name
+# ---------------------------------------------------------------------------
+
+
+class TestCustomName:
+    def test_overrides_function_name(self) -> None:
+        @tool(name="my_double", description="Doubles.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert double.name == "my_double"
+
+
+# ---------------------------------------------------------------------------
+# Description fallback
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionFallback:
+    def test_uses_docstring_when_no_description(self) -> None:
+        @tool()
+        def double(number: int) -> ValueOutput:
+            """Doubles a number."""
+            return {"value": number * 2}
+
+        assert double.description == "Doubles a number."
+
+    def test_bare_decorator_uses_docstring(self) -> None:
+        @tool
+        def double(number: int) -> ValueOutput:
+            """Doubles a number."""
+            return {"value": number * 2}
+
+        assert double.description == "Doubles a number."
+
+    def test_empty_description_when_nothing_provided(self) -> None:
+        @tool()
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert double.description == ""
+
+    def test_explicit_description_overrides_docstring(self) -> None:
+        @tool(description="Custom desc.")
+        def double(number: int) -> ValueOutput:
+            """This docstring is ignored."""
+            return {"value": number * 2}
+
+        assert double.description == "Custom desc."
+
+
+# ---------------------------------------------------------------------------
+# Direct callable
+# ---------------------------------------------------------------------------
+
+
+class TestDirectCallable:
+    def test_callable_with_kwargs(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert double(number=5) == {"value": 10}
+
+    def test_callable_with_positional_args(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        assert double(5) == {"value": 10}
+
+
+# ---------------------------------------------------------------------------
+# Missing / insufficient type hints
+# ---------------------------------------------------------------------------
+
+
+class TestMissingHints:
+    def test_missing_return_type(self) -> None:
+        with pytest.raises(ChainWeaverError, match="missing a return type"):
+
+            @tool(description="Bad.")
+            def bad(x: int):  # type: ignore[no-untyped-def]
+                return {"value": x}
+
+    def test_non_basemodel_return_type(self) -> None:
+        with pytest.raises(ChainWeaverError, match="must be a BaseModel subclass"):
+
+            @tool(description="Bad.")
+            def bad(x: int) -> dict:  # type: ignore[type-arg]
+                return {"value": x}
+
+    def test_missing_param_annotation(self) -> None:
+        with pytest.raises(ChainWeaverError, match="missing a type annotation"):
+
+            @tool(description="Bad.")
+            def bad(x) -> ValueOutput:  # type: ignore[no-untyped-def]
+                return {"value": x}
+
+    def test_var_positional_rejected(self) -> None:
+        with pytest.raises(ChainWeaverError, match="\\*args or \\*\\*kwargs"):
+
+            @tool(description="Bad.")
+            def bad(*args: int) -> ValueOutput:
+                return {"value": 0}
+
+    def test_var_keyword_rejected(self) -> None:
+        with pytest.raises(ChainWeaverError, match="\\*args or \\*\\*kwargs"):
+
+            @tool(description="Bad.")
+            def bad(**kwargs: int) -> ValueOutput:
+                return {"value": 0}
+
+
+# ---------------------------------------------------------------------------
+# Default parameter values
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultValues:
+    def test_required_param_only(self) -> None:
+        @tool(description="Adds.")
+        def add(a: int, b: int = 10) -> ValueOutput:
+            return {"value": a + b}
+
+        result = add.run({"a": 5})
+        assert result == {"value": 15}
+
+    def test_both_params_provided(self) -> None:
+        @tool(description="Adds.")
+        def add(a: int, b: int = 10) -> ValueOutput:
+            return {"value": a + b}
+
+        result = add.run({"a": 5, "b": 20})
+        assert result == {"value": 25}
+
+
+# ---------------------------------------------------------------------------
+# No-parameter tools
+# ---------------------------------------------------------------------------
+
+
+class TestNoParameters:
+    def test_no_params_creates_empty_schema(self) -> None:
+        @tool(description="Returns fixed value.")
+        def fixed() -> ValueOutput:
+            return {"value": 42}
+
+        result = fixed.run({})
+        assert result == {"value": 42}
+
+
+# ---------------------------------------------------------------------------
+# Annotated type support
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotatedSupport:
+    def test_annotated_field_metadata(self) -> None:
+        @tool(description="Greets.")
+        def greet(
+            name: Annotated[str, Field(description="The name to greet")],
+        ) -> GreetOutput:
+            return {"message": f"Hello, {name}!"}
+
+        result = greet.run({"name": "World"})
+        assert result == {"message": "Hello, World!"}
+
+        # Verify the field description was preserved in the schema.
+        name_field = greet.input_schema.model_fields["name"]
+        assert name_field.description == "The name to greet"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip with FlowExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripWithExecutor:
+    def test_decorator_tool_in_flow(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        flow = Flow(
+            name="decorator_flow",
+            description="Test flow with decorated tool.",
+            steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double)
+
+        result = ex.execute_flow("decorator_flow", {"number": 5})
+        assert result.success is True
+        assert result.final_output is not None
+        assert result.final_output["value"] == 10
+
+    def test_multi_step_flow_with_decorated_tools(self) -> None:
+        @tool(description="Doubles a number.")
+        def double(number: int) -> ValueOutput:
+            return {"value": number * 2}
+
+        @tool(description="Adds ten.")
+        def add_ten(value: int) -> ValueOutput:
+            return {"value": value + 10}
+
+        flow = Flow(
+            name="double_then_add",
+            description="Doubles then adds ten.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double)
+        ex.register_tool(add_ten)
+
+        result = ex.execute_flow("double_then_add", {"number": 5})
+        assert result.success is True
+        assert result.final_output is not None
+        assert result.final_output["value"] == 20


### PR DESCRIPTION
## What changed

Add a `@chainweaver.tool` decorator that creates a valid `Tool` from a type-annotated Python function, reducing tool definition boilerplate from 8+ lines to 2-3 lines.

### Files

- **`chainweaver/decorators.py`** (new) — Decorator implementation using `inspect.signature()`, `typing.get_type_hints()`, and `pydantic.create_model()` to auto-generate input schemas from function parameters. Returns a `_DecoratedTool` (subclass of `Tool`) that is also directly callable.
- **`chainweaver/__init__.py`** — Import and export `tool` in `__all__`.
- **`tests/test_decorators.py`** (new) — 21 tests across 9 test classes.
- **`AGENTS.md`** — Updated repo map to include `decorators.py`.
- **`docs/agent-context/architecture.md`** — Added `decorators.py` to module boundaries table.

## Why

Closes #67. Defining a tool required separate Pydantic input/output models, a function, and a `Tool()` constructor call (8+ lines). The decorator introspects type hints to eliminate this boilerplate while preserving full compatibility with the existing `Tool()` constructor.

## How verified

All four repo validation commands run locally:

| Command | Result |
|---------|--------|
| `ruff check chainweaver/ tests/ examples/` | All checks passed |
| `ruff format --check chainweaver/ tests/ examples/` | 16 files already formatted |
| `python -m mypy chainweaver/` | Success: no issues found in 8 source files |
| `python -m pytest tests/ -v` | 86 passed, 1 failed (pre-existing) |

The 1 failure (`TestToolZeroDivisionError`) is a pre-existing issue: Python 3.14 changed the `ZeroDivisionError` message from "integer division or modulo by zero" to "division by zero". Unrelated to this PR.

### Test coverage

`chainweaver/decorators.py` — **100% coverage** (44/44 statements).

Tests cover:
- Basic usage (creates valid Tool, run validates, repr)
- Custom name override
- Description fallback (docstring, bare decorator, empty, explicit override)
- Direct callable (kwargs, positional args)
- Missing/insufficient type hints (missing return, non-BaseModel return, missing param annotation, *args, **kwargs)
- Default parameter values
- No-parameter tools
- `Annotated[T, Field(...)]` metadata preservation
- Round-trip with FlowExecutor (single-step and multi-step flows)

## Tradeoffs / risks

- **`create_model()` dynamic models**: The auto-generated input schemas are dynamically created Pydantic models. They work identically to hand-written models but won't appear in static analysis tools' type graph. This is an inherent tradeoff of the convenience layer.
- **No breaking changes**: The existing `Tool()` constructor is completely unchanged. The decorator is a pure addition.

## Doc / agent instruction updates

- **AGENTS.md**: Repo map updated to include `decorators.py`
- **docs/agent-context/architecture.md**: Module boundaries table updated with `decorators.py` entry