### PR TITLE
Add flow serialization, storage backends, and CLI enhancements (v0.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -24,16 +27,19 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # Lint / format / mypy are stable across OSes and Pythons, so we run
+      # them once (the canonical Python 3.10 on ubuntu-latest leg) to keep
+      # the matrix fast and the gating signal unambiguous.
       - name: Lint with Ruff
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         run: ruff check chainweaver/ tests/ examples/
 
       - name: Check formatting with Ruff
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         run: ruff format --check chainweaver/ tests/ examples/
 
       - name: Type check with mypy
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         run: python -m mypy chainweaver/ tests/
 
       - name: Run tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,9 @@ python -m mypy chainweaver/ tests/
 python -m pytest tests/ -v
 ```
 
-CI runs lint + format + mypy on Python 3.10 only; tests run across 3.10–3.13.
+CI runs lint + format + mypy on Python 3.10 / `ubuntu-latest` only; tests
+run across `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11,
+3.12, 3.13}` (12 jobs in total).
 
 For full CI, PR, branch, and commit conventions, see
 [workflows.md](docs/agent-context/workflows.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,8 @@ Full checklist: [review-checklist.md](docs/agent-context/review-checklist.md).
 | [invariants.md](docs/agent-context/invariants.md) | Hard rules, forbidden patterns | Modifying core modules, adding deps, touching executor |
 | [lessons-learned.md](docs/agent-context/lessons-learned.md) | Recurring mistake patterns | Before proposing changes to avoid known pitfalls |
 | [review-checklist.md](docs/agent-context/review-checklist.md) | Definition-of-done, review gates | Before submitting a PR, during code review |
+| [versioning-policy.md](docs/versioning-policy.md) | SemVer policy, public-API scope, deprecation process | Adding / removing / renaming public symbols, planning a release |
+| [v1-release-criteria.md](docs/v1-release-criteria.md) | Measurable v1.0.0 release bar | Before tagging a release, when scoping issues against the v1.0 milestone |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ chainweaver/
 ├── cost.py            CostProfile + CostReport for cost-avoided estimation
 ├── observation.py     TraceRecorder + ObservedTrace for ad-hoc capture
 ├── viz.py             ASCII + Mermaid renderers for Flow/ExecutionResult
+├── serialization.py   YAML + JSON encode/decode for Flow and DAGFlow
 ├── cli.py             typer-based 'chainweaver inspect' entry point
 └── py.typed           PEP 561 marker
 tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ chainweaver/
 ├── decorators.py      @tool decorator for zero-boilerplate tool definition
 ├── tools.py           Tool class: named callable with Pydantic I/O schemas + schema_hash
 ├── flow.py            FlowStep + Flow + DAGFlow + FlowStatus enum + DriftInfo dataclass
-├── registry.py        FlowRegistry: multi-version catalogue with status filtering
+├── registry.py        FlowRegistry: multi-version catalogue with status filtering (store-backed)
+├── storage.py         RegistryStore protocol + InMemoryStore + FileStore (#16)
 ├── executor.py        FlowExecutor: sequential/DAG runner + drift detection (main entry point)
 ├── exceptions.py      Typed exception hierarchy (all inherit ChainWeaverError)
 ├── log_utils.py       Structured per-step logging utilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog
+
+All notable changes to ChainWeaver will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see [docs/versioning-policy.md](docs/versioning-policy.md)).
+
+## [Unreleased]
+
+## [0.4.0] - 2026-05-12
+
+### Added
+
+- **Flow serialization** (#14): `Flow.to_yaml` / `to_json` /
+  `from_yaml` / `from_json` (and `DAGFlow` equivalents) plus the
+  module-level helpers `flow_to_dict`, `flow_from_dict`, `flow_to_json`,
+  `flow_from_json`, `flow_to_yaml`, `flow_from_yaml`. JSON support has
+  no extra runtime dependency; YAML support requires the new optional
+  extra `chainweaver[yaml]` (`pyyaml>=6.0`).
+- **`FlowSerializationError`** exception covering malformed payloads,
+  unknown `type` discriminators, unresolvable class refs, and
+  wrong-base refs.
+- **Pluggable registry storage** (#16): new `chainweaver/storage.py`
+  with a `RegistryStore` `typing.Protocol`, an `InMemoryStore` default
+  (preserves prior in-process behavior), and a `FileStore` that
+  persists each flow as `{name}@{version}.flow.json`. `FlowRegistry`
+  now accepts an optional `store=` parameter; the latest-version
+  pointer is rebuilt from the store on construction so file-backed
+  registries survive process restarts.
+- **CLI `validate`** (#45) — validate a single
+  `.flow.yaml` / `.flow.yml` / `.flow.json` file. Exit codes:
+  0 = valid, 1 = validation error, 2 = file not found.
+- **CLI `check`** (#45) — validate every flow file in a directory
+  (recursive). Supports `--quiet` and `--format json`. Exit codes:
+  0 = all valid, 1 = at least one invalid, 2 = directory not found.
+- **CLI `viz`** (#46) — render a registered flow as ASCII (default)
+  or DOT/Graphviz text. `chainweaver viz my_flow --format dot |
+  dot -Tpng -o my_flow.png` produces a rendered image.
+- **`flow_to_dot`** renderer in `chainweaver/viz.py`, plus
+  `Flow.to_dot()` / `DAGFlow.to_dot()` convenience methods.
+- **Benchmarks** (#29): new top-level `benchmarks/` directory with
+  `bench_naive_vs_compiled.py` (standalone, no test-framework deps)
+  and `benchmarks/README.md`.
+- **CI matrix** (#34): `ubuntu-latest`, `windows-latest`, and
+  `macos-latest` × Python 3.10–3.13 (12 jobs total). Lint, format, and
+  mypy remain pinned to the canonical Python 3.10 / Ubuntu leg.
+- **`docs/versioning-policy.md`** documenting the SemVer policy, public
+  API surface, and deprecation process.
+
+### Changed
+
+- **BREAKING:** `Flow.version` and `DAGFlow.version` are now **required**
+  fields (no `"0.0.0"` default). Callers that previously relied on the
+  implicit default must pass an explicit `version="..."`.
+- **BREAKING:** `Flow.input_schema` / `output_schema` (and the
+  `DAGFlow` equivalents) are no longer `type[BaseModel] | None` fields.
+  They are now read-only properties that lazy-resolve new
+  `input_schema_ref` / `output_schema_ref` fields holding
+  `"module:qualname"` strings. Use
+  `Flow.schema_ref_from(MySchema)` to derive the ref string from a
+  class. This change makes flows fully JSON/YAML-serializable; the
+  cost is that schemas referenced by serialized flows **must** live at
+  module top level (Python cannot reach `<locals>` via `importlib`).
+- **BREAKING:** `RetryPolicy.retryable_errors` is now a
+  `tuple[str, ...]` of `"module:qualname"` references rather than a
+  `tuple[type[BaseException], ...]`. The default value is
+  `("builtins:Exception",)`. `RetryPolicy.resolved_retryable_errors()`
+  resolves the refs to live classes just before the executor's retry
+  loop. Migrate `retryable_errors=(KeyError,)` to
+  `retryable_errors=("builtins:KeyError",)`.
+- `FlowBuilder` gains a `with_version(...)` method; if not called, the
+  builder picks a sensible `"0.1.0"` default to keep prototypes terse.
+- The CLI top-level help string now lists all four subcommands
+  (`inspect`, `validate`, `check`, `viz`).
+
+### Migration guide (0.2.x → 0.4.0)
+
+```python
+# Before
+flow = Flow(
+    name="example",
+    description="...",
+    steps=[...],
+    input_schema=MyInput,
+    output_schema=MyOutput,
+)
+policy = RetryPolicy(retryable_errors=(ValueError,))
+
+# After
+flow = Flow(
+    name="example",
+    version="1.0.0",            # now required
+    description="...",
+    steps=[...],
+    input_schema_ref=Flow.schema_ref_from(MyInput),
+    output_schema_ref=Flow.schema_ref_from(MyOutput),
+)
+policy = RetryPolicy(retryable_errors=("builtins:ValueError",))
+```
+
+Reading the resolved schema is still ergonomic:
+
+```python
+flow.input_schema   # → MyInput (resolves the ref lazily)
+```
+
+## [0.2.0] and earlier
+
+This file starts at 0.4.0.  See the git history for the contents of the
+0.1.0 and 0.2.0 releases.
+
+[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/dgenio/ChainWeaver/releases/tag/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   builder picks a sensible `"0.1.0"` default to keep prototypes terse.
 - The CLI top-level help string now lists all four subcommands
   (`inspect`, `validate`, `check`, `viz`).
+- `flow_to_ascii` (and the `Flow.to_ascii()` / `DAGFlow.to_ascii()`
+  convenience methods, which it backs) now emits the unicode arrow `→`
+  between steps instead of `-->`, matching issue #46's acceptance
+  criterion. Consumers that string-matched `[a] --> [b]` should update
+  their expectations to `[a] → [b]`. The Mermaid renderer
+  (`flow_to_mermaid`) is unaffected — Mermaid grammar still requires
+  `-->`.
 
 ### Migration guide (0.2.x → 0.4.0)
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ All errors are typed and traceable:
 | `FlowAlreadyExistsError` | Registering a flow that already exists (without `overwrite=True`) |
 | `FlowStatusError` | Executing a flow whose status is not `ACTIVE` (without `force=True`) |
 | `InvalidFlowVersionError` | A flow is registered with a version string that is not valid PEP 440 |
+| `FlowSerializationError` | A flow file (YAML/JSON) is malformed, has an unknown discriminator, or references an unresolvable class |
 | `SchemaValidationError` | Input or output fails Pydantic validation |
 | `InputMappingError` | A mapping key is not present in the context |
 | `FlowExecutionError` | The tool callable raises an unexpected exception |
@@ -452,36 +453,19 @@ All exceptions inherit from `ChainWeaverError`.
 
 ## Roadmap
 
-### v0.1 — MVP (current)
+Milestones below mirror the [GitHub milestones](https://github.com/dgenio/ChainWeaver/milestones); see
+[CHANGELOG.md](CHANGELOG.md) for a per-release feature breakdown.
 
-- [x] `Tool` with Pydantic input/output schemas
-- [x] `Flow` as an ordered list of `FlowStep` objects
-- [x] `FlowBuilder` fluent API for flow construction
-- [x] `FlowRegistry` (in-memory)
-- [x] `FlowExecutor` (sequential, LLM-free)
-- [x] Structured per-step logging
-- [x] Typed exceptions
-- [x] Full test suite
-
-### v0.2 — DAG & Branching
-
-- [x] DAG-based execution with dependency edges (`DAGFlow`, `DAGFlowStep`)
-- [x] Topological level-grouped execution with sibling key-conflict detection
-- [x] `DAGDefinitionError` — cycle / duplicate ID / unknown dep detected at registration
-- [ ] Actual parallel/async execution for independent levels
-- [ ] Conditional branching inside flows
-
-### v0.3 — Persistence & Learning
-
-- [ ] JSON/YAML flow storage and reload
-- [ ] Runtime chain observation (record ad-hoc tool sequences)
-- [ ] Automatic flow suggestion from observed patterns
-
-### v0.4 — Scoring & Observability
-
-- [ ] Determinism scoring for partial flows
-- [ ] OpenTelemetry trace export
-- [ ] Async execution mode
+| Milestone | Theme | Status |
+|-----------|-------|--------|
+| **v0.1.0** — Harden Foundation & Streamline DX | Infra, docs, DX APIs, CI | shipped |
+| **v0.2.0** — Build Core Execution & MCP Bridge | DAG execution, MCP adapter/server, guardrails | shipped |
+| **v0.3.0** — Enable Composition, Resilience & Observation | Sub-flows, retry, serialization, governance pipeline | shipped |
+| **v0.4.0** — Add Async, Persistence & Visualization | File-backed registry store, JSON/YAML flow serialization, ASCII/DOT visualization, multi-OS CI matrix | **shipped (current)** |
+| **v0.5.0** — Enforce Schema Governance & Maturity | Fingerprinting, drift detection, structured traces | planned |
+| **v0.6.0** — Expand Integrations & Ecosystem Reach | Replay, VirtualTool, export, LangChain/LlamaIndex bridges | planned |
+| **v0.7.0** — Ship CLI & Validate Performance | CLI polish, benchmarks, offline LLM compiler | planned |
+| **v1.0.0** — Finalize Stable Release | Ecosystem research, release criteria | planned (see [docs/v1-release-criteria.md](docs/v1-release-criteria.md)) |
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,83 @@
+# ChainWeaver Benchmarks
+
+Quantitative evidence for the "compiled, not interpreted" claim
+(issue #29).  Each benchmark contrasts a deterministic ChainWeaver flow
+against a baseline that simulates an LLM call between every tool — the
+naive-chaining approach we expect ChainWeaver to displace.
+
+## Running
+
+```bash
+# Default sweep (4 cases, ~5 seconds wall-clock)
+python benchmarks/bench_naive_vs_compiled.py
+
+# Single ad-hoc case
+python benchmarks/bench_naive_vs_compiled.py --steps 10 --llm-ms 500
+
+# Emit a machine-readable JSON report alongside the human table
+python benchmarks/bench_naive_vs_compiled.py --output results/bench.json
+```
+
+`time.sleep` is used to simulate the LLM round-trip — no real LLM is
+invoked, so the benchmark is reproducible and dependency-free.  All
+durations are measured with `time.perf_counter`.
+
+## Metrics captured
+
+| Metric | Meaning |
+|--------|---------|
+| `total_duration_ms` | Wall-clock time for the full chain. |
+| `tool_execution_ms` | Cumulative time spent inside tool functions. |
+| `overhead_ms` | `total_duration_ms - tool_execution_ms` (orchestration cost). |
+| `llm_calls_count` | Number of simulated LLM calls (naive only). |
+| `llm_calls_avoided` | `naive.llm_calls_count - compiled.llm_calls_count`. |
+| `speedup_factor` | `naive.total_duration_ms / compiled.total_duration_ms`. |
+| `final_value` | Sanity field — the two approaches must agree. |
+
+## Interpreting the results
+
+- The `compiled` row should consistently report `llm_calls_count = 0`.
+- The `speedup_factor` grows linearly with chain length and with the
+  per-step LLM latency.  At default settings (5 steps, 200ms LLM delay,
+  near-instant tools) the speedup is typically 20× or more.
+- `overhead_ms` for the compiled approach reflects pure ChainWeaver
+  orchestration (schema validation + context merge); it should remain in
+  the sub-millisecond range regardless of chain length.
+- The `final_value` field is identical between the two approaches when
+  `--no-verify` is not set; this is the correctness gate that lives
+  alongside the latency comparison.
+
+## What the benchmark does **not** measure
+
+- Real LLM API costs (tokens, dollars).  The simulated delay is a proxy
+  for latency only.
+- Memory or GC pressure.
+- Concurrency or parallel execution (DAG-level parallelism is tracked
+  separately in issue #80).
+- Cross-language comparisons.
+
+## JSON report shape
+
+When `--output` is supplied the script writes a JSON document of the
+shape:
+
+```json
+{
+  "cases": [
+    {
+      "n_steps": 5,
+      "llm_delay_ms": 200.0,
+      "tool_delay_ms": 0.0,
+      "rows": [
+        { "approach": "naive",    "total_duration_ms": 803.4, "...": "..." },
+        { "approach": "compiled", "total_duration_ms": 1.1,   "...": "..." }
+      ],
+      "speedup_factor": 730.4,
+      "llm_calls_avoided": 4
+    }
+  ]
+}
+```
+
+This format is stable enough to feed into a CI tracker if/when the
+historical-tracking issue (out of scope for #29) lands.

--- a/benchmarks/bench_naive_vs_compiled.py
+++ b/benchmarks/bench_naive_vs_compiled.py
@@ -1,0 +1,322 @@
+"""Naive chaining vs compiled flow benchmark (issue #29).
+
+Measures the latency cost of inserting a simulated LLM round-trip
+between each tool step (the "naive chaining" baseline) versus executing
+the same chain through :class:`~chainweaver.FlowExecutor` with zero LLM
+calls in between (the "compiled flow" approach).
+
+The script is standalone — there are no test-framework dependencies and
+the only chainweaver import is the public package surface.  Run it from
+the repository root::
+
+    python benchmarks/bench_naive_vs_compiled.py
+    python benchmarks/bench_naive_vs_compiled.py --output results.json
+    python benchmarks/bench_naive_vs_compiled.py --steps 10 --llm-ms 500
+
+The benchmark always prints a human-readable table to stdout.  When
+``--output`` is provided it additionally writes a machine-readable JSON
+report so CI can ingest the results (see ``benchmarks/README.md``).
+
+LLM calls are simulated with ``time.sleep`` of a configurable duration;
+no real network traffic is required.  All durations are measured with
+``time.perf_counter`` for sub-millisecond precision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from chainweaver import Flow, FlowExecutor, FlowRegistry, FlowStep, Tool
+
+# ---------------------------------------------------------------------------
+# Schemas + tool functions
+# ---------------------------------------------------------------------------
+
+
+class NumberInput(BaseModel):
+    """Inputs for every benchmark tool."""
+
+    value: int
+
+
+class NumberOutput(BaseModel):
+    """Outputs for every benchmark tool."""
+
+    value: int
+
+
+def _make_step_fn(step_index: int, tool_delay_s: float) -> Any:
+    """Build a tool function that adds 1 to ``value`` after a configurable delay."""
+
+    def _fn(inp: NumberInput) -> dict[str, Any]:
+        if tool_delay_s > 0:
+            time.sleep(tool_delay_s)
+        return {"value": inp.value + 1}
+
+    _fn.__name__ = f"step_{step_index}"
+    return _fn
+
+
+def _make_tool(step_index: int, tool_delay_s: float) -> Tool:
+    return Tool(
+        name=f"step_{step_index}",
+        description=f"Increment value by 1 (step {step_index}).",
+        input_schema=NumberInput,
+        output_schema=NumberOutput,
+        fn=_make_step_fn(step_index, tool_delay_s),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark drivers
+# ---------------------------------------------------------------------------
+
+
+def benchmark_naive_chaining(
+    *,
+    n_steps: int,
+    llm_delay_s: float,
+    tool_delay_s: float,
+) -> dict[str, Any]:
+    """Run *n_steps* tools with a simulated LLM call between each pair.
+
+    The simulated LLM is a ``time.sleep`` of duration *llm_delay_s*; one
+    sleep is inserted between consecutive tools, for a total of
+    ``n_steps - 1`` LLM calls.
+
+    Returns a metrics dict (see :func:`_metric_keys`).
+    """
+    tools = [_make_tool(i, tool_delay_s) for i in range(n_steps)]
+    value = 0
+    tool_time = 0.0
+    llm_calls = 0
+
+    started = time.perf_counter()
+    for index, tool in enumerate(tools):
+        tool_start = time.perf_counter()
+        outputs = tool.run({"value": value})
+        tool_time += time.perf_counter() - tool_start
+        value = int(outputs["value"])
+        if index < len(tools) - 1:
+            time.sleep(llm_delay_s)
+            llm_calls += 1
+    total = time.perf_counter() - started
+
+    return {
+        "approach": "naive",
+        "n_steps": n_steps,
+        "llm_delay_ms": llm_delay_s * 1000.0,
+        "tool_delay_ms": tool_delay_s * 1000.0,
+        "total_duration_ms": total * 1000.0,
+        "tool_execution_ms": tool_time * 1000.0,
+        "overhead_ms": (total - tool_time) * 1000.0,
+        "llm_calls_count": llm_calls,
+        "final_value": value,
+    }
+
+
+def benchmark_compiled_flow(
+    *,
+    n_steps: int,
+    tool_delay_s: float,
+) -> dict[str, Any]:
+    """Execute *n_steps* tools via :class:`FlowExecutor` — zero LLM calls.
+
+    Returns a metrics dict with the same keys as
+    :func:`benchmark_naive_chaining`, with ``llm_delay_ms`` set to ``0``
+    and ``llm_calls_count`` to ``0``.
+    """
+    tools = [_make_tool(i, tool_delay_s) for i in range(n_steps)]
+    flow = Flow(
+        name="bench_compiled",
+        version="0.1.0",
+        description=f"Compiled benchmark flow with {n_steps} steps.",
+        steps=[FlowStep(tool_name=t.name, input_mapping={"value": "value"}) for t in tools],
+    )
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    executor = FlowExecutor(registry=registry)
+    for tool in tools:
+        executor.register_tool(tool)
+
+    started = time.perf_counter()
+    result = executor.execute_flow("bench_compiled", {"value": 0})
+    total = time.perf_counter() - started
+
+    tool_time = sum(record.duration_ms for record in result.execution_log) / 1000.0
+    final_value: int = (result.final_output or {"value": 0})["value"]
+
+    return {
+        "approach": "compiled",
+        "n_steps": n_steps,
+        "llm_delay_ms": 0.0,
+        "tool_delay_ms": tool_delay_s * 1000.0,
+        "total_duration_ms": total * 1000.0,
+        "tool_execution_ms": tool_time * 1000.0,
+        "overhead_ms": (total - tool_time) * 1000.0,
+        "llm_calls_count": 0,
+        "final_value": final_value,
+    }
+
+
+def _metric_keys() -> list[str]:
+    return [
+        "approach",
+        "n_steps",
+        "llm_delay_ms",
+        "tool_delay_ms",
+        "total_duration_ms",
+        "tool_execution_ms",
+        "overhead_ms",
+        "llm_calls_count",
+        "final_value",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _format_row(row: dict[str, Any]) -> str:
+    return (
+        f"  {row['approach']:<8}  "
+        f"steps={row['n_steps']:<3}  "
+        f"llm={row['llm_delay_ms']:>5.0f}ms  "
+        f"tool={row['tool_delay_ms']:>5.0f}ms  "
+        f"total={row['total_duration_ms']:>8.2f}ms  "
+        f"tool_time={row['tool_execution_ms']:>8.2f}ms  "
+        f"overhead={row['overhead_ms']:>8.2f}ms  "
+        f"llm_calls={row['llm_calls_count']}"
+    )
+
+
+def _print_table(report: dict[str, Any]) -> None:
+    print("ChainWeaver Benchmark Results")
+    print("=" * 78)
+    for case in report["cases"]:
+        print(
+            f"\nChain length: {case['n_steps']} steps "
+            f"| LLM delay: {case['llm_delay_ms']:.0f}ms "
+            f"| Tool delay: {case['tool_delay_ms']:.0f}ms"
+        )
+        print("-" * 78)
+        for row in case["rows"]:
+            print(_format_row(row))
+        speedup = case["speedup_factor"]
+        avoided = case["llm_calls_avoided"]
+        print(f"  → speedup: {speedup:.2f}x, LLM calls avoided: {avoided}")
+
+
+def run_cases(
+    cases: list[tuple[int, float, float]],
+    *,
+    verify_correctness: bool = True,
+) -> dict[str, Any]:
+    """Run one benchmark case per ``(n_steps, llm_delay_s, tool_delay_s)`` tuple."""
+    output_cases: list[dict[str, Any]] = []
+    for n_steps, llm_delay_s, tool_delay_s in cases:
+        naive = benchmark_naive_chaining(
+            n_steps=n_steps, llm_delay_s=llm_delay_s, tool_delay_s=tool_delay_s
+        )
+        compiled = benchmark_compiled_flow(n_steps=n_steps, tool_delay_s=tool_delay_s)
+
+        if verify_correctness and naive["final_value"] != compiled["final_value"]:
+            raise RuntimeError(
+                f"Correctness check failed for n_steps={n_steps}: "
+                f"naive={naive['final_value']}, compiled={compiled['final_value']}"
+            )
+
+        speedup = (
+            naive["total_duration_ms"] / compiled["total_duration_ms"]
+            if compiled["total_duration_ms"] > 0
+            else float("inf")
+        )
+        output_cases.append(
+            {
+                "n_steps": n_steps,
+                "llm_delay_ms": llm_delay_s * 1000.0,
+                "tool_delay_ms": tool_delay_s * 1000.0,
+                "rows": [naive, compiled],
+                "speedup_factor": speedup,
+                "llm_calls_avoided": naive["llm_calls_count"] - compiled["llm_calls_count"],
+            }
+        )
+    return {"cases": output_cases}
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark naive LLM chaining vs compiled ChainWeaver flows."
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=None,
+        help="Run a single case with this chain length (overrides default sweep).",
+    )
+    parser.add_argument(
+        "--llm-ms",
+        type=float,
+        default=200.0,
+        help="Simulated LLM round-trip duration in ms (single-case mode). Default: 200.",
+    )
+    parser.add_argument(
+        "--tool-ms",
+        type=float,
+        default=0.0,
+        help="Simulated per-tool execution time in ms. Default: 0 (near-instant).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the machine-readable JSON report.",
+    )
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Skip the correctness assertion between naive and compiled runs.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if args.steps is not None:
+        cases = [(args.steps, args.llm_ms / 1000.0, args.tool_ms / 1000.0)]
+    else:
+        # Default sweep covers the parameter combinations the issue calls out.
+        cases = [
+            (2, 0.100, 0.000),
+            (5, 0.200, 0.000),
+            (10, 0.200, 0.010),
+            (5, 0.500, 0.050),
+        ]
+
+    report = run_cases(cases, verify_correctness=not args.no_verify)
+    _print_table(report)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"\nJSON report written to {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -105,7 +105,7 @@ from chainweaver.viz import flow_to_ascii, flow_to_dot, flow_to_mermaid, result_
 # applications can configure logging centrally without interference.
 logging.getLogger("chainweaver").addHandler(logging.NullHandler())
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "ChainWeaverError",

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -99,7 +99,7 @@ from chainweaver.serialization import (
 )
 from chainweaver.storage import FileStore, InMemoryStore, RegistryStore
 from chainweaver.tools import Tool
-from chainweaver.viz import flow_to_ascii, flow_to_mermaid, result_to_mermaid
+from chainweaver.viz import flow_to_ascii, flow_to_dot, flow_to_mermaid, result_to_mermaid
 
 # Follow Python library best practice: attach only a NullHandler so that
 # applications can configure logging centrally without interference.
@@ -162,6 +162,7 @@ __all__ = [
     "flow_from_yaml",
     "flow_to_ascii",
     "flow_to_dict",
+    "flow_to_dot",
     "flow_to_json",
     "flow_to_mermaid",
     "flow_to_yaml",

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -97,6 +97,7 @@ from chainweaver.serialization import (
     flow_to_json,
     flow_to_yaml,
 )
+from chainweaver.storage import FileStore, InMemoryStore, RegistryStore
 from chainweaver.tools import Tool
 from chainweaver.viz import flow_to_ascii, flow_to_mermaid, result_to_mermaid
 
@@ -120,6 +121,7 @@ __all__ = [
     "DriftInfo",
     "ExecutionPlan",
     "ExecutionResult",
+    "FileStore",
     "Flow",
     "FlowAlreadyExistsError",
     "FlowBuilder",
@@ -132,11 +134,13 @@ __all__ = [
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
+    "InMemoryStore",
     "InputMappingError",
     "InvalidFlowVersionError",
     "ObservedStep",
     "ObservedTrace",
     "RedactionPolicy",
+    "RegistryStore",
     "ReplayMode",
     "ReplayResult",
     "RetryPolicy",

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -16,6 +16,8 @@ Public API
         schema_fingerprint, check_flow_compatibility, CompatibilityIssue,
         compile_flow, CompilationResult, CompilationError, CompilationWarning,
         flow_to_ascii, flow_to_mermaid, result_to_mermaid,
+        flow_to_dict, flow_to_json, flow_to_yaml,
+        flow_from_dict, flow_from_json, flow_from_yaml,
     )
     from chainweaver.exceptions import (
         ChainWeaverError,
@@ -23,6 +25,7 @@ Public API
         ToolNotFoundError,
         FlowNotFoundError,
         FlowAlreadyExistsError,
+        FlowSerializationError,
         FlowStatusError,
         InvalidFlowVersionError,
         SchemaValidationError,
@@ -53,6 +56,7 @@ from chainweaver.exceptions import (
     FlowAlreadyExistsError,
     FlowExecutionError,
     FlowNotFoundError,
+    FlowSerializationError,
     FlowStatusError,
     InputMappingError,
     InvalidFlowVersionError,
@@ -85,6 +89,14 @@ from chainweaver.flow import (
 from chainweaver.log_utils import RedactionPolicy
 from chainweaver.observation import ObservedStep, ObservedTrace, TraceRecorder
 from chainweaver.registry import FlowRegistry
+from chainweaver.serialization import (
+    flow_from_dict,
+    flow_from_json,
+    flow_from_yaml,
+    flow_to_dict,
+    flow_to_json,
+    flow_to_yaml,
+)
 from chainweaver.tools import Tool
 from chainweaver.viz import flow_to_ascii, flow_to_mermaid, result_to_mermaid
 
@@ -116,6 +128,7 @@ __all__ = [
     "FlowExecutor",
     "FlowNotFoundError",
     "FlowRegistry",
+    "FlowSerializationError",
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
@@ -140,8 +153,14 @@ __all__ = [
     "check_flow_compatibility",
     "cli",
     "compile_flow",
+    "flow_from_dict",
+    "flow_from_json",
+    "flow_from_yaml",
     "flow_to_ascii",
+    "flow_to_dict",
+    "flow_to_json",
     "flow_to_mermaid",
+    "flow_to_yaml",
     "result_to_mermaid",
     "schema_fingerprint",
     "tool",

--- a/chainweaver/builder.py
+++ b/chainweaver/builder.py
@@ -53,9 +53,12 @@ class FlowBuilder:
         )
     """
 
+    _DEFAULT_VERSION: str = "0.1.0"
+
     def __init__(self, name: str, description: str) -> None:
         self._name: str = name
         self._description: str = description
+        self._version: str = self._DEFAULT_VERSION
         self._steps: list[FlowStep] = []
         self._input_schema: type[BaseModel] | None = None
         self._output_schema: type[BaseModel] | None = None
@@ -128,6 +131,22 @@ class FlowBuilder:
         self._output_schema = schema
         return self
 
+    def with_version(self, version: str) -> FlowBuilder:
+        """Set the flow's PEP 440 version string.
+
+        Defaults to ``"0.1.0"`` when not called.  The :class:`Flow` constructor
+        requires an explicit version, so the builder picks a sensible default
+        so that quick prototypes and tests stay terse.
+
+        Args:
+            version: A PEP 440-compatible version string (e.g. ``"1.2.0"``).
+
+        Returns:
+            ``self`` — supports method chaining.
+        """
+        self._version = version
+        return self
+
     def with_trigger(self, conditions: dict[str, Any]) -> FlowBuilder:
         """Set optional trigger conditions (free-form metadata).
 
@@ -168,10 +187,19 @@ class FlowBuilder:
 
         return Flow(
             name=self._name,
+            version=self._version,
             description=self._description,
             steps=list(self._steps),
-            input_schema=self._input_schema,
-            output_schema=self._output_schema,
+            input_schema_ref=(
+                Flow.schema_ref_from(self._input_schema)
+                if self._input_schema is not None
+                else None
+            ),
+            output_schema_ref=(
+                Flow.schema_ref_from(self._output_schema)
+                if self._output_schema is not None
+                else None
+            ),
             trigger_conditions=(
                 dict(self._trigger_conditions) if self._trigger_conditions is not None else None
             ),

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -13,6 +13,9 @@ Available commands
 - ``chainweaver check <dir>`` — validate every flow file in *dir* and
   print a summary; quiet mode (``--quiet``) emits only the exit code
   (issue #45).
+- ``chainweaver viz <flow>`` — render a registered flow as ASCII or DOT
+  (Graphviz) text. Pipe the DOT output through ``dot -Tpng`` to produce
+  an image (issue #46).
 
 Programmatic registration entry point
 -------------------------------------
@@ -59,6 +62,7 @@ from chainweaver.exceptions import FlowNotFoundError, FlowSerializationError
 from chainweaver.flow import DAGFlow, Flow
 from chainweaver.registry import FlowRegistry
 from chainweaver.serialization import flow_from_json, flow_from_yaml
+from chainweaver.viz import flow_to_ascii, flow_to_dot
 
 app = typer.Typer(
     name="chainweaver",
@@ -138,6 +142,64 @@ def inspect_command(
         typer.echo(json.dumps(_flow_to_dict(flow), indent=2, default=str))
     else:
         typer.echo(_flow_to_table(flow))
+
+
+# ---------------------------------------------------------------------------
+# viz command (issue #46)
+# ---------------------------------------------------------------------------
+
+
+class VizFormat(str, Enum):
+    """Output format options for ``chainweaver viz``."""
+
+    ASCII = "ascii"
+    DOT = "dot"
+
+
+_VIZ_FLOW_NAME_ARG = typer.Argument(..., help="Name of the flow to visualize.")
+_VIZ_FORMAT_OPTION = typer.Option(
+    VizFormat.ASCII,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Visualization format: 'ascii' (default, terminal-friendly) or 'dot' (Graphviz).",
+)
+
+
+@app.command("viz")
+def viz_command(
+    flow_name: str = _VIZ_FLOW_NAME_ARG,
+    output_format: VizFormat = _VIZ_FORMAT_OPTION,
+) -> None:
+    """Render a registered flow as ASCII or DOT (Graphviz) text.
+
+    Reads the flow from the registry installed via
+    :func:`set_default_registry`, exactly like ``inspect``.  The DOT output
+    is plain text — pipe it through ``dot`` to produce an image::
+
+        chainweaver viz my_flow --format dot | dot -Tpng -o my_flow.png
+
+    Exit codes: 0 = success, 1 = flow not found or no registry configured.
+    """
+    registry = _DEFAULT_REGISTRY
+    if registry is None:
+        typer.echo(
+            "No registry configured. Call chainweaver.cli.set_default_registry(...) "
+            "before invoking the CLI.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        flow = registry.get_flow(flow_name)
+    except FlowNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    if output_format is VizFormat.DOT:
+        typer.echo(flow_to_dot(flow), nl=False)
+    else:
+        typer.echo(flow_to_ascii(flow))
 
 
 # ---------------------------------------------------------------------------

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -1,16 +1,26 @@
-"""Command-line interface for ChainWeaver (issue #44).
+"""Command-line interface for ChainWeaver.
 
-Built on `typer <https://typer.tiangolo.com/>`_.  The ``inspect`` command
-prints a registered flow's structure either as a human-friendly table or
-as machine-readable JSON.
+Built on `typer <https://typer.tiangolo.com/>`_.
+
+Available commands
+------------------
+
+- ``chainweaver inspect <flow>`` — print a registered flow's structure as a
+  human-friendly table or machine-readable JSON (issue #44).
+- ``chainweaver validate <file>`` — validate a flow definition file
+  (``.flow.yaml`` / ``.flow.json``) and report any structural errors
+  (issue #45).
+- ``chainweaver check <dir>`` — validate every flow file in *dir* and
+  print a summary; quiet mode (``--quiet``) emits only the exit code
+  (issue #45).
 
 Programmatic registration entry point
 -------------------------------------
 
-The CLI inspects a :class:`~chainweaver.registry.FlowRegistry` that the
-host application registers via :func:`set_default_registry`.  This avoids
-hard-coding a discovery mechanism (env vars, plugin entry points, etc.)
-and keeps the CLI usable from notebooks and tests:
+The ``inspect`` command queries a :class:`~chainweaver.registry.FlowRegistry`
+that the host application registers via :func:`set_default_registry`.
+This avoids hard-coding a discovery mechanism (env vars, plugin entry
+points, etc.) and keeps the CLI usable from notebooks and tests:
 
 .. code-block:: python
 
@@ -22,12 +32,17 @@ and keeps the CLI usable from notebooks and tests:
     cli.app()  # or use the ``chainweaver`` console script
 
 The :func:`set_default_registry` lookup is module-level state, scoped to
-the current process; tests reset it between cases.
+the current process; tests reset it between cases.  ``validate`` and
+``check`` do **not** consult the default registry — they read flow files
+directly from disk and exercise the serialization round-trip from
+issue #14.
 
 Exit codes:
 
-- ``0`` — success.
-- ``1`` — flow not found, no registry configured, or unexpected error.
+- ``0`` — success / all flows valid.
+- ``1`` — flow not found, validation errors, no registry configured,
+  or unexpected error.
+- ``2`` — input file or directory not found.
 """
 
 from __future__ import annotations
@@ -35,17 +50,19 @@ from __future__ import annotations
 import json
 import sys
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import typer
 
-from chainweaver.exceptions import FlowNotFoundError
+from chainweaver.exceptions import FlowNotFoundError, FlowSerializationError
 from chainweaver.flow import DAGFlow, Flow
 from chainweaver.registry import FlowRegistry
+from chainweaver.serialization import flow_from_json, flow_from_yaml
 
 app = typer.Typer(
     name="chainweaver",
-    help="ChainWeaver CLI — inspect registered flows.",
+    help="ChainWeaver CLI — inspect, validate, and check flows.",
     no_args_is_help=True,
 )
 
@@ -121,6 +138,184 @@ def inspect_command(
         typer.echo(json.dumps(_flow_to_dict(flow), indent=2, default=str))
     else:
         typer.echo(_flow_to_table(flow))
+
+
+# ---------------------------------------------------------------------------
+# validate / check commands (issue #45)
+# ---------------------------------------------------------------------------
+
+_FLOW_FILE_SUFFIXES: tuple[str, ...] = (".flow.yaml", ".flow.yml", ".flow.json")
+
+
+def _load_flow_file(path: Path) -> Flow | DAGFlow:
+    """Load a single flow file by extension; raises :class:`FlowSerializationError`."""
+    name_lower = path.name.lower()
+    text = path.read_text(encoding="utf-8")
+    if name_lower.endswith(".flow.json"):
+        return flow_from_json(text)
+    if name_lower.endswith((".flow.yaml", ".flow.yml")):
+        return flow_from_yaml(text)
+    raise FlowSerializationError(
+        f"Unrecognised extension; expected one of {_FLOW_FILE_SUFFIXES}",
+        source=str(path),
+    )
+
+
+def _iter_flow_files(directory: Path) -> list[Path]:
+    """Return all flow files under *directory* (recursive), sorted for stability."""
+    matches: list[Path] = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_file() and path.name.lower().endswith(_FLOW_FILE_SUFFIXES):
+            matches.append(path)
+    return matches
+
+
+_VALIDATE_PATH_ARG = typer.Argument(
+    ...,
+    help="Path to a .flow.yaml, .flow.yml, or .flow.json file.",
+)
+_CHECK_DIR_ARG = typer.Argument(
+    ...,
+    help="Directory to scan for flow files (recursive).",
+)
+_QUIET_OPTION = typer.Option(
+    False,
+    "--quiet",
+    "-q",
+    help="Suppress per-flow output; exit code communicates the result.",
+)
+_VALIDATE_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("validate")
+def validate_command(
+    file_path: Path = _VALIDATE_PATH_ARG,
+    output_format: OutputFormat = _VALIDATE_FORMAT_OPTION,
+) -> None:
+    """Validate a flow definition file.
+
+    Reads ``file_path`` (``.flow.yaml`` / ``.flow.yml`` / ``.flow.json``),
+    deserializes it via :func:`chainweaver.serialization.flow_from_yaml` or
+    :func:`chainweaver.serialization.flow_from_json`, and reports the
+    outcome.
+
+    Exit codes: 0 = valid, 1 = validation error, 2 = file not found.
+    """
+    if not file_path.exists():
+        typer.echo(f"chainweaver: file not found: {file_path}", err=True)
+        raise typer.Exit(code=2)
+    if not file_path.is_file():
+        typer.echo(f"chainweaver: not a file: {file_path}", err=True)
+        raise typer.Exit(code=2)
+
+    try:
+        flow = _load_flow_file(file_path)
+    except FlowSerializationError as exc:
+        if output_format is OutputFormat.JSON:
+            typer.echo(
+                json.dumps(
+                    {"path": str(file_path), "valid": False, "error": exc.detail},
+                    indent=2,
+                )
+            )
+        else:
+            typer.echo(f"INVALID  {file_path}: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if output_format is OutputFormat.JSON:
+        typer.echo(
+            json.dumps(
+                {
+                    "path": str(file_path),
+                    "valid": True,
+                    "name": flow.name,
+                    "version": flow.version,
+                    "type": "DAGFlow" if isinstance(flow, DAGFlow) else "Flow",
+                    "step_count": len(flow.steps),
+                },
+                indent=2,
+            )
+        )
+    else:
+        kind = "DAGFlow" if isinstance(flow, DAGFlow) else "Flow"
+        typer.echo(f"OK       {file_path}: {flow.name} v{flow.version} [{kind}]")
+
+
+@app.command("check")
+def check_command(
+    directory: Path = _CHECK_DIR_ARG,
+    output_format: OutputFormat = _VALIDATE_FORMAT_OPTION,
+    quiet: bool = _QUIET_OPTION,
+) -> None:
+    """Validate every flow file in *directory* (recursive).
+
+    Walks the directory, attempts to deserialize each ``.flow.*`` file, and
+    prints a per-file status plus a final summary.  When *quiet* is set,
+    only the exit code is meaningful (table output is suppressed; JSON
+    output is still produced because it is the machine-readable contract).
+
+    Exit codes: 0 = all valid, 1 = at least one invalid file, 2 = directory
+    not found.
+    """
+    if not directory.exists():
+        typer.echo(f"chainweaver: directory not found: {directory}", err=True)
+        raise typer.Exit(code=2)
+    if not directory.is_dir():
+        typer.echo(f"chainweaver: not a directory: {directory}", err=True)
+        raise typer.Exit(code=2)
+
+    flow_files = _iter_flow_files(directory)
+    results: list[dict[str, Any]] = []
+    valid_count = 0
+    invalid_count = 0
+
+    for path in flow_files:
+        try:
+            flow = _load_flow_file(path)
+        except FlowSerializationError as exc:
+            invalid_count += 1
+            results.append({"path": str(path), "valid": False, "error": exc.detail})
+            if not quiet and output_format is OutputFormat.TABLE:
+                typer.echo(f"INVALID  {path}: {exc.detail}", err=True)
+            continue
+        valid_count += 1
+        results.append(
+            {
+                "path": str(path),
+                "valid": True,
+                "name": flow.name,
+                "version": flow.version,
+                "type": "DAGFlow" if isinstance(flow, DAGFlow) else "Flow",
+                "step_count": len(flow.steps),
+            }
+        )
+        if not quiet and output_format is OutputFormat.TABLE:
+            kind = "DAGFlow" if isinstance(flow, DAGFlow) else "Flow"
+            typer.echo(f"OK       {path}: {flow.name} v{flow.version} [{kind}]")
+
+    if output_format is OutputFormat.JSON:
+        typer.echo(
+            json.dumps(
+                {
+                    "directory": str(directory),
+                    "valid_count": valid_count,
+                    "invalid_count": invalid_count,
+                    "results": results,
+                },
+                indent=2,
+            )
+        )
+    elif not quiet:
+        typer.echo(f"\n{valid_count} valid, {invalid_count} invalid")
+
+    if invalid_count > 0:
+        raise typer.Exit(code=1)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/chainweaver/exceptions.py
+++ b/chainweaver/exceptions.py
@@ -157,3 +157,24 @@ class InvalidFlowVersionError(ChainWeaverError):
         self.version = version
         self.detail = detail
         super().__init__(f"Flow '{flow_name}' has invalid version '{version}': {detail}.")
+
+
+class FlowSerializationError(ChainWeaverError):
+    """Raised when a flow cannot be serialized or deserialized.
+
+    Covers malformed YAML/JSON payloads, unknown ``type`` discriminators,
+    unresolvable schema/exception class references, and missing required
+    fields.
+
+    Attributes:
+        detail: Human-readable explanation of what failed.
+        source: Optional identifier for the input source (e.g. file path).
+    """
+
+    def __init__(self, detail: str, *, source: str | None = None) -> None:
+        self.detail = detail
+        self.source = source
+        if source is None:
+            super().__init__(f"Flow serialization failed: {detail}.")
+        else:
+            super().__init__(f"Flow serialization failed for '{source}': {detail}.")

--- a/chainweaver/executor.py
+++ b/chainweaver/executor.py
@@ -1181,7 +1181,7 @@ class FlowExecutor:
         retryer = Retrying(
             stop=stop_after_attempt(policy.max_retries + 1),
             wait=_wait_fn if policy.max_retries > 0 else wait_fixed(0),
-            retry=retry_if_exception_type(policy.retryable_errors),
+            retry=retry_if_exception_type(policy.resolved_retryable_errors()),
             reraise=True,
         )
 

--- a/chainweaver/flow.py
+++ b/chainweaver/flow.py
@@ -332,6 +332,12 @@ class Flow(BaseModel):
 
         return flow_to_mermaid(self, direction=direction, show_schemas=show_schemas)
 
+    def to_dot(self) -> str:
+        """Return a DOT (Graphviz) rendering of this flow (issue #46)."""
+        from chainweaver.viz import flow_to_dot
+
+        return flow_to_dot(self)
+
     def to_json(self, *, indent: int | None = 2) -> str:
         """Serialize this flow to a JSON string (issue #14).
 
@@ -579,6 +585,12 @@ class DAGFlow(BaseModel):
         from chainweaver.viz import flow_to_mermaid
 
         return flow_to_mermaid(self, direction=direction, show_schemas=show_schemas)
+
+    def to_dot(self) -> str:
+        """Return a DOT (Graphviz) rendering of this DAG (issue #46)."""
+        from chainweaver.viz import flow_to_dot
+
+        return flow_to_dot(self)
 
     def to_json(self, *, indent: int | None = 2) -> str:
         """Serialize this DAG flow to a JSON string (issue #14)."""

--- a/chainweaver/flow.py
+++ b/chainweaver/flow.py
@@ -13,6 +13,7 @@ registration time via :func:`validate_dag_topology`.
 
 from __future__ import annotations
 
+import importlib
 import random
 from dataclasses import dataclass
 from enum import Enum
@@ -21,7 +22,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from chainweaver.exceptions import DAGDefinitionError
+from chainweaver.exceptions import DAGDefinitionError, FlowSerializationError
 
 
 class FlowStatus(str, Enum):
@@ -36,6 +37,65 @@ class FlowStatus(str, Enum):
     ACTIVE = "active"
     NEEDS_REVIEW = "needs_review"
     DISABLED = "disabled"
+
+
+def _qualified_name(cls: type) -> str:
+    """Return ``"module:qualname"`` for *cls*, suitable for storage and lookup."""
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def resolve_class_ref(ref: str, *, expected_base: type | None = None) -> type:
+    """Resolve a ``"module:qualname"`` string to the referenced class object.
+
+    Used for both schema refs (``Flow.input_schema_ref``, etc.) and exception
+    refs (``RetryPolicy.retryable_errors``).  All breakage modes raise
+    :class:`~chainweaver.exceptions.FlowSerializationError` with a precise
+    detail so that callers can surface actionable error messages.
+
+    Args:
+        ref: A reference of the form ``"package.module:ClassName"`` or
+            ``"package.module:Outer.Inner"`` (for nested classes).
+        expected_base: When provided, the resolved class must be a subclass
+            of this type.  Useful to enforce that schema refs resolve to
+            ``BaseModel`` subclasses or that error refs resolve to
+            ``BaseException`` subclasses.
+
+    Returns:
+        The resolved class object.
+
+    Raises:
+        FlowSerializationError: When *ref* is not in ``module:qualname`` form,
+            when the module cannot be imported, when the attribute does not
+            exist, when the attribute is not a class, or when it does not
+            subclass *expected_base*.
+    """
+    if ":" not in ref:
+        raise FlowSerializationError(f"Class ref '{ref}' must be in 'module:qualname' form")
+    module_path, qualname = ref.split(":", 1)
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise FlowSerializationError(
+            f"Cannot import module '{module_path}' for ref '{ref}': {exc}"
+        ) from exc
+    obj: Any = module
+    for part in qualname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError as exc:
+            raise FlowSerializationError(
+                f"Attribute '{qualname}' not found in module '{module_path}' for ref '{ref}'"
+            ) from exc
+    if not isinstance(obj, type):
+        raise FlowSerializationError(
+            f"Ref '{ref}' resolved to {type(obj).__name__}, expected a class"
+        )
+    if expected_base is not None and not issubclass(obj, expected_base):
+        raise FlowSerializationError(
+            f"Ref '{ref}' resolved to {obj.__name__}, "
+            f"which is not a subclass of {expected_base.__name__}"
+        )
+    return obj
 
 
 class RetryPolicy(BaseModel):
@@ -59,18 +119,48 @@ class RetryPolicy(BaseModel):
             between retries.  Must be ``>= 1.0``.
         jitter: When ``True``, multiply each computed delay by a uniform
             sample in ``[0.5, 1.5)``.
-        retryable_errors: Exception types that trigger a retry.  Anything
-            else fails immediately.  Defaults to ``(Exception,)`` — retry on
-            any error.
+        retryable_errors: Exception class references that trigger a retry.
+            Each entry is a ``"module:qualname"`` string (e.g.
+            ``"builtins.ValueError"`` written as ``"builtins:ValueError"``).
+            Anything else fails immediately.  Defaults to
+            ``("builtins:Exception",)`` — retry on any error.
+
+            String refs (rather than live class objects) keep the policy
+            JSON/YAML-serializable; refs are resolved to types just before
+            the retry loop in :mod:`chainweaver.executor`.
     """
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+    model_config = ConfigDict(frozen=True)
 
     max_retries: int = Field(default=3, ge=0)
     backoff_seconds: float = Field(default=1.0, ge=0.0)
     backoff_multiplier: float = Field(default=2.0, ge=1.0)
     jitter: bool = False
-    retryable_errors: tuple[type[BaseException], ...] = (Exception,)
+    retryable_errors: tuple[str, ...] = ("builtins:Exception",)
+
+    @field_validator("retryable_errors")
+    @classmethod
+    def _validate_retryable_errors(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("retryable_errors must contain at least one class ref.")
+        for ref in value:
+            if ":" not in ref:
+                raise ValueError(
+                    f"retryable_errors entry '{ref}' must be in 'module:qualname' form "
+                    f"(e.g. 'builtins:ValueError')."
+                )
+        return value
+
+    def resolved_retryable_errors(self) -> tuple[type[BaseException], ...]:
+        """Resolve ``retryable_errors`` ref strings to a tuple of exception classes.
+
+        Raises:
+            FlowSerializationError: When any ref cannot be resolved or does
+                not point to a :class:`BaseException` subclass.
+        """
+        return tuple(
+            resolve_class_ref(ref, expected_base=BaseException) for ref in self.retryable_errors
+        )
 
     def compute_delay(self, attempt_number: int) -> float:
         """Return the wait, in seconds, before retry attempt *attempt_number*.
@@ -147,46 +237,88 @@ class Flow(BaseModel):
         trigger_conditions: Optional free-form metadata that an agent or
             higher-level orchestrator can use to decide when to invoke this
             flow.  ChainWeaver itself does not evaluate these conditions.
-        input_schema: An optional Pydantic :class:`~pydantic.BaseModel`
-            subclass describing the shape of the *initial_input* dictionary
-            that a caller must provide when executing this flow.  When set,
-            the :class:`~chainweaver.executor.FlowExecutor` validates
-            *initial_input* against this schema **before** the first step
-            runs.
-        output_schema: An optional Pydantic :class:`~pydantic.BaseModel`
-            subclass describing the shape of the final merged context
-            produced after every step has completed.  When set, the
+        input_schema_ref: An optional ``"module:qualname"`` reference to a
+            Pydantic :class:`~pydantic.BaseModel` subclass describing the
+            shape of the *initial_input* dictionary that a caller must
+            provide when executing this flow.  When set, the
+            :class:`~chainweaver.executor.FlowExecutor` validates
+            *initial_input* against the resolved schema **before** the first
+            step runs.
+
+            String refs (rather than live class objects) keep the flow
+            JSON/YAML-serializable; use :meth:`schema_ref_from` to derive
+            the ref from a class.  The :attr:`input_schema` property
+            resolves the ref lazily.
+        output_schema_ref: An optional ``"module:qualname"`` reference to a
+            Pydantic :class:`~pydantic.BaseModel` subclass describing the
+            shape of the final merged context produced after every step has
+            completed.  When set, the
             :class:`~chainweaver.executor.FlowExecutor` validates the
-            accumulated context against this schema **after** the last step
-            finishes.
+            accumulated context against the resolved schema **after** the
+            last step finishes.
 
     Example::
 
         flow = Flow(
             name="double_add_format",
+            version="1.0.0",
             description="Doubles a number, adds 10, and formats the result.",
             steps=[
                 FlowStep(tool_name="double",    input_mapping={"number": "number"}),
                 FlowStep(tool_name="add_ten",   input_mapping={"value": "value"}),
                 FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
-            output_schema=FormattedOutput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(FormattedOutput),
         )
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     name: str
-    version: str = "0.0.0"
+    version: str
     description: str
     steps: list[FlowStep]
     deterministic: bool = True
     status: FlowStatus = FlowStatus.ACTIVE
     trigger_conditions: dict[str, Any] | None = None
-    input_schema: type[BaseModel] | None = None
-    output_schema: type[BaseModel] | None = None
+    input_schema_ref: str | None = None
+    output_schema_ref: str | None = None
     tool_schema_hashes: dict[str, str] | None = None
+
+    @staticmethod
+    def schema_ref_from(cls: type[BaseModel]) -> str:
+        """Return a ``"module:qualname"`` ref string for *cls*.
+
+        Convenience helper so callers can write
+        ``input_schema_ref=Flow.schema_ref_from(NumberInput)`` instead of
+        hand-formatting the ref string.
+        """
+        return _qualified_name(cls)
+
+    @property
+    def input_schema(self) -> type[BaseModel] | None:
+        """Resolve :attr:`input_schema_ref` to a class, or ``None`` if unset.
+
+        Raises:
+            FlowSerializationError: When the ref cannot be resolved or does
+                not point to a :class:`BaseModel` subclass.
+        """
+        if self.input_schema_ref is None:
+            return None
+        resolved = resolve_class_ref(self.input_schema_ref, expected_base=BaseModel)
+        return resolved
+
+    @property
+    def output_schema(self) -> type[BaseModel] | None:
+        """Resolve :attr:`output_schema_ref` to a class, or ``None`` if unset.
+
+        Raises:
+            FlowSerializationError: When the ref cannot be resolved or does
+                not point to a :class:`BaseModel` subclass.
+        """
+        if self.output_schema_ref is None:
+            return None
+        resolved = resolve_class_ref(self.output_schema_ref, expected_base=BaseModel)
+        return resolved
 
     def to_ascii(self) -> str:
         """Return a single-line ASCII flow diagram (issue #79)."""
@@ -199,6 +331,73 @@ class Flow(BaseModel):
         from chainweaver.viz import flow_to_mermaid
 
         return flow_to_mermaid(self, direction=direction, show_schemas=show_schemas)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Serialize this flow to a JSON string (issue #14).
+
+        Args:
+            indent: Indentation level for pretty-printing.  ``None`` produces
+                a compact single-line representation.
+
+        Returns:
+            A JSON string that round-trips via :meth:`from_json`.
+        """
+        from chainweaver.serialization import flow_to_json
+
+        return flow_to_json(self, indent=indent)
+
+    def to_yaml(self) -> str:
+        """Serialize this flow to a YAML string (issue #14).
+
+        Requires ``pyyaml`` to be installed (``pip install chainweaver[yaml]``).
+
+        Returns:
+            A YAML string that round-trips via :meth:`from_yaml`.
+
+        Raises:
+            FlowSerializationError: When ``pyyaml`` is not available.
+        """
+        from chainweaver.serialization import flow_to_yaml
+
+        return flow_to_yaml(self)
+
+    @classmethod
+    def from_json(cls, data: str) -> Flow:
+        """Deserialize a :class:`Flow` from a JSON string (issue #14).
+
+        Raises:
+            FlowSerializationError: When the JSON payload is malformed,
+                missing required fields, or describes a :class:`DAGFlow`
+                instead of a :class:`Flow`.
+        """
+        from chainweaver.serialization import flow_from_json
+
+        result = flow_from_json(data)
+        if not isinstance(result, cls):
+            raise FlowSerializationError(
+                f"Expected a Flow payload but got {type(result).__name__}"
+            )
+        return result
+
+    @classmethod
+    def from_yaml(cls, data: str) -> Flow:
+        """Deserialize a :class:`Flow` from a YAML string (issue #14).
+
+        Requires ``pyyaml`` to be installed (``pip install chainweaver[yaml]``).
+
+        Raises:
+            FlowSerializationError: When the YAML payload is malformed,
+                missing required fields, or describes a :class:`DAGFlow`
+                instead of a :class:`Flow`.
+        """
+        from chainweaver.serialization import flow_from_yaml
+
+        result = flow_from_yaml(data)
+        if not isinstance(result, cls):
+            raise FlowSerializationError(
+                f"Expected a Flow payload but got {type(result).__name__}"
+            )
+        return result
 
 
 # TODO (Phase 2): Add conditional branching — a step that inspects
@@ -304,10 +503,14 @@ class DAGFlow(BaseModel):
             that no LLM calls are inserted between steps.
         trigger_conditions: Optional free-form metadata for agent-level
             dispatch (not evaluated by ChainWeaver itself).
-        input_schema: Optional Pydantic :class:`~pydantic.BaseModel` subclass
-            validated against ``initial_input`` before the first step runs.
-        output_schema: Optional Pydantic :class:`~pydantic.BaseModel` subclass
-            validated against the final merged context after all steps finish.
+        input_schema_ref: Optional ``"module:qualname"`` ref to a Pydantic
+            :class:`~pydantic.BaseModel` subclass validated against
+            ``initial_input`` before the first step runs.  Resolved lazily
+            via the :attr:`input_schema` property.
+        output_schema_ref: Optional ``"module:qualname"`` ref to a Pydantic
+            :class:`~pydantic.BaseModel` subclass validated against the
+            final merged context after all steps finish.  Resolved lazily
+            via the :attr:`output_schema` property.
 
     Raises:
         DAGDefinitionError: If topology is invalid (cycle, duplicate
@@ -319,6 +522,7 @@ class DAGFlow(BaseModel):
 
         dag = DAGFlow(
             name="diamond",
+            version="1.0.0",
             description="A → (B, C) → D",
             steps=[
                 DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
@@ -329,18 +533,40 @@ class DAGFlow(BaseModel):
         )
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     name: str
-    version: str = "0.0.0"
+    version: str
     description: str
     steps: list[DAGFlowStep]
     deterministic: bool = True
     status: FlowStatus = FlowStatus.ACTIVE
     trigger_conditions: dict[str, Any] | None = None
-    input_schema: type[BaseModel] | None = None
-    output_schema: type[BaseModel] | None = None
+    input_schema_ref: str | None = None
+    output_schema_ref: str | None = None
     tool_schema_hashes: dict[str, str] | None = None
+
+    @staticmethod
+    def schema_ref_from(cls: type[BaseModel]) -> str:
+        """Return a ``"module:qualname"`` ref string for *cls*.
+
+        See :meth:`Flow.schema_ref_from` for full docs.
+        """
+        return _qualified_name(cls)
+
+    @property
+    def input_schema(self) -> type[BaseModel] | None:
+        """Resolve :attr:`input_schema_ref` to a class, or ``None`` if unset."""
+        if self.input_schema_ref is None:
+            return None
+        resolved = resolve_class_ref(self.input_schema_ref, expected_base=BaseModel)
+        return resolved
+
+    @property
+    def output_schema(self) -> type[BaseModel] | None:
+        """Resolve :attr:`output_schema_ref` to a class, or ``None`` if unset."""
+        if self.output_schema_ref is None:
+            return None
+        resolved = resolve_class_ref(self.output_schema_ref, expected_base=BaseModel)
+        return resolved
 
     def to_ascii(self) -> str:
         """Return a multi-line ASCII rendering of this DAG (issue #79)."""
@@ -353,6 +579,57 @@ class DAGFlow(BaseModel):
         from chainweaver.viz import flow_to_mermaid
 
         return flow_to_mermaid(self, direction=direction, show_schemas=show_schemas)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Serialize this DAG flow to a JSON string (issue #14)."""
+        from chainweaver.serialization import flow_to_json
+
+        return flow_to_json(self, indent=indent)
+
+    def to_yaml(self) -> str:
+        """Serialize this DAG flow to a YAML string (issue #14).
+
+        Raises:
+            FlowSerializationError: When ``pyyaml`` is not available.
+        """
+        from chainweaver.serialization import flow_to_yaml
+
+        return flow_to_yaml(self)
+
+    @classmethod
+    def from_json(cls, data: str) -> DAGFlow:
+        """Deserialize a :class:`DAGFlow` from a JSON string (issue #14).
+
+        Raises:
+            FlowSerializationError: When the JSON payload is malformed,
+                missing required fields, or describes a :class:`Flow`
+                instead of a :class:`DAGFlow`.
+        """
+        from chainweaver.serialization import flow_from_json
+
+        result = flow_from_json(data)
+        if not isinstance(result, cls):
+            raise FlowSerializationError(
+                f"Expected a DAGFlow payload but got {type(result).__name__}"
+            )
+        return result
+
+    @classmethod
+    def from_yaml(cls, data: str) -> DAGFlow:
+        """Deserialize a :class:`DAGFlow` from a YAML string (issue #14).
+
+        Raises:
+            FlowSerializationError: When ``pyyaml`` is not available or when
+                the payload is malformed or refers to a :class:`Flow`.
+        """
+        from chainweaver.serialization import flow_from_yaml
+
+        result = flow_from_yaml(data)
+        if not isinstance(result, cls):
+            raise FlowSerializationError(
+                f"Expected a DAGFlow payload but got {type(result).__name__}"
+            )
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/chainweaver/registry.py
+++ b/chainweaver/registry.py
@@ -1,4 +1,4 @@
-"""In-memory flow registry for ChainWeaver.
+"""Flow registry for ChainWeaver.
 
 The :class:`FlowRegistry` is the central catalogue of all registered
 :class:`~chainweaver.flow.Flow` and :class:`~chainweaver.flow.DAGFlow`
@@ -9,18 +9,21 @@ For :class:`~chainweaver.flow.DAGFlow` registrations, topology validation
 (cycle detection, duplicate step IDs, unknown dependency references) is
 performed at registration time via
 :func:`~chainweaver.flow.validate_dag_topology`.
+
+The registry delegates persistence to a :class:`~chainweaver.storage.RegistryStore`.
+The default :class:`~chainweaver.storage.InMemoryStore` preserves the
+original in-process behavior; pass a
+:class:`~chainweaver.storage.FileStore` to persist flows to disk
+(issue #16).
 """
 
 from __future__ import annotations
 
 from packaging.version import InvalidVersion, Version
 
-from chainweaver.exceptions import (
-    FlowAlreadyExistsError,
-    FlowNotFoundError,
-    InvalidFlowVersionError,
-)
+from chainweaver.exceptions import FlowNotFoundError, InvalidFlowVersionError
 from chainweaver.flow import DAGFlow, Flow, FlowStatus, validate_dag_topology
+from chainweaver.storage import InMemoryStore, RegistryStore
 
 AnyFlow = Flow | DAGFlow
 
@@ -34,29 +37,57 @@ def _parse_version(flow_name: str, version: str) -> Version:
 
 
 class FlowRegistry:
-    """An in-memory registry of :class:`~chainweaver.flow.Flow` and
+    """A registry of :class:`~chainweaver.flow.Flow` and
     :class:`~chainweaver.flow.DAGFlow` objects.
 
-    Flows are stored by ``(name, version)`` tuple.  A separate latest-pointer
+    Flows are stored by ``(name, version)`` tuple via a pluggable
+    :class:`~chainweaver.storage.RegistryStore`.  A separate latest-pointer
     tracks the highest-versioned flow per name for fast lookup.
 
     :class:`~chainweaver.flow.DAGFlow` instances are topology-validated at
     registration time; a :class:`~chainweaver.exceptions.DAGDefinitionError`
     is raised immediately if the graph is invalid.
 
+    Args:
+        store: Optional :class:`~chainweaver.storage.RegistryStore` instance
+            used for persistence.  Defaults to a fresh
+            :class:`~chainweaver.storage.InMemoryStore`, preserving the
+            registry's original in-process behavior.
+
     Example::
 
+        # In-memory (default)
         registry = FlowRegistry()
         registry.register_flow(my_flow)
-        registry.register_flow(my_dag_flow)
-        flow = registry.get_flow("my_flow")
 
-    # TODO (Phase 2): Persist and reload flows from JSON/YAML storage.
+        # File-backed
+        from pathlib import Path
+        from chainweaver.storage import FileStore
+
+        registry = FlowRegistry(store=FileStore(Path("./flows")))
+        registry.register_flow(my_flow)  # writes my_flow@<version>.flow.json
     """
 
-    def __init__(self) -> None:
-        self._flows: dict[tuple[str, str], AnyFlow] = {}
-        self._latest: dict[str, str] = {}  # name → latest version
+    def __init__(self, store: RegistryStore | None = None) -> None:
+        self._store: RegistryStore = store if store is not None else InMemoryStore()
+        # Latest-version pointer; rebuilt from the store on construction so a
+        # file-backed registry restored across process boundaries still
+        # answers ``get_flow(name)`` queries without an explicit version.
+        self._latest: dict[str, str] = {}
+        for name, version in self._store.list_keys():
+            self._touch_latest(name, version)
+
+    @property
+    def store(self) -> RegistryStore:
+        """Return the underlying :class:`~chainweaver.storage.RegistryStore`."""
+        return self._store
+
+    def _touch_latest(self, name: str, version: str) -> None:
+        """Update the latest-version pointer for *name* if *version* is newer."""
+        parsed_new = _parse_version(name, version)
+        current = self._latest.get(name)
+        if current is None or parsed_new >= _parse_version(name, current):
+            self._latest[name] = version
 
     def register_flow(self, flow: AnyFlow, *, overwrite: bool = False) -> None:
         """Register a :class:`~chainweaver.flow.Flow` or
@@ -81,17 +112,11 @@ class FlowRegistry:
                 PEP 440 version string.
         """
         # Validate version up-front so callers always see a ChainWeaverError.
-        new_version = _parse_version(flow.name, flow.version)
-        key = (flow.name, flow.version)
-        if key in self._flows and not overwrite:
-            raise FlowAlreadyExistsError(flow.name)
+        _parse_version(flow.name, flow.version)
         if isinstance(flow, DAGFlow):
             validate_dag_topology(flow)
-        self._flows[key] = flow
-        # Update latest pointer.
-        current_latest = self._latest.get(flow.name)
-        if current_latest is None or new_version >= _parse_version(flow.name, current_latest):
-            self._latest[flow.name] = flow.version
+        self._store.save_flow(flow, overwrite=overwrite)
+        self._touch_latest(flow.name, flow.version)
 
     def get_flow(self, name: str, *, version: str | None = None) -> AnyFlow:
         """Return the flow registered under *name*.
@@ -108,18 +133,12 @@ class FlowRegistry:
         Raises:
             FlowNotFoundError: When no flow with *name* (and *version*) is registered.
         """
-        if version is not None:
-            key = (name, version)
-        else:
+        if version is None:
             latest_ver = self._latest.get(name)
             if latest_ver is None:
                 raise FlowNotFoundError(name)
-            key = (name, latest_ver)
-
-        try:
-            return self._flows[key]
-        except KeyError:
-            raise FlowNotFoundError(name, version=version) from None
+            version = latest_ver
+        return self._store.load_flow(name, version)
 
     def list_flows(
         self,
@@ -144,7 +163,8 @@ class FlowRegistry:
             pairs, after applying the optional status filters.
         """
         results: list[AnyFlow] = []
-        for flow in self._flows.values():
+        for name, version in self._store.list_keys():
+            flow = self._store.load_flow(name, version)
             if status is not None and flow.status != status:
                 continue
             if exclude_status is not None and flow.status in exclude_status:
@@ -159,7 +179,11 @@ class FlowRegistry:
     def set_flow_status(
         self, flow_name: str, status: FlowStatus, *, version: str | None = None
     ) -> None:
-        """Update a flow's status in-place.
+        """Update a flow's status.
+
+        For in-memory stores the mutation is in-place; for stores that
+        snapshot on read (e.g. :class:`~chainweaver.storage.FileStore`) the
+        updated flow is re-saved.
 
         Args:
             flow_name: Name of the flow to update.
@@ -172,6 +196,10 @@ class FlowRegistry:
         """
         flow = self.get_flow(flow_name, version=version)
         flow.status = status
+        # Persist the mutation back to the store.  For ``InMemoryStore`` the
+        # save is a no-op identity write (objects are mutated in place); for
+        # ``FileStore`` it re-writes the JSON file with the new status.
+        self._store.save_flow(flow, overwrite=True)
 
     def list_flow_versions(self, name: str) -> list[str]:
         """Return all registered versions of a flow, sorted ascending.
@@ -185,7 +213,7 @@ class FlowRegistry:
         Raises:
             FlowNotFoundError: When no flow with *name* is registered.
         """
-        versions = [ver for (n, ver) in self._flows if n == name]
+        versions = [ver for (n, ver) in self._store.list_keys() if n == name]
         if not versions:
             raise FlowNotFoundError(name)
         return sorted(versions, key=lambda v: _parse_version(name, v))
@@ -206,14 +234,15 @@ class FlowRegistry:
         #   agents can discover flows from natural-language descriptions.
         """
         intent_lower = intent.lower()
-        for flow in self._flows.values():
+        for name, version in self._store.list_keys():
+            flow = self._store.load_flow(name, version)
             if intent_lower in flow.name.lower() or intent_lower in flow.description.lower():
                 return flow
         return None
 
     def __len__(self) -> int:
-        return len(self._flows)
+        return len(self._store.list_keys())
 
     def __repr__(self) -> str:
-        names = sorted({n for n, _ in self._flows})
+        names = sorted({n for n, _ in self._store.list_keys()})
         return f"FlowRegistry(flows={names})"

--- a/chainweaver/serialization.py
+++ b/chainweaver/serialization.py
@@ -136,8 +136,9 @@ def flow_to_yaml(flow: AnyFlow) -> str:
     """Serialize *flow* to a YAML string.
 
     Requires ``pyyaml`` to be installed.  The output uses block style
-    (`default_flow_style=False`) and preserves key order so files are
-    diff-friendly.
+    (``default_flow_style=False``) and emits keys in alphabetical order
+    (``sort_keys=True``) so the same flow always renders identically and
+    diffs stay stable across processes.
 
     Raises:
         FlowSerializationError: When ``pyyaml`` is not available.

--- a/chainweaver/serialization.py
+++ b/chainweaver/serialization.py
@@ -123,7 +123,7 @@ def flow_from_json(data: str) -> AnyFlow:
 def _require_yaml() -> Any:
     """Return the ``yaml`` module, or raise :class:`FlowSerializationError`."""
     try:
-        import yaml  # type: ignore[import-untyped]
+        import yaml
     except ImportError as exc:
         raise FlowSerializationError(
             "YAML support requires 'pyyaml' to be installed. "

--- a/chainweaver/serialization.py
+++ b/chainweaver/serialization.py
@@ -1,0 +1,169 @@
+"""Flow serialization helpers (issue #14).
+
+Round-trips :class:`~chainweaver.flow.Flow` and :class:`~chainweaver.flow.DAGFlow`
+through JSON or YAML strings.  A ``"type": "Flow"`` / ``"type": "DAGFlow"``
+discriminator at the top of the payload disambiguates the two flow shapes
+on deserialization.
+
+JSON serialization has no extra dependencies.  YAML serialization requires
+``pyyaml`` (available via ``pip install chainweaver[yaml]``); the YAML
+helpers raise :class:`~chainweaver.exceptions.FlowSerializationError` with
+an informative message when it is missing.
+
+Schema references (``input_schema_ref`` / ``output_schema_ref``) round-trip
+as ``"module:qualname"`` strings.  Retry exception types likewise round-trip
+as strings.  No live class objects are written to the payload, so flow
+files stay JSON-compatible end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from chainweaver.exceptions import FlowSerializationError
+from chainweaver.flow import DAGFlow, Flow
+
+_TYPE_KEY = "type"
+_FLOW_DISCRIMINATOR = "Flow"
+_DAG_DISCRIMINATOR = "DAGFlow"
+
+AnyFlow = Flow | DAGFlow
+
+
+# ---------------------------------------------------------------------------
+# dict <-> Flow|DAGFlow
+# ---------------------------------------------------------------------------
+
+
+def flow_to_dict(flow: AnyFlow) -> dict[str, Any]:
+    """Return a JSON-serializable dict representation of *flow*.
+
+    Adds a ``type`` discriminator so the inverse :func:`flow_from_dict` can
+    re-instantiate the correct class.
+    """
+    payload = flow.model_dump(mode="json")
+    if isinstance(flow, DAGFlow):
+        payload[_TYPE_KEY] = _DAG_DISCRIMINATOR
+    else:
+        payload[_TYPE_KEY] = _FLOW_DISCRIMINATOR
+    return payload
+
+
+def flow_from_dict(data: dict[str, Any]) -> AnyFlow:
+    """Reconstruct a :class:`Flow` or :class:`DAGFlow` from a dict payload.
+
+    The dict must contain a ``type`` key whose value is either ``"Flow"`` or
+    ``"DAGFlow"``.
+
+    Raises:
+        FlowSerializationError: When the payload is not a dict, lacks a
+            valid ``type`` discriminator, or fails Pydantic validation
+            against the chosen model.
+    """
+    if not isinstance(data, dict):
+        raise FlowSerializationError(
+            f"Expected a mapping at the top level, got {type(data).__name__}"
+        )
+    flow_type = data.get(_TYPE_KEY)
+    if flow_type not in (_FLOW_DISCRIMINATOR, _DAG_DISCRIMINATOR):
+        raise FlowSerializationError(
+            f"Missing or invalid 'type' discriminator (got {flow_type!r}); "
+            f"expected 'Flow' or 'DAGFlow'"
+        )
+    payload = {k: v for k, v in data.items() if k != _TYPE_KEY}
+    model: type[AnyFlow] = DAGFlow if flow_type == _DAG_DISCRIMINATOR else Flow
+    try:
+        return model.model_validate(payload)
+    except Exception as exc:
+        raise FlowSerializationError(
+            f"Validation failed while reconstructing {flow_type}: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def flow_to_json(flow: AnyFlow, *, indent: int | None = 2) -> str:
+    """Serialize *flow* to a JSON string.
+
+    Args:
+        flow: The flow to serialize.
+        indent: Indentation level for pretty-printing.  ``None`` produces a
+            compact single-line representation.
+
+    Returns:
+        A JSON string that round-trips via :func:`flow_from_json`.
+    """
+    return json.dumps(flow_to_dict(flow), indent=indent, sort_keys=True)
+
+
+def flow_from_json(data: str) -> AnyFlow:
+    """Deserialize a JSON string produced by :func:`flow_to_json`.
+
+    Raises:
+        FlowSerializationError: When *data* is not valid JSON, when the
+            payload is not a JSON object, or when validation fails (see
+            :func:`flow_from_dict`).
+    """
+    try:
+        parsed = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise FlowSerializationError(f"Invalid JSON: {exc}") from exc
+    return flow_from_dict(parsed)
+
+
+# ---------------------------------------------------------------------------
+# YAML
+# ---------------------------------------------------------------------------
+
+
+def _require_yaml() -> Any:
+    """Return the ``yaml`` module, or raise :class:`FlowSerializationError`."""
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise FlowSerializationError(
+            "YAML support requires 'pyyaml' to be installed. "
+            "Install it via 'pip install chainweaver[yaml]'"
+        ) from exc
+    return yaml
+
+
+def flow_to_yaml(flow: AnyFlow) -> str:
+    """Serialize *flow* to a YAML string.
+
+    Requires ``pyyaml`` to be installed.  The output uses block style
+    (`default_flow_style=False`) and preserves key order so files are
+    diff-friendly.
+
+    Raises:
+        FlowSerializationError: When ``pyyaml`` is not available.
+    """
+    yaml = _require_yaml()
+    return str(
+        yaml.safe_dump(
+            flow_to_dict(flow),
+            default_flow_style=False,
+            sort_keys=True,
+        )
+    )
+
+
+def flow_from_yaml(data: str) -> AnyFlow:
+    """Deserialize a YAML string produced by :func:`flow_to_yaml`.
+
+    Raises:
+        FlowSerializationError: When ``pyyaml`` is not available, when *data*
+            is not valid YAML, or when validation fails.
+    """
+    yaml = _require_yaml()
+    try:
+        parsed = yaml.safe_load(data)
+    except yaml.YAMLError as exc:
+        raise FlowSerializationError(f"Invalid YAML: {exc}") from exc
+    if parsed is None:
+        raise FlowSerializationError("YAML payload is empty")
+    return flow_from_dict(parsed)

--- a/chainweaver/serialization.py
+++ b/chainweaver/serialization.py
@@ -14,6 +14,22 @@ Schema references (``input_schema_ref`` / ``output_schema_ref``) round-trip
 as ``"module:qualname"`` strings.  Retry exception types likewise round-trip
 as strings.  No live class objects are written to the payload, so flow
 files stay JSON-compatible end-to-end.
+
+.. warning::
+
+    **Trust boundary**: deserialization resolves ``input_schema_ref``,
+    ``output_schema_ref``, and ``RetryPolicy.retryable_errors`` via
+    :func:`chainweaver.flow.resolve_class_ref`, which calls
+    :func:`importlib.import_module` on the module half of every ``"module:qualname"``
+    string in the payload.  Importing a module runs its top-level code, so a
+    crafted flow file can trigger arbitrary side effects in any module that
+    happens to be available on ``sys.path``.  The subsequent ``isinstance``
+    and ``expected_base`` checks reject the *resolved attribute* but do not
+    undo the import.
+
+    Load flow files only from sources you trust (your own repo, a controlled
+    registry, etc.).  Treat untrusted flow payloads with the same caution as
+    untrusted ``pickle`` input.
 """
 
 from __future__ import annotations

--- a/chainweaver/storage.py
+++ b/chainweaver/storage.py
@@ -72,7 +72,13 @@ class RegistryStore(Protocol):
         ...
 
     def list_keys(self) -> list[tuple[str, str]]:
-        """Return all ``(name, version)`` pairs in deterministic order."""
+        """Return all ``(name, version)`` pairs sorted lexicographically.
+
+        Sort order is fixed (``sorted(..., key=lambda kv: kv)``) so the
+        result is reproducible across processes, backends, and the same
+        backend's repeated calls.  Callers that need a different ordering
+        (e.g. semver) should re-sort the returned list.
+        """
         ...
 
     def delete_flow(self, name: str, version: str) -> None:
@@ -116,7 +122,7 @@ class InMemoryStore:
         return (name, version) in self._flows
 
     def list_keys(self) -> list[tuple[str, str]]:
-        return list(self._flows)
+        return sorted(self._flows)
 
     def delete_flow(self, name: str, version: str) -> None:
         try:

--- a/chainweaver/storage.py
+++ b/chainweaver/storage.py
@@ -1,0 +1,227 @@
+"""Pluggable storage backends for :class:`~chainweaver.registry.FlowRegistry` (issue #16).
+
+Defines a :class:`RegistryStore` :class:`typing.Protocol` and two reference
+implementations:
+
+- :class:`InMemoryStore` — dict-backed (the default; preserves the original
+  registry behavior).
+- :class:`FileStore` — JSON-on-disk, one file per ``(name, version)`` pair.
+  Uses the serialization helpers from :mod:`chainweaver.serialization` so
+  flow files are human-readable and diff-friendly.
+
+Persistence beyond JSON-on-disk (SQLite, S3, etc.) is deliberately out of
+scope; both implementations are intentionally simple so that downstream
+projects can subclass or wrap them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from chainweaver.exceptions import (
+    FlowAlreadyExistsError,
+    FlowNotFoundError,
+    FlowSerializationError,
+)
+from chainweaver.flow import DAGFlow, Flow
+from chainweaver.serialization import flow_from_json, flow_to_json
+
+AnyFlow = Flow | DAGFlow
+
+# Filenames look like "<name>@<version>.flow.json".
+_FILE_SUFFIX = ".flow.json"
+_FILENAME_RE = re.compile(r"^(?P<name>[^@/\\]+)@(?P<version>[^/\\]+)\.flow\.json$")
+# Restrict flow names to characters that are safe on Windows + POSIX.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@runtime_checkable
+class RegistryStore(Protocol):
+    """Storage protocol consumed by :class:`~chainweaver.registry.FlowRegistry`.
+
+    Implementations must be deterministic in the sense that
+    :meth:`load_flow` returns the same flow object (or one equal to it) for
+    repeated calls until an explicit :meth:`save_flow` or :meth:`delete_flow`
+    intervenes.
+
+    The protocol intentionally mirrors the public ``FlowRegistry`` surface so
+    backends can be swapped without rewriting the registry.
+    """
+
+    def save_flow(self, flow: AnyFlow, *, overwrite: bool = False) -> None:
+        """Persist *flow* under ``(flow.name, flow.version)``.
+
+        Raises:
+            FlowAlreadyExistsError: When a flow with the same name and
+                version already exists and *overwrite* is ``False``.
+        """
+        ...
+
+    def load_flow(self, name: str, version: str) -> AnyFlow:
+        """Return the flow stored under ``(name, version)``.
+
+        Raises:
+            FlowNotFoundError: When no flow matches.
+        """
+        ...
+
+    def has_flow(self, name: str, version: str) -> bool:
+        """Return ``True`` when ``(name, version)`` is stored."""
+        ...
+
+    def list_keys(self) -> list[tuple[str, str]]:
+        """Return all ``(name, version)`` pairs in deterministic order."""
+        ...
+
+    def delete_flow(self, name: str, version: str) -> None:
+        """Remove the flow stored under ``(name, version)``.
+
+        Raises:
+            FlowNotFoundError: When no flow matches.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# InMemoryStore — default, backward-compatible
+# ---------------------------------------------------------------------------
+
+
+class InMemoryStore:
+    """Default in-process store backed by a dict.
+
+    Preserves the original :class:`~chainweaver.registry.FlowRegistry`
+    behavior bit-for-bit; the registry uses this when no ``store`` is
+    supplied at construction time.
+    """
+
+    def __init__(self) -> None:
+        self._flows: dict[tuple[str, str], AnyFlow] = {}
+
+    def save_flow(self, flow: AnyFlow, *, overwrite: bool = False) -> None:
+        key = (flow.name, flow.version)
+        if key in self._flows and not overwrite:
+            raise FlowAlreadyExistsError(flow.name)
+        self._flows[key] = flow
+
+    def load_flow(self, name: str, version: str) -> AnyFlow:
+        try:
+            return self._flows[(name, version)]
+        except KeyError:
+            raise FlowNotFoundError(name, version=version) from None
+
+    def has_flow(self, name: str, version: str) -> bool:
+        return (name, version) in self._flows
+
+    def list_keys(self) -> list[tuple[str, str]]:
+        return list(self._flows)
+
+    def delete_flow(self, name: str, version: str) -> None:
+        try:
+            del self._flows[(name, version)]
+        except KeyError:
+            raise FlowNotFoundError(name, version=version) from None
+
+    def __len__(self) -> int:
+        return len(self._flows)
+
+
+# ---------------------------------------------------------------------------
+# FileStore — JSON-on-disk
+# ---------------------------------------------------------------------------
+
+
+def _validate_name(name: str) -> None:
+    """Reject names that would produce unsafe filenames."""
+    if not _NAME_RE.match(name):
+        raise FlowSerializationError(
+            f"Flow name '{name}' is not safe for file storage; "
+            f"only ASCII letters, digits, '.', '_', and '-' are allowed"
+        )
+
+
+def _validate_version(version: str) -> None:
+    if "/" in version or "\\" in version or "@" in version:
+        raise FlowSerializationError(
+            f"Flow version '{version}' contains a path separator or '@'; "
+            f"these are reserved in filenames"
+        )
+
+
+class FileStore:
+    """JSON-on-disk registry store.
+
+    Each flow is written to ``<base_dir>/<name>@<version>.flow.json`` using
+    the canonical :func:`~chainweaver.serialization.flow_to_json` encoder.
+    Suitable for single-process local development and small deployments;
+    concurrent multi-process access is not coordinated and is out of scope.
+
+    Args:
+        base_dir: Directory where flow files live.  Created (with parents)
+            if it does not exist.
+
+    Raises:
+        FlowSerializationError: When a flow's name or version is unsafe for
+            file storage (see :func:`_validate_name` / :func:`_validate_version`).
+    """
+
+    def __init__(self, base_dir: Path | str) -> None:
+        self._base_dir = Path(base_dir)
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def base_dir(self) -> Path:
+        """Return the on-disk directory where flow files are stored."""
+        return self._base_dir
+
+    def _path_for(self, name: str, version: str) -> Path:
+        _validate_name(name)
+        _validate_version(version)
+        return self._base_dir / f"{name}@{version}{_FILE_SUFFIX}"
+
+    def save_flow(self, flow: AnyFlow, *, overwrite: bool = False) -> None:
+        path = self._path_for(flow.name, flow.version)
+        if path.exists() and not overwrite:
+            raise FlowAlreadyExistsError(flow.name)
+        # Write to a temp file then rename for atomic-on-POSIX semantics.
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(flow_to_json(flow), encoding="utf-8")
+        tmp.replace(path)
+
+    def load_flow(self, name: str, version: str) -> AnyFlow:
+        path = self._path_for(name, version)
+        if not path.exists():
+            raise FlowNotFoundError(name, version=version)
+        try:
+            return flow_from_json(path.read_text(encoding="utf-8"))
+        except FlowSerializationError as exc:
+            # Re-raise with the file path for better diagnostics.
+            raise FlowSerializationError(exc.detail, source=str(path)) from exc
+
+    def has_flow(self, name: str, version: str) -> bool:
+        try:
+            return self._path_for(name, version).exists()
+        except FlowSerializationError:
+            return False
+
+    def list_keys(self) -> list[tuple[str, str]]:
+        keys: list[tuple[str, str]] = []
+        for entry in sorted(self._base_dir.iterdir()):
+            if not entry.is_file():
+                continue
+            match = _FILENAME_RE.match(entry.name)
+            if match is None:
+                continue
+            keys.append((match.group("name"), match.group("version")))
+        return keys
+
+    def delete_flow(self, name: str, version: str) -> None:
+        path = self._path_for(name, version)
+        if not path.exists():
+            raise FlowNotFoundError(name, version=version)
+        path.unlink()
+
+    def __len__(self) -> int:
+        return len(self.list_keys())

--- a/chainweaver/viz.py
+++ b/chainweaver/viz.py
@@ -43,9 +43,10 @@ def _node_id(prefix: str, idx: int) -> str:
 def flow_to_ascii(flow: Flow | DAGFlow) -> str:
     """Render *flow* as a single-line ASCII flow diagram.
 
-    Linear flows produce ``[a] --> [b] --> [c]``; DAG flows render each
-    dependency as a separate line ``[a] --> [b]`` so that branching is
-    visible.  Empty flows return ``"(empty flow)"``.
+    Linear flows produce ``[a] → [b] → [c]``; DAG flows render each
+    dependency as a separate line ``[a] → [b]`` so that branching is
+    visible (issue #46 acceptance: ASCII output uses the unicode arrow
+    ``→``).  Empty flows return ``"(empty flow)"``.
     """
     from chainweaver.flow import DAGFlow
 
@@ -56,16 +57,16 @@ def flow_to_ascii(flow: Flow | DAGFlow) -> str:
         return _dag_to_ascii(flow)
 
     parts = [f"[{step.tool_name}]" for step in flow.steps]
-    return " --> ".join(parts)
+    return " → ".join(parts)
 
 
 def _dag_to_ascii(flow: DAGFlow) -> str:
-    """Render a DAG as one ``[parent] --> [child]`` edge per line."""
+    """Render a DAG as one ``[parent] → [child]`` edge per line."""
     label_by_id = {step.step_id: f"[{step.tool_name}]" for step in flow.steps}
     edges: list[str] = []
     for step in flow.steps:
         for dep in step.depends_on:
-            edges.append(f"{label_by_id[dep]} --> {label_by_id[step.step_id]}")
+            edges.append(f"{label_by_id[dep]} → {label_by_id[step.step_id]}")
     if not edges:
         # All steps independent (no edges) — list them on one line.
         return ", ".join(label_by_id.values())

--- a/chainweaver/viz.py
+++ b/chainweaver/viz.py
@@ -141,6 +141,85 @@ def _node_label(
 
 
 # ---------------------------------------------------------------------------
+# Flow → DOT (Graphviz)
+# ---------------------------------------------------------------------------
+
+
+def _dot_quote(text: str) -> str:
+    r"""Quote *text* for a DOT label (per the Graphviz spec).
+
+    Wraps the string in double quotes and escapes embedded ``"`` and ``\``.
+    Newlines are converted to ``\n`` so labels never break the DOT grammar.
+    """
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def _dot_identifier(flow_name: str) -> str:
+    """Return a DOT graph identifier derived from *flow_name*.
+
+    Identifiers are ASCII-letter-digit-underscore only; anything else is
+    replaced with ``_`` so the resulting ``digraph <id> { ... }`` parses
+    cleanly even when the flow name contains hyphens or spaces.
+    """
+    sanitized = "".join(c if c.isalnum() or c == "_" else "_" for c in flow_name)
+    if not sanitized or not sanitized[0].isalpha():
+        sanitized = "G_" + sanitized
+    return sanitized
+
+
+def flow_to_dot(flow: Flow | DAGFlow) -> str:
+    """Render *flow* as a DOT (Graphviz) string (issue #46).
+
+    Pure-string generation with no Graphviz dependency.  Consumers can pipe
+    the output to ``dot`` (e.g. ``chainweaver viz my_flow --format dot |
+    dot -Tpng -o my_flow.png``) when they want a rendered image.
+
+    Linear :class:`~chainweaver.flow.Flow` objects produce a chain of edges
+    in declaration order; :class:`~chainweaver.flow.DAGFlow` objects use
+    each step's ``depends_on`` declaration verbatim.  Empty flows return
+    a syntactically valid empty digraph.
+
+    Args:
+        flow: A :class:`~chainweaver.flow.Flow` or
+            :class:`~chainweaver.flow.DAGFlow`.
+
+    Returns:
+        A valid DOT graph string ready to feed to Graphviz.
+    """
+    from chainweaver.flow import DAGFlow as _DAGFlow
+
+    graph_id = _dot_identifier(flow.name)
+    if not flow.steps:
+        return f"digraph {graph_id} {{\n}}\n"
+
+    lines = [f"digraph {graph_id} {{"]
+
+    if isinstance(flow, _DAGFlow):
+        # Use stable node ids derived from step_id; emit labels separately so
+        # tool names with spaces / special chars don't break the syntax.
+        node_ids = {step.step_id: f"S_{_dot_identifier(step.step_id)}" for step in flow.steps}
+        for dag_step in flow.steps:
+            lines.append(
+                f"  {node_ids[dag_step.step_id]} [label={_dot_quote(dag_step.tool_name)}];"
+            )
+        for dag_step in flow.steps:
+            for dep in dag_step.depends_on:
+                lines.append(f"  {node_ids[dep]} -> {node_ids[dag_step.step_id]};")
+    else:
+        node_ids = {step.tool_name: _node_id("S", i) for i, step in enumerate(flow.steps)}
+        # We could have duplicate tool names in a linear flow; index by position.
+        positional_ids = [_node_id("S", i) for i in range(len(flow.steps))]
+        for nid, lin_step in zip(positional_ids, flow.steps, strict=True):
+            lines.append(f"  {nid} [label={_dot_quote(lin_step.tool_name)}];")
+        for prev, nxt in pairwise(positional_ids):
+            lines.append(f"  {prev} -> {nxt};")
+
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
 # ExecutionResult → Mermaid (status overlay)
 # ---------------------------------------------------------------------------
 

--- a/chainweaver/viz.py
+++ b/chainweaver/viz.py
@@ -207,8 +207,8 @@ def flow_to_dot(flow: Flow | DAGFlow) -> str:
             for dep in dag_step.depends_on:
                 lines.append(f"  {node_ids[dep]} -> {node_ids[dag_step.step_id]};")
     else:
-        node_ids = {step.tool_name: _node_id("S", i) for i, step in enumerate(flow.steps)}
-        # We could have duplicate tool names in a linear flow; index by position.
+        # Linear flows may have duplicate tool names, so node ids are derived
+        # from step position rather than tool name.
         positional_ids = [_node_id("S", i) for i in range(len(flow.steps))]
         for nid, lin_step in zip(positional_ids, flow.steps, strict=True):
             lines.append(f"  {nid} [label={_dot_quote(lin_step.tool_name)}];")

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -27,7 +27,8 @@ and tools, the same flow produces the same output every time.
 | `decorators.py` | `@tool` decorator for zero-boilerplate tool definition | Returns a `Tool` subclass; introspects type hints |
 | `tools.py` | Define `Tool`: name + callable + Pydantic I/O schemas + `schema_hash` | Tool functions must be `fn(BaseModel) -> dict[str, Any]` |
 | `flow.py` | Define `FlowStep`, `Flow`, `DAGFlowStep`, `DAGFlow`, `FlowStatus`, `DriftInfo`, `validate_dag_topology` | Pure data definitions + topology validation; no execution logic |
-| `registry.py` | Store and retrieve `Flow`/`DAGFlow` by `(name, version)`; status filtering; multi-version support | In-memory; intentionally simple for later wrapping |
+| `registry.py` | Store and retrieve `Flow`/`DAGFlow` by `(name, version)`; status filtering; multi-version support | Delegates persistence to a `RegistryStore`; defaults to `InMemoryStore` |
+| `storage.py` | `RegistryStore` Protocol + `InMemoryStore` (default) + `FileStore` (one JSON file per flow) | Filenames are `{name}@{version}.flow.json`; concurrent multi-process access not coordinated |
 | `executor.py` | Run flows step-by-step (linear) or level-by-level (DAG), validate I/O, merge context, drift detection | **No LLM, no network I/O, no randomness** |
 | `exceptions.py` | Typed exception hierarchy | All inherit `ChainWeaverError`; carry context attrs |
 | `log_utils.py` | Per-step structured logging | Library-safe (NullHandler only); no handler config |

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -34,6 +34,7 @@ and tools, the same flow produces the same output every time.
 | `cost.py` | `CostProfile` + `CostReport` for cost-avoided estimation | Pure data + a single ``compute_cost_report`` helper; no execution logic |
 | `observation.py` | `TraceRecorder` + `ObservedTrace` for ad-hoc tool sequence capture | In-memory storage only; persistence deferred |
 | `viz.py` | `flow_to_ascii`, `flow_to_mermaid`, `result_to_mermaid` pure renderers | No external dependencies — string generation only |
+| `serialization.py` | YAML + JSON encode/decode for `Flow` and `DAGFlow` (`flow_to_json`, `flow_from_yaml`, etc.) | JSON path is dep-free; YAML requires `pyyaml` (optional extra `chainweaver[yaml]`); schema/exception refs round-trip as `"module:qualname"` strings |
 | `cli.py` | typer-based `chainweaver inspect` entry point | Reads from a process-scoped default registry installed via `cli.set_default_registry` |
 | `__init__.py` | Public API surface | Every public symbol must be in `__all__` |
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -34,7 +34,7 @@ python -m pytest tests/ -v
 
 | Workflow | Trigger | Steps |
 |----------|---------|-------|
-| `ci.yml` | Push/PR to `main` | Ruff lint + format + mypy `chainweaver/ tests/` (Python 3.10 only); pytest across 3.10, 3.11, 3.12, 3.13 |
+| `ci.yml` | Push/PR to `main` | Ruff lint + format + mypy `chainweaver/ tests/` (Python 3.10 on `ubuntu-latest` only); pytest across the OS × Python matrix `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12, 3.13}` |
 | `publish.yml` | `v*` tags | Test → build → PyPI publish → GitHub Release |
 
 ---

--- a/docs/v1-release-criteria.md
+++ b/docs/v1-release-criteria.md
@@ -1,0 +1,146 @@
+# ChainWeaver v1.0 Release Criteria
+
+This document defines the **measurable, testable bar** ChainWeaver must
+clear before the v1.0.0 tag is cut.  Each criterion is a checkbox that
+must be ticked, with a referenced source of truth (issue, file, or
+command) so progress is unambiguous.
+
+Pre-1.0 releases (0.x.y) follow
+[docs/versioning-policy.md](versioning-policy.md) and may include
+breaking changes between minor versions.  Once v1.0.0 ships, SemVer
+guarantees apply in full.
+
+## 1. Stable public API
+
+- [ ] `Tool`, `Flow`, `FlowStep`, `FlowRegistry`, `FlowExecutor` have
+  signatures that have not changed since the 1.0.0-rc1 candidate.
+- [ ] `DAGFlow`, `DAGFlowStep` (issue #10 ✅) are part of the public
+  API and exported in `chainweaver/__init__.py` `__all__`.
+- [ ] `flow_to_dict` / `flow_from_dict` / `flow_to_json` /
+  `flow_from_json` / `flow_to_yaml` / `flow_from_yaml` (issue #14 ✅)
+  are public and stable.
+- [ ] `RegistryStore` / `InMemoryStore` / `FileStore` (issue #16 ✅) are
+  public and stable.
+- [ ] `RetryPolicy.retryable_errors` is `tuple[str, ...]` of qualified
+  exception class names (since 0.4.0); the executor resolves refs
+  via `resolved_retryable_errors()`.
+- [ ] All public classes/functions have complete docstrings with
+  Args/Returns/Raises sections.
+- [ ] `__all__` in `chainweaver/__init__.py` is comprehensive and
+  intentional — every symbol listed is meant for external use.
+- [ ] No `TODO (Phase 2)` markers remain in the public API surface.
+
+## 2. Deterministic execution
+
+- [ ] Linear flows execute without LLM calls (delivered in 0.1.0 ✅).
+- [ ] DAG flows execute with topological-level ordering (issue #10 ✅).
+- [ ] Conditional branching with safe predicate evaluation
+  (issue #9, **pending**).
+- [ ] Partial-determinism checkpoints — LLM/agent intervention only at
+  defined steps (issue #8, **pending**).
+- [ ] The three executor invariants are still in force: no LLM, no
+  network I/O, no randomness in `executor.py` (see
+  [invariants.md](agent-context/invariants.md)).
+
+## 3. Structured execution trace
+
+- [ ] Every `execute_flow()` call produces a serializable
+  `ExecutionResult` with `trace_id`, timestamps, per-step inputs /
+  outputs / durations, and flow metadata (delivered in 0.2.0 ✅).
+- [ ] `ExecutionResult` and `StepRecord` round-trip via
+  `model_dump_json()` / `model_validate_json(...)` (delivered ✅).
+- [ ] Trace schema is versioned (covered by `Flow.version` becoming
+  required in 0.4.0 ✅).
+
+## 4. Observability
+
+- [ ] Per-step wall-clock timings captured via `time.perf_counter`
+  (delivered ✅).
+- [ ] Trace IDs propagated through all log records (delivered via
+  `log_utils.py` ✅).
+- [ ] Structured logging compatible with JSON log formatters
+  (delivered ✅).
+
+## 5. Persistence and versioning
+
+- [ ] Flows serialize to and from YAML and JSON (issue #14 ✅).
+- [ ] `Flow.version` is required and validated as PEP 440 (since
+  0.4.0 ✅).
+- [ ] Registry supports file-based persistence via `FileStore`
+  (issue #16 ✅).
+- [ ] Tool schema hashes round-trip through serialization for drift
+  detection (delivered via `tool_schema_hashes` ✅).
+- [ ] Schema references resolve through `importlib` and surface
+  actionable errors when the target module is unimportable (since
+  0.4.0 ✅, covered by `tests/test_serialization.py`).
+
+## 6. CLI
+
+- [ ] `chainweaver inspect <flow>` — flow structure (issue #44 ✅).
+- [ ] `chainweaver validate <file>` — single-file validation
+  (issue #45 ✅).
+- [ ] `chainweaver check <dir>` — directory-wide validation
+  (issue #45 ✅).
+- [ ] `chainweaver viz <flow>` — ASCII / DOT rendering
+  (issue #46 ✅).
+- [ ] All CLI commands honor `--format json` for machine consumption.
+- [ ] Documented exit-code contract (0 / 1 / 2) covered by tests.
+
+## 7. Tooling and CI
+
+- [ ] Lint (`ruff check`), format (`ruff format --check`), type-check
+  (`python -m mypy`), and tests (`python -m pytest`) all pass on the
+  canonical Python 3.10 / Ubuntu leg (delivered ✅).
+- [ ] Tests pass on the full
+  `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12,
+  3.13}` matrix (issue #34 ✅; **awaiting first green run on Windows
+  + macOS**).
+- [ ] Test coverage stays ≥ 80% (enforced via
+  `--cov-fail-under=80` in `pyproject.toml` ✅).
+- [ ] PyPI publish workflow (`.github/workflows/publish.yml`) builds
+  cleanly and tags trigger an automatic release (delivered ✅).
+
+## 8. Documentation and governance
+
+- [ ] AGENTS.md, `docs/agent-context/`, and the `.github/`
+  copilot/claude instruction projections stay consistent with each
+  other (governance enforced per
+  [workflows.md](agent-context/workflows.md#documentation-governance-triggers)).
+- [ ] [CHANGELOG.md](../CHANGELOG.md) exists and tracks every release
+  back to 0.4.0 (issue #35 ✅).
+- [ ] [docs/versioning-policy.md](versioning-policy.md) defines the
+  SemVer policy, public API surface, and deprecation process
+  (issue #35 ✅).
+- [ ] This document (issue #18) reflects the actual codebase state.
+
+## 9. Benchmarks and value evidence
+
+- [ ] `benchmarks/bench_naive_vs_compiled.py` runs standalone, reports
+  a >10× speedup on the default sweep, and writes machine-readable
+  JSON when `--output` is supplied (issue #29 ✅).
+- [ ] Correctness benchmark for naive-vs-compiled data integrity
+  (issue #103, **pending** — separate work item).
+- [ ] Headline performance numbers ("compiled flows are N× faster,
+  with 0 LLM calls") appear in the README's intro section.
+
+## 10. Definition of "done"
+
+ChainWeaver may be tagged `v1.0.0` when:
+
+1. Every checkbox in §1 through §9 is ticked.
+2. The CI matrix (12 jobs) has a green run on the release commit.
+3. The CHANGELOG entry for the release follows the schema in
+   [docs/versioning-policy.md](versioning-policy.md).
+4. A release announcement covering migration from `0.x` is published.
+
+## Currently outstanding
+
+| Issue | Why it blocks v1.0 |
+|-------|-------------------|
+| #8    | Determinism-level metadata + checkpoints (§2). |
+| #9    | Conditional branching (§2). |
+| #103  | Correctness benchmark (§9). |
+| —     | First green Windows + macOS CI run (§7). |
+
+Everything else listed in §1–§8 is either delivered (✅) or covered by
+the eight issues in this PR.

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -1,0 +1,109 @@
+# Versioning Policy
+
+ChainWeaver follows [SemVer 2.0.0](https://semver.org/).  This document
+defines what counts as the public API, what kinds of changes warrant
+each version bump, and how deprecations are communicated.
+
+## Semantic Versioning
+
+| Bump | Examples |
+|------|----------|
+| **MAJOR** (`1.0.0 → 2.0.0`) | Removing or renaming a public symbol; changing the type of a public field; raising a different exception class for an existing failure mode; removing a CLI subcommand. |
+| **MINOR** (`1.0.0 → 1.1.0`) | Adding a new public symbol; adding optional parameters with safe defaults; adding a new CLI subcommand or flag; widening (never narrowing) what an existing function accepts. |
+| **PATCH** (`1.0.0 → 1.0.1`) | Bug fixes that do not change the public API; documentation corrections; performance improvements; internal refactors. |
+
+Pre-1.0 releases (`0.x.y`) follow the same shape, but **MINOR** bumps
+may include breaking changes.  Pre-1.0 callers should pin a specific
+version or accept that minor releases can break them.
+
+## Public API surface
+
+The public API is everything exported from `chainweaver/__init__.py`
+`__all__`.  This includes:
+
+- Data models — `Tool`, `Flow`, `FlowStep`, `DAGFlow`, `DAGFlowStep`,
+  `FlowStatus`, `ExecutionPlan`, `ExecutionResult`, `StepRecord`,
+  `StepPlan`, `StepDiff`, `RetryPolicy`, `RedactionPolicy`, `DriftInfo`,
+  `CostProfile`, `CostReport`.
+- Runtime entry points — `FlowExecutor`, `FlowRegistry`, `FlowBuilder`,
+  `TraceRecorder`, `ObservedStep`, `ObservedTrace`.
+- Compilation and compatibility — `compile_flow`, `CompilationResult`,
+  `CompilationError`, `CompilationWarning`, `schema_fingerprint`,
+  `check_flow_compatibility`, `CompatibilityIssue`,
+  `validate_dag_topology`.
+- Serialization — `flow_to_dict`, `flow_from_dict`, `flow_to_json`,
+  `flow_from_json`, `flow_to_yaml`, `flow_from_yaml`.
+- Storage — `RegistryStore`, `InMemoryStore`, `FileStore`.
+- Visualization — `flow_to_ascii`, `flow_to_dot`, `flow_to_mermaid`,
+  `result_to_mermaid`.
+- Decorators — `tool`.
+- The CLI module — `cli` (and its `main` entry point exposed as the
+  `chainweaver` console script).
+- All exception classes inheriting from `ChainWeaverError`.
+
+## Not part of the public API
+
+- Anything prefixed with `_` (module-level helpers, leading-underscore
+  attributes).
+- Log message text, log levels, and structured log field names.  These
+  are observability conveniences, not contracts.
+- Test utilities under `tests/`.
+- The exact contents of `ExecutionResult.execution_log` for an
+  intermediate failure path — the *shape* of `StepRecord` is public, the
+  *number* of records produced by a given error path is not.
+- Internal Pydantic field validators (e.g. `_validate_on_error`,
+  `_validate_retryable_errors`).  They will be renamed or replaced
+  freely as long as the externally observable validation contract
+  (which inputs are accepted vs rejected) does not change.
+
+## Deprecation process
+
+1. **Announce.**  Mark the deprecated API in a `DeprecationWarning`
+   raised at first use via `warnings.warn(..., DeprecationWarning,
+   stacklevel=2)` and document the replacement in its docstring.
+2. **List.**  Add an entry to the relevant
+   `## [x.y.z] - YYYY-MM-DD` section of [CHANGELOG.md](../CHANGELOG.md)
+   under `### Deprecated`.
+3. **Retain.**  Keep the deprecated API functional for at least one
+   minor release before removal.  For pre-1.0 releases this window may
+   shrink to one minor release; for post-1.0 the window is at least one
+   major version.
+4. **Remove.**  Drop the deprecated API in the appropriate MAJOR (or
+   MINOR, pre-1.0) release; document the removal under `### Removed` in
+   the changelog.
+
+## Breaking changes vs invariants
+
+Some properties are not just "the public API" but core invariants
+(documented in
+[docs/agent-context/invariants.md](agent-context/invariants.md)):
+
+- The executor has no LLM calls, no network I/O, no randomness.
+- Tool functions have the signature `fn(BaseModel) -> dict[str, Any]`.
+- All exceptions inherit from `ChainWeaverError`.
+- `from __future__ import annotations` at the top of every module.
+
+Changing any of these is **always** a MAJOR bump, regardless of how
+small the surface change appears.
+
+## Schema reference resolution (since 0.4.0)
+
+`Flow.input_schema_ref` / `output_schema_ref` and
+`RetryPolicy.retryable_errors` store class references as
+`"module:qualname"` strings rather than live class objects.  This makes
+flow definitions fully JSON/YAML-serializable but introduces an
+import-time dependency: a flow file referencing `"myapp.schemas:Order"`
+only loads if `myapp.schemas` is importable in the destination process.
+
+The qualified-name resolver (`chainweaver.flow.resolve_class_ref`)
+uses `importlib.import_module` + `getattr`, so classes defined inside
+function bodies (`<locals>`) cannot be referenced.  Schemas referenced
+by serialized flows **must** live at module top level.
+
+## Tracking changes
+
+Every release adds a section to [CHANGELOG.md](../CHANGELOG.md) following
+the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) convention.
+PRs that introduce user-visible changes are expected to add an
+`Unreleased` entry in the same commit; release tagging promotes the
+entry into a versioned heading.

--- a/examples/decorator_tool.py
+++ b/examples/decorator_tool.py
@@ -109,6 +109,7 @@ print(f"format_result(value=20) = {format_result(value=20)}")
 
 flow = Flow(
     name="double_add_format",
+    version="0.1.0",
     description="Doubles a number, adds 10, and formats the result.",
     steps=[
         FlowStep(tool_name="double", input_mapping={"number": "number"}),

--- a/examples/etl_flow.py
+++ b/examples/etl_flow.py
@@ -240,6 +240,7 @@ store_tool = Tool(
 
 etl_flow = Flow(
     name="data_etl",
+    version="0.1.0",
     description="ETL flow: fetch → validate → normalize → enrich → store.",
     steps=[
         FlowStep(
@@ -263,8 +264,8 @@ etl_flow = Flow(
             input_mapping={"enriched_records": "enriched_records"},
         ),
     ],
-    input_schema=FetchInput,
-    output_schema=StoreOutput,
+    input_schema_ref=Flow.schema_ref_from(FetchInput),
+    output_schema_ref=Flow.schema_ref_from(StoreOutput),
 )
 
 

--- a/examples/mcp_search_flow.py
+++ b/examples/mcp_search_flow.py
@@ -223,6 +223,7 @@ format_tool = Tool(
 
 search_flow = Flow(
     name="mcp_search",
+    version="0.1.0",
     description="MCP-style search: search → extract → format.",
     steps=[
         FlowStep(
@@ -238,8 +239,8 @@ search_flow = Flow(
             input_mapping={"extracted_items": "extracted_items", "query": "query"},
         ),
     ],
-    input_schema=SearchInput,
-    output_schema=FormatOutput,
+    input_schema_ref=Flow.schema_ref_from(SearchInput),
+    output_schema_ref=Flow.schema_ref_from(FormatOutput),
 )
 
 

--- a/examples/naive_vs_compiled.py
+++ b/examples/naive_vs_compiled.py
@@ -220,6 +220,7 @@ ALL_TOOLS = [fetch_tool, parse_tool, rules_tool, score_tool, emit_tool]
 
 enrichment_flow = Flow(
     name="record_enrichment",
+    version="0.1.0",
     description="Fetch, parse, rule-check, score, and emit a record.",
     steps=[
         FlowStep(
@@ -248,8 +249,8 @@ enrichment_flow = Flow(
             },
         ),
     ],
-    input_schema=FetchInput,
-    output_schema=EmitOutput,
+    input_schema_ref=Flow.schema_ref_from(FetchInput),
+    output_schema_ref=Flow.schema_ref_from(EmitOutput),
 )
 
 

--- a/examples/simple_linear_flow.py
+++ b/examples/simple_linear_flow.py
@@ -117,14 +117,15 @@ format_tool = Tool(
 
 flow = Flow(
     name="double_add_format",
+    version="0.1.0",
     description="Doubles a number, adds 10, and formats the result.",
     steps=[
         FlowStep(tool_name="double", input_mapping={"number": "number"}),
         FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
         FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
     ],
-    input_schema=NumberInput,
-    output_schema=FormattedOutput,
+    input_schema_ref=Flow.schema_ref_from(NumberInput),
+    output_schema_ref=Flow.schema_ref_from(FormattedOutput),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chainweaver"
-version = "0.2.0"
+version = "0.4.0"
 description = "Deterministic orchestration layer for MCP-based agents."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,16 @@ dependencies = [
 chainweaver = "chainweaver.cli:main"
 
 [project.optional-dependencies]
+yaml = [
+    "pyyaml>=6.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.8",
     "mypy>=1.0",
+    "pyyaml>=6.0",
+    "types-pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def format_tool() -> Tool:
 def linear_flow() -> Flow:
     return Flow(
         name="double_add_format",
+        version="0.1.0",
         description="Doubles a number, adds 10, and formats the result.",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -41,6 +41,7 @@ class TestBasicBuild:
         )
         manual_flow = Flow(
             name="double_add_format",
+            version="0.1.0",
             description="Doubles a number, adds 10, and formats.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
-"""Tests for the ``chainweaver`` CLI entry point (issue #44)."""
+"""Tests for the ``chainweaver`` CLI entry point (issues #44, #45)."""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from helpers import NumberInput, ValueOutput, _double_fn
@@ -150,3 +151,274 @@ class TestMainEntryPoint:
         payload = json.loads(captured.out)
         assert exit_code == 0
         assert payload["steps"][0]["tool_name"] == "double"
+
+
+# ---------------------------------------------------------------------------
+# validate command (issue #45)
+# ---------------------------------------------------------------------------
+
+
+def _write_valid_yaml(path: Path) -> None:
+    flow = Flow(
+        name="from_file",
+        version="2.0.0",
+        description="Loaded from a YAML file.",
+        steps=[FlowStep(tool_name="x")],
+    )
+    path.write_text(flow.to_yaml(), encoding="utf-8")
+
+
+def _write_valid_json(path: Path) -> None:
+    flow = Flow(
+        name="from_file_json",
+        version="2.0.0",
+        description="Loaded from a JSON file.",
+        steps=[FlowStep(tool_name="x")],
+    )
+    path.write_text(flow.to_json(), encoding="utf-8")
+
+
+def _write_valid_dag_json(path: Path) -> None:
+    dag = DAGFlow(
+        name="dag_from_file",
+        version="2.0.0",
+        description="DAG loaded from a JSON file.",
+        steps=[
+            DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
+            DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
+        ],
+    )
+    path.write_text(dag.to_json(), encoding="utf-8")
+
+
+class TestValidateCommand:
+    def test_valid_yaml_returns_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow_path = tmp_path / "ok.flow.yaml"
+        _write_valid_yaml(flow_path)
+        exit_code = cli.main(["validate", str(flow_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "OK" in captured.out
+        assert "from_file" in captured.out
+        assert "v2.0.0" in captured.out
+
+    def test_valid_json_returns_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow_path = tmp_path / "ok.flow.json"
+        _write_valid_json(flow_path)
+        exit_code = cli.main(["validate", str(flow_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "[Flow]" in captured.out
+
+    def test_valid_dag_json_returns_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow_path = tmp_path / "ok.flow.json"
+        _write_valid_dag_json(flow_path)
+        exit_code = cli.main(["validate", str(flow_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "[DAGFlow]" in captured.out
+
+    def test_invalid_file_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bad = tmp_path / "broken.flow.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        exit_code = cli.main(["validate", str(bad)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "INVALID" in captured.err
+
+    def test_missing_file_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["validate", str(tmp_path / "nope.flow.yaml")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_directory_path_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["validate", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "not a file" in captured.err
+
+    def test_unrecognised_extension_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        weird = tmp_path / "ok.txt"
+        weird.write_text("anything", encoding="utf-8")
+        exit_code = cli.main(["validate", str(weird)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "extension" in captured.err.lower()
+
+    def test_json_output_format(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow_path = tmp_path / "ok.flow.json"
+        _write_valid_json(flow_path)
+        exit_code = cli.main(["validate", str(flow_path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["valid"] is True
+        assert payload["name"] == "from_file_json"
+        assert payload["type"] == "Flow"
+
+    def test_json_output_format_for_invalid(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bad = tmp_path / "bad.flow.json"
+        bad.write_text("{garbage", encoding="utf-8")
+        exit_code = cli.main(["validate", str(bad), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        payload = json.loads(captured.out)
+        assert payload["valid"] is False
+        assert "error" in payload
+
+
+# ---------------------------------------------------------------------------
+# check command (issue #45)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCommand:
+    def test_all_valid_returns_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_valid_yaml(tmp_path / "a.flow.yaml")
+        _write_valid_json(tmp_path / "b.flow.json")
+        _write_valid_dag_json(tmp_path / "c.flow.json")
+        exit_code = cli.main(["check", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "3 valid" in captured.out
+        assert "0 invalid" in captured.out
+
+    def test_mixed_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_valid_yaml(tmp_path / "good.flow.yaml")
+        (tmp_path / "bad.flow.json").write_text("{nope", encoding="utf-8")
+        exit_code = cli.main(["check", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "1 valid" in captured.out
+        assert "1 invalid" in captured.out
+
+    def test_quiet_suppresses_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_valid_yaml(tmp_path / "good.flow.yaml")
+        exit_code = cli.main(["check", str(tmp_path), "--quiet"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_missing_directory_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["check", str(tmp_path / "no_such_dir")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "directory not found" in captured.err
+
+    def test_file_path_instead_of_dir_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow_path = tmp_path / "one.flow.json"
+        _write_valid_json(flow_path)
+        exit_code = cli.main(["check", str(flow_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "not a directory" in captured.err
+
+    def test_recursive_walk_finds_nested_flows(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        nested = tmp_path / "team_a" / "flows"
+        nested.mkdir(parents=True)
+        _write_valid_json(nested / "deep.flow.json")
+        exit_code = cli.main(["check", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "1 valid" in captured.out
+
+    def test_json_output_includes_results(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_valid_yaml(tmp_path / "good.flow.yaml")
+        (tmp_path / "bad.flow.json").write_text("not json", encoding="utf-8")
+        exit_code = cli.main(["check", str(tmp_path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        payload = json.loads(captured.out)
+        assert payload["valid_count"] == 1
+        assert payload["invalid_count"] == 1
+        assert len(payload["results"]) == 2
+
+    def test_empty_directory_returns_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["check", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "0 valid" in captured.out
+        assert "0 invalid" in captured.out
+
+    def test_ignores_unrelated_files(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_valid_yaml(tmp_path / "ok.flow.yaml")
+        (tmp_path / "README.md").write_text("docs", encoding="utf-8")
+        (tmp_path / "config.toml").write_text("[x]\ny = 1", encoding="utf-8")
+        exit_code = cli.main(["check", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "1 valid" in captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ def _reset_registry() -> None:
 def _make_linear_registry() -> FlowRegistry:
     flow = Flow(
         name="double_flow",
+        version="0.1.0",
         description="Doubles a number.",
         steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
     )
@@ -32,6 +33,7 @@ def _make_linear_registry() -> FlowRegistry:
 def _make_dag_registry() -> FlowRegistry:
     dag = DAGFlow(
         name="dag_flow",
+        version="0.1.0",
         description="Tiny DAG.",
         steps=[
             DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -177,6 +177,7 @@ class TestCheckFlowCompatibility:
         )
         flow = Flow(
             name="f",
+            version="0.1.0",
             description="Flow.",
             steps=[FlowStep(tool_name="proc")],
             tool_schema_hashes={"proc": tool.schema_hash},
@@ -187,6 +188,7 @@ class TestCheckFlowCompatibility:
     def test_missing_tool_detected(self) -> None:
         flow = Flow(
             name="f",
+            version="0.1.0",
             description="Flow.",
             steps=[FlowStep(tool_name="missing")],
         )
@@ -205,6 +207,7 @@ class TestCheckFlowCompatibility:
         )
         flow = Flow(
             name="f",
+            version="0.1.0",
             description="Flow.",
             steps=[FlowStep(tool_name="proc")],
             tool_schema_hashes={"proc": "0000000000000000"},
@@ -223,6 +226,7 @@ class TestCheckFlowCompatibility:
         )
         flow = Flow(
             name="f",
+            version="0.1.0",
             description="Flow.",
             steps=[FlowStep(tool_name="proc")],
             tool_schema_hashes=None,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -35,6 +35,11 @@ class FloatInput(BaseModel):
     value: float
 
 
+class RequiredOutputWithMissingField(BaseModel):
+    value: int
+    missing_field: str
+
+
 # ---------------------------------------------------------------------------
 # Tool functions
 # ---------------------------------------------------------------------------
@@ -93,14 +98,15 @@ class TestValidFlow:
         tools = _make_tools()
         flow = Flow(
             name="double_add_format",
+            version="0.1.0",
             description="Doubles, adds ten, formats.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
                 FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
-            output_schema=FormattedOutput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(FormattedOutput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -110,11 +116,12 @@ class TestValidFlow:
         tools = _make_tools()
         flow = Flow(
             name="simple",
+            version="0.1.0",
             description="Simple flow.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -124,9 +131,10 @@ class TestMissingTool:
     def test_missing_tool_detected(self) -> None:
         flow = Flow(
             name="bad",
+            version="0.1.0",
             description="Bad flow.",
             steps=[FlowStep(tool_name="nonexistent", input_mapping={"x": "x"})],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, {})
         assert result.success is False
@@ -140,11 +148,12 @@ class TestMissingMappingKey:
         tools = _make_tools()
         flow = Flow(
             name="bad_mapping",
+            version="0.1.0",
             description="Bad mapping.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "missing_key"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is False
@@ -154,12 +163,13 @@ class TestMissingMappingKey:
         tools = _make_tools()
         flow = Flow(
             name="multi_step",
+            version="0.1.0",
             description="Multi-step flow.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -187,13 +197,14 @@ class TestTypeMismatch:
         tools = {"str_tool": str_tool, **_make_tools()}
         flow = Flow(
             name="type_mismatch",
+            version="0.1.0",
             description="Type mismatch flow.",
             steps=[
                 FlowStep(tool_name="str_tool", input_mapping={"value": "number"}),
                 # "text" (str) mapped to "value" (int) on add_ten
                 FlowStep(tool_name="add_ten", input_mapping={"value": "text"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is False
@@ -234,12 +245,13 @@ class TestTypeMismatch:
         tools = {"int_tool": int_tool, "float_tool": float_tool}
         flow = Flow(
             name="widening",
+            version="0.1.0",
             description="Int to float widening.",
             steps=[
                 FlowStep(tool_name="int_tool", input_mapping={"number": "number"}),
                 FlowStep(tool_name="float_tool", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -247,19 +259,16 @@ class TestTypeMismatch:
 
 class TestOutputSchemaGap:
     def test_output_schema_gap_detected(self) -> None:
-        class RequiredOutput(BaseModel):
-            value: int
-            missing_field: str
-
         tools = _make_tools()
         flow = Flow(
             name="gap",
+            version="0.1.0",
             description="Missing output field.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
             ],
-            input_schema=NumberInput,
-            output_schema=RequiredOutput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(RequiredOutputWithMissingField),
         )
         result = compile_flow(flow, tools)
         assert result.success is False
@@ -302,12 +311,13 @@ class TestOptionalTypeCompatibility:
         tools = {"opt": opt_tool, **_make_tools()}
         flow = Flow(
             name="opt_flow",
+            version="0.1.0",
             description="Map int into Optional[int].",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="opt", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -333,12 +343,13 @@ class TestOptionalTypeCompatibility:
         tools = {"pep604": tool, **_make_tools()}
         flow = Flow(
             name="pep604_flow",
+            version="0.1.0",
             description="Map int into int | None.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="pep604", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -364,12 +375,13 @@ class TestOptionalTypeCompatibility:
         # Map an int source — should pass (unknown target treats as compatible).
         flow = Flow(
             name="multi_flow",
+            version="0.1.0",
             description="Map int into Union[int, str].",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="multi", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         # Multi-arm Union[int, str] is unknown → no false-positive type_mismatch.
@@ -381,6 +393,7 @@ class TestUnknownTargetKey:
         tools = _make_tools()
         flow = Flow(
             name="bad_target",
+            version="0.1.0",
             description="Maps to a field the tool does not declare.",
             steps=[
                 FlowStep(
@@ -388,7 +401,7 @@ class TestUnknownTargetKey:
                     input_mapping={"number": "number", "ghost": "number"},
                 ),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is False
@@ -421,9 +434,10 @@ class TestMissingRequiredInput:
         # Provide only `a` via mapping — `b` is required but missing.
         flow = Flow(
             name="missing_required",
+            version="0.1.0",
             description="Only `a` is mapped.",
             steps=[FlowStep(tool_name="two", input_mapping={"a": "number"})],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is False
@@ -453,9 +467,10 @@ class TestMissingRequiredInput:
         # Empty mapping — `number` is in the input_schema context, so it is satisfied.
         flow = Flow(
             name="empty_map",
+            version="0.1.0",
             description="Empty mapping satisfied by context.",
             steps=[FlowStep(tool_name="one")],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         assert result.success is True
@@ -482,9 +497,10 @@ class TestMissingRequiredInput:
         # No mapping for "value", and "value" not in context — but it's optional.
         flow = Flow(
             name="optional_unmapped",
+            version="0.1.0",
             description="Optional input deliberately unmapped.",
             steps=[FlowStep(tool_name="opt", input_mapping={"_dummy": "number"})],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         result = compile_flow(flow, tools)
         # Optional input field `value` should not produce a missing_required_input

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -23,6 +23,7 @@ from chainweaver.tools import Tool
 def _build_two_step_executor(*, cost_profile: CostProfile | None = None) -> FlowExecutor:
     flow = Flow(
         name="cost_two_step",
+        version="0.1.0",
         description="Two-step flow.",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -159,6 +160,7 @@ class TestExecutorIntegration:
 
         flow = Flow(
             name="cost_boom",
+            version="0.1.0",
             description="Always-failing flow.",
             steps=[FlowStep(tool_name="boom", input_mapping={"x": "x"})],
         )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -261,6 +261,7 @@ class TestRoundTripWithExecutor:
 
         flow = Flow(
             name="decorator_flow",
+            version="0.1.0",
             description="Test flow with decorated tool.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )
@@ -285,6 +286,7 @@ class TestRoundTripWithExecutor:
 
         flow = Flow(
             name="double_then_add",
+            version="0.1.0",
             description="Doubles then adds ten.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),

--- a/tests/test_drift_detection.py
+++ b/tests/test_drift_detection.py
@@ -70,6 +70,7 @@ def _make_tool_v2() -> Tool:
 def _make_flow_with_hashes(tool: Tool) -> Flow:
     return Flow(
         name="my_flow",
+        version="0.1.0",
         description="A flow using proc.",
         steps=[FlowStep(tool_name="proc", input_mapping={"value": "value"})],
         tool_schema_hashes={"proc": tool.schema_hash},
@@ -97,6 +98,7 @@ class TestNoDrift:
         registry = FlowRegistry()
         flow = Flow(
             name="no_hashes",
+            version="0.1.0",
             description="No hashes stored.",
             steps=[FlowStep(tool_name="proc")],
             tool_schema_hashes=None,
@@ -134,6 +136,7 @@ class TestDriftDetected:
         # Flow using "other" tool, not "proc".
         flow = Flow(
             name="other_flow",
+            version="0.1.0",
             description="Uses other.",
             steps=[FlowStep(tool_name="other")],
             tool_schema_hashes={"other": other_tool.schema_hash},

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -57,6 +57,7 @@ class TestValidPlan:
     def test_returns_execution_plan(self) -> None:
         flow = Flow(
             name="double_add",
+            version="0.1.0",
             description="Double then add 10.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -73,6 +74,7 @@ class TestValidPlan:
     def test_steps_carry_schema_shapes(self) -> None:
         flow = Flow(
             name="double_only",
+            version="0.1.0",
             description="Double.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )
@@ -85,6 +87,7 @@ class TestValidPlan:
     def test_input_sources_for_context_lookup(self) -> None:
         flow = Flow(
             name="double_only",
+            version="0.1.0",
             description="Double.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )
@@ -109,6 +112,7 @@ class TestValidPlan:
         )
         flow = Flow(
             name="scale_flow",
+            version="0.1.0",
             description="Scale by 3.",
             steps=[
                 FlowStep(
@@ -128,6 +132,7 @@ class TestValidPlan:
     def test_empty_mapping_documented(self) -> None:
         flow = Flow(
             name="passthrough_flow",
+            version="0.1.0",
             description="No mapping.",
             steps=[FlowStep(tool_name="double")],
         )
@@ -138,6 +143,7 @@ class TestValidPlan:
     def test_final_context_shape_accumulates(self) -> None:
         flow = Flow(
             name="double_add",
+            version="0.1.0",
             description="Double then add 10.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -160,6 +166,7 @@ class TestPlanWarnings:
     def test_unresolved_key_flagged_not_raised(self) -> None:
         flow = Flow(
             name="bad_mapping",
+            version="0.1.0",
             description="Mapping references a key that won't exist.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "ghost"})],
         )
@@ -174,6 +181,7 @@ class TestPlanWarnings:
     def test_missing_tool_flagged_not_raised(self) -> None:
         flow = Flow(
             name="missing_tool_flow",
+            version="0.1.0",
             description="References an unregistered tool.",
             steps=[FlowStep(tool_name="ghost_tool", input_mapping={"x": "x"})],
         )
@@ -190,6 +198,7 @@ class TestEmptyFlow:
     def test_zero_steps_plan(self) -> None:
         flow = Flow(
             name="empty",
+            version="0.1.0",
             description="No steps.",
             steps=[],
         )
@@ -218,6 +227,7 @@ class TestNoToolFunctionInvoked:
         )
         flow = Flow(
             name="watcher_flow",
+            version="0.1.0",
             description="Single watcher step.",
             steps=[FlowStep(tool_name="watcher", input_mapping={"number": "number"})],
         )
@@ -230,6 +240,7 @@ class TestStringRepresentation:
     def test_str_contains_flow_name(self) -> None:
         flow = Flow(
             name="double_only",
+            version="0.1.0",
             description="Double.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )
@@ -240,7 +251,7 @@ class TestStringRepresentation:
         assert "double" in rendered
 
     def test_unknown_flow_raises(self) -> None:
-        ex = _build_executor(flow=Flow(name="x", description="x", steps=[]))
+        ex = _build_executor(flow=Flow(name="x", version="0.1.0", description="x", steps=[]))
         with pytest.raises(FlowNotFoundError):
             ex.explain_flow("nope", {})
 
@@ -249,6 +260,7 @@ class TestStepPlanSerialization:
     def test_round_trip(self) -> None:
         flow = Flow(
             name="double_only",
+            version="0.1.0",
             description="Double.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )

--- a/tests/test_flow_execution.py
+++ b/tests/test_flow_execution.py
@@ -20,6 +20,33 @@ from chainweaver.registry import FlowRegistry
 from chainweaver.tools import Tool
 
 # ---------------------------------------------------------------------------
+# Module-level schemas (must be importable via "module:qualname" so that
+# Flow.input_schema_ref / output_schema_ref can resolve them — locally-defined
+# classes inside test methods are unreachable through importlib lookup).
+# ---------------------------------------------------------------------------
+
+
+class _MissingFieldOutput(BaseModel):
+    missing_field: str
+
+
+class _ExtraFieldOutput(BaseModel):
+    extra_field: str
+
+
+class _KeyOnly(BaseModel):
+    key: str
+
+
+class _DagN(BaseModel):
+    n: int
+
+
+class _DagDoubled(BaseModel):
+    doubled: int
+
+
+# ---------------------------------------------------------------------------
 # Successful execution
 # ---------------------------------------------------------------------------
 
@@ -138,6 +165,7 @@ class TestSchemaValidation:
 
         flow = Flow(
             name="bad_flow",
+            version="0.1.0",
             description="Flow with bad output schema.",
             steps=[FlowStep(tool_name="bad_tool", input_mapping={"number": "number"})],
         )
@@ -175,6 +203,7 @@ class TestInputMapping:
         )
         flow = Flow(
             name="bad_mapping",
+            version="0.1.0",
             description="Flow with a broken mapping.",
             steps=[
                 FlowStep(
@@ -214,6 +243,7 @@ class TestInputMapping:
         )
         flow = Flow(
             name="scale_flow",
+            version="0.1.0",
             description="Scales by 3.",
             steps=[
                 FlowStep(
@@ -254,6 +284,7 @@ class TestInputMapping:
         )
         flow = Flow(
             name="passthrough_flow",
+            version="0.1.0",
             description="Step with empty input_mapping.",
             steps=[FlowStep(tool_name="sum", input_mapping={})],
         )
@@ -295,6 +326,7 @@ class TestFlowExecutionError:
         )
         flow = Flow(
             name="boom_flow",
+            version="0.1.0",
             description="Flow whose tool explodes.",
             steps=[FlowStep(tool_name="boom", input_mapping={"x": "x"})],
         )
@@ -330,6 +362,7 @@ class TestFlowExecutionError:
         )
         flow = Flow(
             name="bad_flow",
+            version="0.1.0",
             description="Flow with ValueError tool.",
             steps=[FlowStep(tool_name="bad", input_mapping={"x": "x"})],
         )
@@ -353,6 +386,7 @@ class TestEmptyFlow:
         """A flow with no steps should succeed, returning the initial input."""
         flow = Flow(
             name="empty",
+            version="0.1.0",
             description="No steps.",
             steps=[],
         )
@@ -431,14 +465,15 @@ class TestFlowLevelSchemas:
         """When schemas are satisfied the flow succeeds normally."""
         flow = Flow(
             name="schema_flow",
+            version="0.1.0",
             description="Flow with input & output schemas.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
                 FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
                 FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
             ],
-            input_schema=NumberInput,
-            output_schema=FormattedOutput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(FormattedOutput),
         )
         registry = FlowRegistry()
         registry.register_flow(flow)
@@ -461,11 +496,12 @@ class TestFlowLevelSchemas:
         """Invalid initial_input is rejected before any step runs."""
         flow = Flow(
             name="guarded_flow",
+            version="0.1.0",
             description="Flow with strict input schema.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
             ],
-            input_schema=NumberInput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
         )
         registry = FlowRegistry()
         registry.register_flow(flow)
@@ -485,17 +521,14 @@ class TestFlowLevelSchemas:
         double_tool: Tool,
     ) -> None:
         """Output schema mismatch is caught after all steps complete."""
-
-        class StrictOutput(BaseModel):
-            missing_field: str
-
         flow = Flow(
             name="bad_output_flow",
+            version="0.1.0",
             description="Output schema requires a field the steps never produce.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
             ],
-            output_schema=StrictOutput,
+            output_schema_ref=Flow.schema_ref_from(_MissingFieldOutput),
         )
         registry = FlowRegistry()
         registry.register_flow(flow)
@@ -523,17 +556,14 @@ class TestFlowLevelSchemas:
 
     def test_empty_flow_with_schemas(self) -> None:
         """Both validation gates work when the step loop is vacuous."""
-
-        class InOut(BaseModel):
-            key: str
-
         # Happy path: initial input satisfies both schemas.
         flow = Flow(
             name="empty_with_schemas",
+            version="0.1.0",
             description="Empty flow with input & output schemas.",
             steps=[],
-            input_schema=InOut,
-            output_schema=InOut,
+            input_schema_ref=Flow.schema_ref_from(_KeyOnly),
+            output_schema_ref=Flow.schema_ref_from(_KeyOnly),
         )
         registry = FlowRegistry()
         registry.register_flow(flow)
@@ -546,16 +576,13 @@ class TestFlowLevelSchemas:
 
     def test_empty_flow_with_output_schema_mismatch(self) -> None:
         """Output schema fails when steps=[] and initial input lacks required fields."""
-
-        class StrictOutput(BaseModel):
-            extra_field: str
-
         flow = Flow(
             name="empty_bad_output",
+            version="0.1.0",
             description="Empty flow whose output schema won't match initial input.",
             steps=[],
-            input_schema=NumberInput,
-            output_schema=StrictOutput,
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(_ExtraFieldOutput),
         )
         registry = FlowRegistry()
         registry.register_flow(flow)
@@ -583,6 +610,7 @@ class TestSingleStepFlow:
     ) -> None:
         flow = Flow(
             name="single_step",
+            version="0.1.0",
             description="One-step flow that doubles a number.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -656,6 +684,7 @@ class TestToolZeroDivisionError:
         )
         flow = Flow(
             name="divide_flow",
+            version="0.1.0",
             description="Flow that divides.",
             steps=[
                 FlowStep(
@@ -759,6 +788,7 @@ class TestSimpleDAG:
         )
         flow = DAGFlow(
             name="simple_dag",
+            version="0.1.0",
             description="A → B",
             steps=[
                 DAGFlowStep(tool_name="step_a", step_id="A", depends_on=[]),
@@ -799,6 +829,7 @@ class TestSingleNodeDAG:
         )
         flow = DAGFlow(
             name="lone_dag",
+            version="0.1.0",
             description="Single node.",
             steps=[DAGFlowStep(tool_name="lone", step_id="ONLY", depends_on=[])],
         )
@@ -867,6 +898,7 @@ class TestDiamondDAG:
         )
         flow = DAGFlow(
             name="diamond",
+            version="0.1.0",
             description="A → (B, C) → D",
             steps=[
                 DAGFlowStep(
@@ -960,6 +992,7 @@ class TestDiamondDAG:
 
         flow = DAGFlow(
             name="diamond_order",
+            version="0.1.0",
             description="Order test.",
             steps=[
                 DAGFlowStep(tool_name="ta", step_id="A", depends_on=[]),
@@ -1045,6 +1078,7 @@ class TestMixedDepthDAG:
 
         flow = DAGFlow(
             name="mixed_depth",
+            version="0.1.0",
             description="A → B, A → C, (B,C) → D with renamed keys",
             steps=[
                 DAGFlowStep(tool_name="ma", step_id="A", depends_on=[]),
@@ -1106,6 +1140,7 @@ class TestDAGSiblingKeyConflict:
 
         flow = DAGFlow(
             name="conflict_dag",
+            version="0.1.0",
             description="Two independent steps writing the same key.",
             steps=[
                 DAGFlowStep(tool_name="sa", step_id="A", depends_on=[]),
@@ -1150,6 +1185,7 @@ class TestDAGSiblingKeyConflict:
 
         flow = DAGFlow(
             name="no_conflict_dag",
+            version="0.1.0",
             description="Two independent steps with distinct keys.",
             steps=[
                 DAGFlowStep(tool_name="nca", step_id="A", depends_on=[]),
@@ -1174,25 +1210,16 @@ class TestDAGFlowLevelSchemas:
     """Optional input_schema / output_schema on DAGFlow."""
 
     def test_valid_input_schema_passes(self) -> None:
-        class Inp(BaseModel):
-            n: int
-
-        class Out(BaseModel):
-            doubled: int
-
         ta = Tool(
             name="ds",
             description="d",
-            input_schema=Inp,
-            output_schema=Out,
+            input_schema=_DagN,
+            output_schema=_DagDoubled,
             fn=lambda i: {"doubled": i.n * 2},
         )
-
-        class OutSchema(BaseModel):
-            doubled: int
-
         flow = DAGFlow(
             name="schema_dag",
+            version="0.1.0",
             description="With schemas.",
             steps=[
                 DAGFlowStep(
@@ -1202,8 +1229,8 @@ class TestDAGFlowLevelSchemas:
                     input_mapping={"n": "n"},
                 )
             ],
-            input_schema=Inp,
-            output_schema=OutSchema,
+            input_schema_ref=DAGFlow.schema_ref_from(_DagN),
+            output_schema_ref=DAGFlow.schema_ref_from(_DagDoubled),
         )
         ex = _build_dag_executor(flow, ta)
         result = ex.execute_flow("schema_dag", {"n": 4})
@@ -1213,24 +1240,19 @@ class TestDAGFlowLevelSchemas:
         assert result.final_output["doubled"] == 8
 
     def test_invalid_input_schema_caught_before_execution(self) -> None:
-        class Inp(BaseModel):
-            n: int
-
-        class Out(BaseModel):
-            doubled: int
-
         ta = Tool(
             name="ds2",
             description="d2",
-            input_schema=Inp,
-            output_schema=Out,
+            input_schema=_DagN,
+            output_schema=_DagDoubled,
             fn=lambda i: {"doubled": i.n * 2},
         )
         flow = DAGFlow(
             name="guard_dag",
+            version="0.1.0",
             description="Guards input.",
             steps=[DAGFlowStep(tool_name="ds2", step_id="A", depends_on=[])],
-            input_schema=Inp,
+            input_schema_ref=DAGFlow.schema_ref_from(_DagN),
         )
         ex = _build_dag_executor(flow, ta)
         result = ex.execute_flow("guard_dag", {"wrong": "value"})
@@ -1241,28 +1263,20 @@ class TestDAGFlowLevelSchemas:
         assert result.execution_log[0].error_type == "SchemaValidationError"
 
     def test_invalid_output_schema_caught_after_execution(self) -> None:
-        class Inp(BaseModel):
-            n: int
-
-        class Out(BaseModel):
-            doubled: int
-
-        class WrongOutputSchema(BaseModel):
-            missing_field: str  # context won't have this key
-
         ta = Tool(
             name="ds3",
             description="d3",
-            input_schema=Inp,
-            output_schema=Out,
+            input_schema=_DagN,
+            output_schema=_DagDoubled,
             fn=lambda i: {"doubled": i.n * 2},
         )
         flow = DAGFlow(
             name="bad_out_dag",
+            version="0.1.0",
             description="Output schema mismatch.",
             steps=[DAGFlowStep(tool_name="ds3", step_id="A", depends_on=[])],
-            input_schema=Inp,
-            output_schema=WrongOutputSchema,
+            input_schema_ref=DAGFlow.schema_ref_from(_DagN),
+            output_schema_ref=DAGFlow.schema_ref_from(_MissingFieldOutput),
         )
         ex = _build_dag_executor(flow, ta)
         result = ex.execute_flow("bad_out_dag", {"n": 4})
@@ -1292,6 +1306,7 @@ class TestDAGMissingTool:
     def test_missing_tool_fails_step(self) -> None:
         flow = DAGFlow(
             name="missing_tool_dag",
+            version="0.1.0",
             description="Step references an unregistered tool.",
             steps=[DAGFlowStep(tool_name="ghost", step_id="G", depends_on=[])],
         )
@@ -1376,6 +1391,7 @@ class TestDAGReverseOrderedSteps:
         # B depends on A, but B is listed FIRST in steps.
         flow = DAGFlow(
             name="reverse_order",
+            version="0.1.0",
             description="B before A in list, A before B in deps.",
             steps=[
                 DAGFlowStep(
@@ -1401,6 +1417,7 @@ class TestDAGCapabilityStepExecution:
     def test_capability_step_rejected_at_execution(self) -> None:
         flow = DAGFlow(
             name="cap_dag",
+            version="0.1.0",
             description="One capability step.",
             steps=[
                 DAGFlowStep(

--- a/tests/test_flow_status.py
+++ b/tests/test_flow_status.py
@@ -43,6 +43,7 @@ def _make_tool() -> Tool:
 def _make_flow(name: str = "test_flow", status: FlowStatus = FlowStatus.ACTIVE) -> Flow:
     return Flow(
         name=name,
+        version="0.1.0",
         description="A test flow.",
         steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         status=status,
@@ -65,7 +66,9 @@ class TestFlowStatusEnum:
         assert FlowStatus.DISABLED.value == "disabled"
 
     def test_default_status_is_active(self) -> None:
-        flow = Flow(name="test", description="Test.", steps=[FlowStep(tool_name="x")])
+        flow = Flow(
+            name="test", version="0.1.0", description="Test.", steps=[FlowStep(tool_name="x")]
+        )
         assert flow.status == FlowStatus.ACTIVE
 
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -130,6 +130,7 @@ class TestToolRunGuardrails:
 def _build_executor(tool: Tool) -> FlowExecutor:
     flow = Flow(
         name="guardrail_flow",
+        version="0.1.0",
         description="One-step flow used for guardrail integration.",
         steps=[FlowStep(tool_name=tool.name, input_mapping={"number": "number"})],
     )

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -136,6 +136,7 @@ class TestExecutorIntegration:
     def test_executor_records_observed_trace(self) -> None:
         flow = Flow(
             name="obs_flow",
+            version="0.1.0",
             description="Two-step.",
             steps=[
                 FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -175,6 +176,7 @@ class TestExecutorIntegration:
     def test_executor_without_recorder_does_not_track(self) -> None:
         flow = Flow(
             name="obs_flow_2",
+            version="0.1.0",
             description="No recorder.",
             steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
         )

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -178,6 +178,7 @@ class TestExecutorIntegration:
 
         flow = Flow(
             name="redact_flow",
+            version="0.1.0",
             description="Single-step flow.",
             steps=[FlowStep(tool_name="check_password")],
         )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,6 +16,7 @@ from chainweaver.registry import FlowRegistry
 def _make_flow(name: str = "test_flow") -> Flow:
     return Flow(
         name=name,
+        version="0.1.0",
         description=f"A test flow called {name}.",
         steps=[FlowStep(tool_name="dummy")],
     )
@@ -93,6 +94,7 @@ class TestMatchFlowByIntent:
         registry = FlowRegistry()
         flow = Flow(
             name="double_add_format",
+            version="0.1.0",
             description="Doubles and adds.",
             steps=[FlowStep(tool_name="dummy")],
         )
@@ -105,6 +107,7 @@ class TestMatchFlowByIntent:
         registry = FlowRegistry()
         flow = Flow(
             name="transform",
+            version="0.1.0",
             description="Converts a raw value into a formatted report.",
             steps=[FlowStep(tool_name="dummy")],
         )
@@ -161,7 +164,7 @@ def _make_dag(name: str = "dag", *, steps: list[DAGFlowStep] | None = None) -> D
             DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
             DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
         ]
-    return DAGFlow(name=name, description=f"Test DAG '{name}'.", steps=steps)
+    return DAGFlow(name=name, version="0.1.0", description=f"Test DAG '{name}'.", steps=steps)
 
 
 class TestDAGFlowRegistration:
@@ -181,7 +184,7 @@ class TestDAGFlowRegistration:
             DAGFlowStep(tool_name="a", step_id="DUP", depends_on=[]),
             DAGFlowStep(tool_name="b", step_id="DUP", depends_on=["DUP"]),
         ]
-        flow = DAGFlow(name="dup_dag", description="Duplicate IDs.", steps=steps)
+        flow = DAGFlow(name="dup_dag", version="0.1.0", description="Duplicate IDs.", steps=steps)
         registry = FlowRegistry()
         with pytest.raises(DAGDefinitionError) as exc_info:
             registry.register_flow(flow)
@@ -192,7 +195,9 @@ class TestDAGFlowRegistration:
         steps = [
             DAGFlowStep(tool_name="a", step_id="A", depends_on=["GHOST"]),
         ]
-        flow = DAGFlow(name="unknown_dag", description="Unknown dep.", steps=steps)
+        flow = DAGFlow(
+            name="unknown_dag", version="0.1.0", description="Unknown dep.", steps=steps
+        )
         registry = FlowRegistry()
         with pytest.raises(DAGDefinitionError) as exc_info:
             registry.register_flow(flow)
@@ -203,7 +208,7 @@ class TestDAGFlowRegistration:
             DAGFlowStep(tool_name="a", step_id="A", depends_on=["B"]),
             DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
         ]
-        flow = DAGFlow(name="cycle_dag", description="Cycle A↔B.", steps=steps)
+        flow = DAGFlow(name="cycle_dag", version="0.1.0", description="Cycle A↔B.", steps=steps)
         registry = FlowRegistry()
         with pytest.raises(DAGDefinitionError) as exc_info:
             registry.register_flow(flow)
@@ -211,7 +216,7 @@ class TestDAGFlowRegistration:
 
     def test_dag_self_loop_raises(self) -> None:
         steps = [DAGFlowStep(tool_name="a", step_id="A", depends_on=["A"])]
-        flow = DAGFlow(name="self_loop", description="Self-dep.", steps=steps)
+        flow = DAGFlow(name="self_loop", version="0.1.0", description="Self-dep.", steps=steps)
         registry = FlowRegistry()
         with pytest.raises(DAGDefinitionError) as exc_info:
             registry.register_flow(flow)
@@ -225,7 +230,7 @@ class TestDAGFlowRegistration:
             DAGFlowStep(tool_name="x", step_id="X", depends_on=["Y"]),
             DAGFlowStep(tool_name="y", step_id="Y", depends_on=["X"]),
         ]
-        bad_dag = DAGFlow(name="dag_v1", description="Cycle.", steps=bad_steps)
+        bad_dag = DAGFlow(name="dag_v1", version="0.1.0", description="Cycle.", steps=bad_steps)
         with pytest.raises(DAGDefinitionError):
             registry.register_flow(bad_dag, overwrite=True)
         # Original should still be present (overwrite never committed).
@@ -242,6 +247,7 @@ class TestDAGFlowRegistration:
         registry = FlowRegistry()
         dag = DAGFlow(
             name="process_events",
+            version="0.1.0",
             description="Processes incoming event streams in parallel.",
             steps=[DAGFlowStep(tool_name="t", step_id="T", depends_on=[])],
         )

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -28,6 +28,7 @@ from chainweaver.tools import Tool
 def _build_executor() -> FlowExecutor:
     flow = Flow(
         name="replay_two_step",
+        version="0.1.0",
         description="Two-step flow used for replay tests.",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -97,6 +98,7 @@ class TestVerifyDiff:
         registry.register_flow(
             Flow(
                 name="moving_target",
+                version="0.1.0",
                 description="Tool output changes between runs.",
                 steps=[FlowStep(tool_name="counter", input_mapping={"number": "number"})],
             )
@@ -183,6 +185,7 @@ class TestResumeFromStep:
         registry = FlowRegistry()
         flow = DAGFlow(
             name="dag_replay",
+            version="0.1.0",
             description="Linear DAG used to verify the rejection path.",
             steps=[DAGFlowStep(tool_name="double", step_id="A", depends_on=[])],
         )
@@ -214,6 +217,7 @@ class TestReplayWithMissingTool:
         registry = FlowRegistry()
         flow = Flow(
             name="missing_tool",
+            version="0.1.0",
             description="Single step.",
             steps=[FlowStep(tool_name="ephemeral", input_mapping={"x": "x"})],
         )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -111,6 +111,7 @@ def _build_executor(
 ) -> FlowExecutor:
     flow = Flow(
         name="retry_flow",
+        version="0.1.0",
         description="Single-step flow used to assert retry behaviour.",
         steps=[
             FlowStep(
@@ -209,7 +210,7 @@ class TestRetryNonRetryable:
                 max_retries=5,
                 backoff_seconds=0.0,
                 backoff_multiplier=1.0,
-                retryable_errors=(KeyError,),
+                retryable_errors=("builtins:KeyError",),
             ),
         )
         result = ex.execute_flow("retry_flow", {"number": 1})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,367 @@
+"""Tests for the flow serialization API (issue #14)."""
+
+from __future__ import annotations
+
+import pytest
+from helpers import NumberInput, ValueOutput
+
+from chainweaver.exceptions import FlowSerializationError
+from chainweaver.flow import (
+    DAGFlow,
+    DAGFlowStep,
+    Flow,
+    FlowStatus,
+    FlowStep,
+    RetryPolicy,
+)
+from chainweaver.serialization import (
+    flow_from_dict,
+    flow_from_json,
+    flow_from_yaml,
+    flow_to_dict,
+    flow_to_yaml,
+)
+
+# ---------------------------------------------------------------------------
+# Reusable fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_linear() -> Flow:
+    return Flow(
+        name="lin",
+        version="1.2.3",
+        description="Linear flow.",
+        steps=[
+            FlowStep(tool_name="double", input_mapping={"number": "number"}),
+            FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+        ],
+    )
+
+
+def _make_dag() -> DAGFlow:
+    return DAGFlow(
+        name="diamond",
+        version="0.9.0",
+        description="A -> (B, C) -> D",
+        steps=[
+            DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
+            DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
+            DAGFlowStep(tool_name="c", step_id="C", depends_on=["A"]),
+            DAGFlowStep(tool_name="d", step_id="D", depends_on=["B", "C"]),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestJsonRoundTrip:
+    def test_linear_round_trips(self) -> None:
+        flow = _make_linear()
+        restored = Flow.from_json(flow.to_json())
+        assert restored == flow
+
+    def test_dag_round_trips(self) -> None:
+        flow = _make_dag()
+        restored = DAGFlow.from_json(flow.to_json())
+        assert restored == flow
+
+    def test_dispatch_via_flow_from_dict(self) -> None:
+        flow = _make_dag()
+        restored = flow_from_dict(flow_to_dict(flow))
+        assert isinstance(restored, DAGFlow)
+        assert restored.name == "diamond"
+
+    def test_indent_none_produces_compact_json(self) -> None:
+        flow = _make_linear()
+        compact = flow.to_json(indent=None)
+        assert "\n" not in compact
+
+    def test_indent_default_pretty_prints(self) -> None:
+        flow = _make_linear()
+        pretty = flow.to_json()
+        assert "\n" in pretty
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestYamlRoundTrip:
+    def test_linear_round_trips(self) -> None:
+        flow = _make_linear()
+        restored = Flow.from_yaml(flow.to_yaml())
+        assert restored == flow
+
+    def test_dag_round_trips(self) -> None:
+        flow = _make_dag()
+        restored = DAGFlow.from_yaml(flow.to_yaml())
+        assert restored == flow
+
+    def test_yaml_is_block_style(self) -> None:
+        # block style YAML uses key: value on its own line, never flow-style {a: b}
+        yaml_text = _make_linear().to_yaml()
+        assert "{" not in yaml_text
+        assert "\nname: lin" in yaml_text
+
+
+# ---------------------------------------------------------------------------
+# Schema ref round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaRefs:
+    def test_input_schema_ref_round_trips(self) -> None:
+        flow = Flow(
+            name="ref",
+            version="1.0.0",
+            description="With schema refs.",
+            steps=[FlowStep(tool_name="double")],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+            output_schema_ref=Flow.schema_ref_from(ValueOutput),
+        )
+        restored = Flow.from_json(flow.to_json())
+        assert restored.input_schema_ref == "helpers:NumberInput"
+        assert restored.input_schema is NumberInput
+        assert restored.output_schema is ValueOutput
+
+    def test_unresolvable_module_raises(self) -> None:
+        flow = Flow(
+            name="bad",
+            version="1.0.0",
+            description="Broken ref.",
+            steps=[FlowStep(tool_name="x")],
+            input_schema_ref="no_such_module:Foo",
+        )
+        with pytest.raises(FlowSerializationError, match="Cannot import module"):
+            _ = flow.input_schema
+
+    def test_unresolvable_attribute_raises(self) -> None:
+        flow = Flow(
+            name="bad",
+            version="1.0.0",
+            description="Broken ref.",
+            steps=[FlowStep(tool_name="x")],
+            input_schema_ref="helpers:DoesNotExist",
+        )
+        with pytest.raises(FlowSerializationError, match="not found"):
+            _ = flow.input_schema
+
+    def test_ref_resolving_to_non_basemodel_raises(self) -> None:
+        flow = Flow(
+            name="bad",
+            version="1.0.0",
+            description="Resolves to a function, not a class.",
+            steps=[FlowStep(tool_name="x")],
+            input_schema_ref="helpers:_double_fn",
+        )
+        with pytest.raises(FlowSerializationError, match="expected a class"):
+            _ = flow.input_schema
+
+    def test_ref_resolving_to_wrong_base_raises(self) -> None:
+        flow = Flow(
+            name="bad",
+            version="1.0.0",
+            description="Resolves to int, not BaseModel.",
+            steps=[FlowStep(tool_name="x")],
+            input_schema_ref="builtins:int",
+        )
+        with pytest.raises(FlowSerializationError, match="not a subclass"):
+            _ = flow.input_schema
+
+    def test_missing_colon_raises(self) -> None:
+        flow = Flow(
+            name="bad",
+            version="1.0.0",
+            description="Malformed ref.",
+            steps=[FlowStep(tool_name="x")],
+            input_schema_ref="helpers.NumberInput",  # dot instead of colon
+        )
+        with pytest.raises(FlowSerializationError, match="'module:qualname' form"):
+            _ = flow.input_schema
+
+    def test_no_schema_ref_returns_none(self) -> None:
+        flow = Flow(
+            name="bare",
+            version="1.0.0",
+            description="No schemas.",
+            steps=[FlowStep(tool_name="x")],
+        )
+        assert flow.input_schema is None
+        assert flow.output_schema is None
+
+
+# ---------------------------------------------------------------------------
+# RetryPolicy refs
+# ---------------------------------------------------------------------------
+
+
+class TestRetryPolicyRefs:
+    def test_default_resolves_to_exception(self) -> None:
+        policy = RetryPolicy()
+        assert policy.retryable_errors == ("builtins:Exception",)
+        assert policy.resolved_retryable_errors() == (Exception,)
+
+    def test_custom_resolves(self) -> None:
+        policy = RetryPolicy(retryable_errors=("builtins:KeyError", "builtins:ValueError"))
+        assert policy.resolved_retryable_errors() == (KeyError, ValueError)
+
+    def test_missing_colon_rejected_at_validation(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="'module:qualname' form"):
+            RetryPolicy(retryable_errors=("builtins.KeyError",))
+
+    def test_empty_tuple_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="at least one"):
+            RetryPolicy(retryable_errors=())
+
+    def test_unresolvable_raises_on_resolve(self) -> None:
+        policy = RetryPolicy(retryable_errors=("no_such_module:NoSuchError",))
+        with pytest.raises(FlowSerializationError):
+            policy.resolved_retryable_errors()
+
+    def test_non_exception_class_rejected_on_resolve(self) -> None:
+        policy = RetryPolicy(retryable_errors=("builtins:int",))
+        with pytest.raises(FlowSerializationError, match="not a subclass"):
+            policy.resolved_retryable_errors()
+
+    def test_retry_policy_round_trips_through_flow_json(self) -> None:
+        flow = Flow(
+            name="ret",
+            version="1.0.0",
+            description="With retry.",
+            steps=[
+                FlowStep(
+                    tool_name="x",
+                    retry=RetryPolicy(retryable_errors=("builtins:KeyError",)),
+                )
+            ],
+        )
+        restored = Flow.from_json(flow.to_json())
+        assert restored.steps[0].retry is not None
+        assert restored.steps[0].retry.retryable_errors == ("builtins:KeyError",)
+
+
+# ---------------------------------------------------------------------------
+# Other Flow fields round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMiscFieldsRoundTrip:
+    def test_tool_schema_hashes_round_trips(self) -> None:
+        flow = Flow(
+            name="hashed",
+            version="1.0.0",
+            description="Hashes attached.",
+            steps=[FlowStep(tool_name="x")],
+            tool_schema_hashes={"x": "abcdef0123456789"},
+        )
+        restored = Flow.from_json(flow.to_json())
+        assert restored.tool_schema_hashes == {"x": "abcdef0123456789"}
+
+    def test_trigger_conditions_round_trips(self) -> None:
+        flow = Flow(
+            name="trig",
+            version="1.0.0",
+            description="Has triggers.",
+            steps=[FlowStep(tool_name="x")],
+            trigger_conditions={"on_intent": "summarize", "min_words": 50},
+        )
+        restored = Flow.from_json(flow.to_json())
+        assert restored.trigger_conditions == {"on_intent": "summarize", "min_words": 50}
+
+    def test_status_round_trips(self) -> None:
+        flow = Flow(
+            name="stat",
+            version="1.0.0",
+            description="Disabled.",
+            steps=[FlowStep(tool_name="x")],
+            status=FlowStatus.DISABLED,
+        )
+        restored = Flow.from_json(flow.to_json())
+        assert restored.status is FlowStatus.DISABLED
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_invalid_json_raises_serialization_error(self) -> None:
+        with pytest.raises(FlowSerializationError, match="Invalid JSON"):
+            flow_from_json("{not valid json")
+
+    def test_invalid_yaml_raises_serialization_error(self) -> None:
+        with pytest.raises(FlowSerializationError, match="Invalid YAML"):
+            flow_from_yaml("key: [unbalanced")
+
+    def test_empty_yaml_raises_serialization_error(self) -> None:
+        with pytest.raises(FlowSerializationError, match="empty"):
+            flow_from_yaml("")
+
+    def test_missing_type_discriminator_raises(self) -> None:
+        with pytest.raises(FlowSerializationError, match="discriminator"):
+            flow_from_dict({"name": "x", "version": "1.0.0", "description": "y", "steps": []})
+
+    def test_unknown_type_discriminator_raises(self) -> None:
+        with pytest.raises(FlowSerializationError, match="discriminator"):
+            flow_from_dict(
+                {
+                    "type": "PickleFlow",
+                    "name": "x",
+                    "version": "1.0.0",
+                    "description": "y",
+                    "steps": [],
+                }
+            )
+
+    def test_non_dict_payload_raises(self) -> None:
+        with pytest.raises(FlowSerializationError, match="mapping"):
+            flow_from_dict(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(FlowSerializationError, match="Validation failed"):
+            flow_from_dict({"type": "Flow", "name": "x"})  # missing version/description/steps
+
+    def test_from_json_flow_payload_to_dag_class_fails(self) -> None:
+        flow = _make_linear()
+        with pytest.raises(FlowSerializationError, match="DAGFlow"):
+            DAGFlow.from_json(flow.to_json())
+
+    def test_from_json_dag_payload_to_flow_class_fails(self) -> None:
+        flow = _make_dag()
+        with pytest.raises(FlowSerializationError, match="Flow"):
+            Flow.from_json(flow.to_json())
+
+
+# ---------------------------------------------------------------------------
+# Missing pyyaml fallback (simulated)
+# ---------------------------------------------------------------------------
+
+
+class TestYamlNotAvailable:
+    def test_clear_error_when_yaml_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When pyyaml is not importable, both encode and decode error cleanly."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "yaml":
+                raise ImportError("simulated missing pyyaml")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(FlowSerializationError, match="pyyaml"):
+            flow_to_yaml(_make_linear())
+        with pytest.raises(FlowSerializationError, match="pyyaml"):
+            flow_from_yaml("type: Flow\nname: x\nversion: 1.0.0\ndescription: y\nsteps: []\n")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,306 @@
+"""Tests for the pluggable registry storage backends (issue #16)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chainweaver.exceptions import (
+    FlowAlreadyExistsError,
+    FlowNotFoundError,
+    FlowSerializationError,
+)
+from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
+from chainweaver.registry import FlowRegistry
+from chainweaver.storage import FileStore, InMemoryStore, RegistryStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _linear(name: str = "lin", version: str = "1.0.0") -> Flow:
+    return Flow(
+        name=name,
+        version=version,
+        description=f"{name} v{version}",
+        steps=[FlowStep(tool_name="x")],
+    )
+
+
+def _dag(name: str = "dag", version: str = "1.0.0") -> DAGFlow:
+    return DAGFlow(
+        name=name,
+        version=version,
+        description=f"{name} v{version}",
+        steps=[
+            DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
+            DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryStoreProtocol:
+    def test_in_memory_store_satisfies_protocol(self) -> None:
+        assert isinstance(InMemoryStore(), RegistryStore)
+
+    def test_file_store_satisfies_protocol(self, tmp_path: Path) -> None:
+        assert isinstance(FileStore(tmp_path), RegistryStore)
+
+
+# ---------------------------------------------------------------------------
+# InMemoryStore CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_save_and_load(self) -> None:
+        store = InMemoryStore()
+        flow = _linear()
+        store.save_flow(flow)
+        assert store.load_flow("lin", "1.0.0") is flow
+
+    def test_save_duplicate_raises(self) -> None:
+        store = InMemoryStore()
+        store.save_flow(_linear())
+        with pytest.raises(FlowAlreadyExistsError):
+            store.save_flow(_linear())
+
+    def test_save_overwrite(self) -> None:
+        store = InMemoryStore()
+        store.save_flow(_linear())
+        replacement = _linear()
+        replacement.description = "replaced"
+        store.save_flow(replacement, overwrite=True)
+        assert store.load_flow("lin", "1.0.0").description == "replaced"
+
+    def test_load_missing_raises(self) -> None:
+        store = InMemoryStore()
+        with pytest.raises(FlowNotFoundError):
+            store.load_flow("ghost", "1.0.0")
+
+    def test_has_flow(self) -> None:
+        store = InMemoryStore()
+        assert store.has_flow("lin", "1.0.0") is False
+        store.save_flow(_linear())
+        assert store.has_flow("lin", "1.0.0") is True
+        assert store.has_flow("lin", "2.0.0") is False
+
+    def test_list_keys(self) -> None:
+        store = InMemoryStore()
+        store.save_flow(_linear("a", "1.0.0"))
+        store.save_flow(_linear("a", "2.0.0"))
+        store.save_flow(_linear("b", "1.0.0"))
+        assert sorted(store.list_keys()) == [("a", "1.0.0"), ("a", "2.0.0"), ("b", "1.0.0")]
+
+    def test_delete_flow(self) -> None:
+        store = InMemoryStore()
+        store.save_flow(_linear())
+        store.delete_flow("lin", "1.0.0")
+        assert store.has_flow("lin", "1.0.0") is False
+
+    def test_delete_missing_raises(self) -> None:
+        store = InMemoryStore()
+        with pytest.raises(FlowNotFoundError):
+            store.delete_flow("ghost", "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# FileStore CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestFileStore:
+    def test_save_writes_a_file(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_linear("disk", "1.0.0"))
+        expected = tmp_path / "disk@1.0.0.flow.json"
+        assert expected.exists()
+        # Confirm the file is JSON (starts with '{').
+        assert expected.read_text(encoding="utf-8").lstrip().startswith("{")
+
+    def test_save_duplicate_raises_without_overwrite(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_linear())
+        with pytest.raises(FlowAlreadyExistsError):
+            store.save_flow(_linear())
+
+    def test_save_overwrite_replaces_file_contents(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_linear())
+        replacement = _linear()
+        replacement.description = "second take"
+        store.save_flow(replacement, overwrite=True)
+        loaded = store.load_flow("lin", "1.0.0")
+        assert loaded.description == "second take"
+
+    def test_load_missing_raises(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        with pytest.raises(FlowNotFoundError):
+            store.load_flow("absent", "1.0.0")
+
+    def test_persistence_across_store_instances(self, tmp_path: Path) -> None:
+        """Process-restart simulation: write with one store, read with a fresh one."""
+        first = FileStore(tmp_path)
+        first.save_flow(_linear("persist", "1.2.3"))
+
+        second = FileStore(tmp_path)
+        assert second.has_flow("persist", "1.2.3") is True
+        restored = second.load_flow("persist", "1.2.3")
+        assert restored.name == "persist"
+        assert restored.version == "1.2.3"
+
+    def test_round_trips_dag_flow(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_dag())
+        restored = store.load_flow("dag", "1.0.0")
+        assert isinstance(restored, DAGFlow)
+        assert [s.step_id for s in restored.steps] == ["A", "B"]
+
+    def test_list_keys_ignores_unrelated_files(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_linear("a", "1.0.0"))
+        store.save_flow(_linear("a", "2.0.0"))
+        # A noise file that does not match the @version.flow.json pattern.
+        (tmp_path / "README.md").write_text("hi", encoding="utf-8")
+        # Another noise file with a similar but wrong suffix.
+        (tmp_path / "z@1.0.0.txt").write_text("nope", encoding="utf-8")
+        assert sorted(store.list_keys()) == [("a", "1.0.0"), ("a", "2.0.0")]
+
+    def test_delete_flow(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        store.save_flow(_linear())
+        store.delete_flow("lin", "1.0.0")
+        assert not (tmp_path / "lin@1.0.0.flow.json").exists()
+        with pytest.raises(FlowNotFoundError):
+            store.delete_flow("lin", "1.0.0")
+
+    def test_base_dir_created_if_missing(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "flows"
+        FileStore(nested)
+        assert nested.is_dir()
+
+    def test_name_with_path_separator_rejected(self, tmp_path: Path) -> None:
+        bad = Flow(
+            name="bad/name",
+            version="1.0.0",
+            description="x",
+            steps=[FlowStep(tool_name="x")],
+        )
+        store = FileStore(tmp_path)
+        with pytest.raises(FlowSerializationError, match="not safe"):
+            store.save_flow(bad)
+
+    def test_name_with_special_chars_rejected(self, tmp_path: Path) -> None:
+        bad = Flow(
+            name="bad*name",
+            version="1.0.0",
+            description="x",
+            steps=[FlowStep(tool_name="x")],
+        )
+        store = FileStore(tmp_path)
+        with pytest.raises(FlowSerializationError, match="not safe"):
+            store.save_flow(bad)
+
+    def test_version_with_at_sign_rejected(self, tmp_path: Path) -> None:
+        bad = Flow(
+            name="ok",
+            version="1.0.0@hack",
+            description="x",
+            steps=[FlowStep(tool_name="x")],
+        )
+        store = FileStore(tmp_path)
+        with pytest.raises(FlowSerializationError, match="reserved"):
+            store.save_flow(bad)
+
+    def test_has_flow_with_unsafe_name_returns_false(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        assert store.has_flow("bad/name", "1.0.0") is False
+
+    def test_corrupt_file_raises_serialization_error(self, tmp_path: Path) -> None:
+        store = FileStore(tmp_path)
+        (tmp_path / "corrupt@1.0.0.flow.json").write_text("{not json", encoding="utf-8")
+        with pytest.raises(FlowSerializationError, match=r"corrupt@1\.0\.0"):
+            store.load_flow("corrupt", "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# FlowRegistry with custom stores
+# ---------------------------------------------------------------------------
+
+
+class TestFlowRegistryWithStores:
+    def test_default_store_is_in_memory(self) -> None:
+        registry = FlowRegistry()
+        assert isinstance(registry.store, InMemoryStore)
+
+    def test_explicit_in_memory_store(self) -> None:
+        store = InMemoryStore()
+        registry = FlowRegistry(store=store)
+        assert registry.store is store
+
+    def test_register_and_get_via_file_store(self, tmp_path: Path) -> None:
+        registry = FlowRegistry(store=FileStore(tmp_path))
+        registry.register_flow(_linear("disk", "1.0.0"))
+        assert registry.get_flow("disk").version == "1.0.0"
+
+    def test_register_persists_across_registries(self, tmp_path: Path) -> None:
+        first = FlowRegistry(store=FileStore(tmp_path))
+        first.register_flow(_linear("p", "1.0.0"))
+        first.register_flow(_linear("p", "2.5.0"))
+
+        second = FlowRegistry(store=FileStore(tmp_path))
+        # Latest-pointer rebuilt from disk content; get_flow(name) → highest version.
+        assert second.get_flow("p").version == "2.5.0"
+        assert len(second) == 2
+
+    def test_list_flows_filters_via_status_round_trip(self, tmp_path: Path) -> None:
+        from chainweaver.flow import FlowStatus
+
+        registry = FlowRegistry(store=FileStore(tmp_path))
+        active = _linear("active", "1.0.0")
+        disabled = _linear("disabled_flow", "1.0.0")
+        disabled.status = FlowStatus.DISABLED
+        registry.register_flow(active)
+        registry.register_flow(disabled)
+        names = sorted(f.name for f in registry.list_flows(status=FlowStatus.ACTIVE))
+        assert names == ["active"]
+
+    def test_set_status_persists_to_disk(self, tmp_path: Path) -> None:
+        from chainweaver.flow import FlowStatus
+
+        registry = FlowRegistry(store=FileStore(tmp_path))
+        registry.register_flow(_linear("toggle", "1.0.0"))
+        registry.set_flow_status("toggle", FlowStatus.DISABLED)
+
+        # Fresh registry over the same dir sees the persisted status.
+        fresh = FlowRegistry(store=FileStore(tmp_path))
+        assert fresh.get_flow("toggle").status is FlowStatus.DISABLED
+
+    def test_match_flow_by_intent_works_through_store(self, tmp_path: Path) -> None:
+        registry = FlowRegistry(store=FileStore(tmp_path))
+        registry.register_flow(
+            Flow(
+                name="summarizer",
+                version="1.0.0",
+                description="Summarizes long docs.",
+                steps=[FlowStep(tool_name="x")],
+            )
+        )
+        match = registry.match_flow_by_intent("summarize")
+        assert match is not None
+        assert match.name == "summarizer"
+
+    def test_repr_lists_persisted_flows(self, tmp_path: Path) -> None:
+        registry = FlowRegistry(store=FileStore(tmp_path))
+        registry.register_flow(_linear("alpha", "1.0.0"))
+        registry.register_flow(_linear("beta", "1.0.0"))
+        rep = repr(registry)
+        assert "alpha" in rep
+        assert "beta" in rep

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -28,6 +28,7 @@ from chainweaver.tools import Tool
 def _build_two_step_executor() -> FlowExecutor:
     flow = Flow(
         name="trace_two_step",
+        version="0.1.0",
         description="Two-step flow used for trace assertions.",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -130,6 +131,7 @@ class TestErrorStorage:
 
         flow = Flow(
             name="trace_err",
+            version="0.1.0",
             description="Always-failing flow.",
             steps=[FlowStep(tool_name="boom", input_mapping={"x": "x"})],
         )
@@ -210,6 +212,7 @@ class TestSerialization:
 
         flow = Flow(
             name="trace_err_round_trip",
+            version="0.1.0",
             description="Always-failing flow.",
             steps=[FlowStep(tool_name="boom", input_mapping={"x": "x"})],
         )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -44,9 +44,12 @@ def _make_flow(name: str = "versioned", version: str = "0.0.0") -> Flow:
 
 
 class TestFlowVersion:
-    def test_default_version(self) -> None:
-        flow = Flow(name="f", description="D.", steps=[FlowStep(tool_name="x")])
-        assert flow.version == "0.0.0"
+    def test_version_is_required(self) -> None:
+        """Flow now requires an explicit version (breaking change in 0.4.0)."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Flow(name="f", description="D.", steps=[FlowStep(tool_name="x")])  # type: ignore[call-arg]
 
     def test_custom_version(self) -> None:
         flow = _make_flow(version="1.2.3")
@@ -136,12 +139,11 @@ class TestMultiVersionRegistry:
         registry.register_flow(_make_flow("f", "0.5.0"))
         assert registry.get_flow("f").version == "3.0.0"
 
-    def test_backward_compat_default_version(self) -> None:
+    def test_register_with_explicit_version(self) -> None:
         registry = FlowRegistry()
-        # Flow without explicit version uses "0.0.0".
-        flow = Flow(name="f", description="D.", steps=[FlowStep(tool_name="x")])
+        flow = Flow(name="f", version="0.1.0", description="D.", steps=[FlowStep(tool_name="x")])
         registry.register_flow(flow)
-        assert registry.get_flow("f").version == "0.0.0"
+        assert registry.get_flow("f").version == "0.1.0"
 
 
 class TestFlowNotFoundErrorIncludesVersion:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,4 @@
-"""Tests for the flow visualization API (issue #79)."""
+"""Tests for the flow visualization API (issues #79, #46)."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ from chainweaver.executor import FlowExecutor
 from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
 from chainweaver.registry import FlowRegistry
 from chainweaver.tools import Tool
-from chainweaver.viz import flow_to_ascii, flow_to_mermaid, result_to_mermaid
+from chainweaver.viz import flow_to_ascii, flow_to_dot, flow_to_mermaid, result_to_mermaid
 
 # ---------------------------------------------------------------------------
 # Linear flow ASCII
@@ -286,3 +286,185 @@ class TestResultMermaid:
         )
         out = result_to_mermaid(result)
         assert "no steps" in out
+
+
+# ---------------------------------------------------------------------------
+# DOT renderer (issue #46)
+# ---------------------------------------------------------------------------
+
+
+class TestLinearDot:
+    def test_three_step_linear_graph_shape(self) -> None:
+        flow = Flow(
+            name="three",
+            version="0.1.0",
+            description="three.",
+            steps=[
+                FlowStep(tool_name="a"),
+                FlowStep(tool_name="b"),
+                FlowStep(tool_name="c"),
+            ],
+        )
+        out = flow_to_dot(flow)
+        # Header + footer.
+        assert out.startswith("digraph three {")
+        assert out.rstrip().endswith("}")
+        # Three labelled nodes.
+        assert 'S0 [label="a"];' in out
+        assert 'S1 [label="b"];' in out
+        assert 'S2 [label="c"];' in out
+        # Two directed edges in declaration order.
+        assert "S0 -> S1;" in out
+        assert "S1 -> S2;" in out
+
+    def test_single_step(self) -> None:
+        flow = Flow(
+            name="one", version="0.1.0", description="one", steps=[FlowStep(tool_name="lone")]
+        )
+        out = flow_to_dot(flow)
+        assert 'S0 [label="lone"];' in out
+        # No edges for a single step.
+        assert "->" not in out
+
+    def test_empty_flow_produces_valid_empty_digraph(self) -> None:
+        flow = Flow(name="empty", version="0.1.0", description="e", steps=[])
+        out = flow_to_dot(flow)
+        assert out == "digraph empty {\n}\n"
+
+    def test_method_on_flow(self) -> None:
+        flow = Flow(name="x", version="0.1.0", description="y", steps=[FlowStep(tool_name="t")])
+        assert "digraph x {" in flow.to_dot()
+
+    def test_tool_name_with_quote_is_escaped(self) -> None:
+        flow = Flow(
+            name="quoted",
+            version="0.1.0",
+            description="q",
+            steps=[FlowStep(tool_name='foo "bar"')],
+        )
+        out = flow_to_dot(flow)
+        # Embedded quotes must be backslash-escaped to keep DOT parseable.
+        assert r'label="foo \"bar\""' in out
+
+    def test_flow_name_with_hyphen_is_sanitized_in_graph_id(self) -> None:
+        flow = Flow(
+            name="my-flow-1", version="0.1.0", description="d", steps=[FlowStep(tool_name="x")]
+        )
+        out = flow_to_dot(flow)
+        # Hyphens are illegal in DOT identifiers — must be replaced with _.
+        assert "digraph my_flow_1 {" in out
+
+
+class TestDagDot:
+    def test_diamond_topology(self) -> None:
+        dag = DAGFlow(
+            name="diamond",
+            version="0.1.0",
+            description="A->B,A->C,B->D,C->D",
+            steps=[
+                DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
+                DAGFlowStep(tool_name="b", step_id="B", depends_on=["A"]),
+                DAGFlowStep(tool_name="c", step_id="C", depends_on=["A"]),
+                DAGFlowStep(tool_name="d", step_id="D", depends_on=["B", "C"]),
+            ],
+        )
+        out = flow_to_dot(dag)
+        assert "digraph diamond {" in out
+        # Per-step labels.
+        assert 'S_A [label="a"];' in out
+        assert 'S_D [label="d"];' in out
+        # Edges follow depends_on.
+        assert "S_A -> S_B;" in out
+        assert "S_A -> S_C;" in out
+        assert "S_B -> S_D;" in out
+        assert "S_C -> S_D;" in out
+
+    def test_independent_dag_steps_produce_no_edges(self) -> None:
+        dag = DAGFlow(
+            name="indep",
+            version="0.1.0",
+            description="two roots",
+            steps=[
+                DAGFlowStep(tool_name="x", step_id="X", depends_on=[]),
+                DAGFlowStep(tool_name="y", step_id="Y", depends_on=[]),
+            ],
+        )
+        out = flow_to_dot(dag)
+        assert "->" not in out
+        assert 'S_X [label="x"];' in out
+        assert 'S_Y [label="y"];' in out
+
+
+# ---------------------------------------------------------------------------
+# viz CLI command (issue #46)
+# ---------------------------------------------------------------------------
+
+
+class TestVizCli:
+    def _setup(self) -> None:
+        from chainweaver import cli
+
+        flow = Flow(
+            name="viz_flow",
+            version="0.1.0",
+            description="three-step.",
+            steps=[
+                FlowStep(tool_name="a"),
+                FlowStep(tool_name="b"),
+                FlowStep(tool_name="c"),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        cli.set_default_registry(registry)
+
+    def _teardown(self) -> None:
+        from chainweaver import cli
+
+        cli.set_default_registry(None)
+
+    def test_ascii_format_default(self, capsys: Any) -> None:
+        from chainweaver import cli
+
+        self._setup()
+        try:
+            exit_code = cli.main(["viz", "viz_flow"])
+        finally:
+            self._teardown()
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "[a] --> [b] --> [c]" in captured.out
+
+    def test_dot_format(self, capsys: Any) -> None:
+        from chainweaver import cli
+
+        self._setup()
+        try:
+            exit_code = cli.main(["viz", "viz_flow", "--format", "dot"])
+        finally:
+            self._teardown()
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "digraph viz_flow {" in captured.out
+        assert "S0 -> S1;" in captured.out
+
+    def test_missing_flow_exits_one(self, capsys: Any) -> None:
+        from chainweaver import cli
+
+        self._setup()
+        try:
+            exit_code = cli.main(["viz", "ghost", "--format", "dot"])
+        finally:
+            self._teardown()
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "ghost" in captured.err
+
+    def test_no_registry_exits_one(self, capsys: Any) -> None:
+        from chainweaver import cli
+
+        cli.set_default_registry(None)
+        exit_code = cli.main(["viz", "anything"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "No registry configured" in captured.err

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -28,6 +28,7 @@ class TestLinearAscii:
     def test_three_step_linear(self) -> None:
         flow = Flow(
             name="three",
+            version="0.1.0",
             description="Three-step.",
             steps=[
                 FlowStep(tool_name="a"),
@@ -40,17 +41,18 @@ class TestLinearAscii:
     def test_single_step(self) -> None:
         flow = Flow(
             name="one",
+            version="0.1.0",
             description="single step.",
             steps=[FlowStep(tool_name="lone")],
         )
         assert flow_to_ascii(flow) == "[lone]"
 
     def test_empty_flow(self) -> None:
-        flow = Flow(name="empty", description="empty", steps=[])
+        flow = Flow(name="empty", version="0.1.0", description="empty", steps=[])
         assert flow_to_ascii(flow) == "(empty flow)"
 
     def test_method_on_flow(self) -> None:
-        flow = Flow(name="x", description="y", steps=[FlowStep(tool_name="t")])
+        flow = Flow(name="x", version="0.1.0", description="y", steps=[FlowStep(tool_name="t")])
         assert flow.to_ascii() == "[t]"
 
 
@@ -63,6 +65,7 @@ class TestDagAscii:
     def test_diamond(self) -> None:
         dag = DAGFlow(
             name="diamond",
+            version="0.1.0",
             description="A->B,A->C,B->D,C->D",
             steps=[
                 DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
@@ -80,6 +83,7 @@ class TestDagAscii:
     def test_independent_dag_steps(self) -> None:
         dag = DAGFlow(
             name="indep",
+            version="0.1.0",
             description="Two independent steps.",
             steps=[
                 DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
@@ -93,6 +97,7 @@ class TestDagAscii:
     def test_dag_method_call(self) -> None:
         dag = DAGFlow(
             name="x",
+            version="0.1.0",
             description="x",
             steps=[DAGFlowStep(tool_name="t", step_id="T", depends_on=[])],
         )
@@ -109,6 +114,7 @@ class TestMermaidLinear:
     def test_basic_graph(self) -> None:
         flow = Flow(
             name="three",
+            version="0.1.0",
             description="three.",
             steps=[
                 FlowStep(tool_name="a"),
@@ -125,18 +131,18 @@ class TestMermaidLinear:
         assert "S1 --> S2" in out
 
     def test_direction_td(self) -> None:
-        flow = Flow(name="t", description="t", steps=[FlowStep(tool_name="x")])
+        flow = Flow(name="t", version="0.1.0", description="t", steps=[FlowStep(tool_name="x")])
         out = flow_to_mermaid(flow, direction="TD")
         assert out.startswith("graph TD")
 
     def test_empty_flow(self) -> None:
-        flow = Flow(name="empty", description="empty", steps=[])
+        flow = Flow(name="empty", version="0.1.0", description="empty", steps=[])
         out = flow_to_mermaid(flow)
         assert "graph LR" in out
         assert "empty" in out
 
     def test_method_on_flow(self) -> None:
-        flow = Flow(name="t", description="t", steps=[FlowStep(tool_name="m")])
+        flow = Flow(name="t", version="0.1.0", description="t", steps=[FlowStep(tool_name="m")])
         assert "S0[m]" in flow.to_mermaid()
 
 
@@ -144,6 +150,7 @@ class TestMermaidDag:
     def test_diamond_renders_all_edges(self) -> None:
         dag = DAGFlow(
             name="diamond",
+            version="0.1.0",
             description="diamond",
             steps=[
                 DAGFlowStep(tool_name="a", step_id="A", depends_on=[]),
@@ -163,6 +170,7 @@ class TestMermaidEscaping:
     def test_dangerous_chars_escaped(self) -> None:
         flow = Flow(
             name="dangerous",
+            version="0.1.0",
             description="x",
             steps=[FlowStep(tool_name="<bad>")],
         )
@@ -180,6 +188,7 @@ class TestMermaidEscaping:
 def _build_two_step_executor() -> FlowExecutor:
     flow = Flow(
         name="viz_two_step",
+        version="0.1.0",
         description="two step",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),
@@ -233,6 +242,7 @@ class TestResultMermaid:
 
         flow = Flow(
             name="viz_fail",
+            version="0.1.0",
             description="failing flow",
             steps=[FlowStep(tool_name="boom", input_mapping={"x": "x"})],
         )

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -36,7 +36,7 @@ class TestLinearAscii:
                 FlowStep(tool_name="c"),
             ],
         )
-        assert flow_to_ascii(flow) == "[a] --> [b] --> [c]"
+        assert flow_to_ascii(flow) == "[a] → [b] → [c]"
 
     def test_single_step(self) -> None:
         flow = Flow(
@@ -75,10 +75,10 @@ class TestDagAscii:
             ],
         )
         rendered = flow_to_ascii(dag)
-        assert "[a] --> [b]" in rendered
-        assert "[a] --> [c]" in rendered
-        assert "[b] --> [d]" in rendered
-        assert "[c] --> [d]" in rendered
+        assert "[a] → [b]" in rendered
+        assert "[a] → [c]" in rendered
+        assert "[b] → [d]" in rendered
+        assert "[c] → [d]" in rendered
 
     def test_independent_dag_steps(self) -> None:
         dag = DAGFlow(
@@ -433,7 +433,7 @@ class TestVizCli:
             self._teardown()
         captured = capsys.readouterr()
         assert exit_code == 0
-        assert "[a] --> [b] --> [c]" in captured.out
+        assert "[a] → [b] → [c]" in captured.out
 
     def test_dot_format(self, capsys: Any) -> None:
         from chainweaver import cli


### PR DESCRIPTION
## Summary

Delivers ChainWeaver v0.4.0: flow JSON/YAML serialization with serializable
schema and exception references, pluggable registry storage (in-memory default
plus a file-backed JSON-on-disk store that survives process restarts), three
new CLI subcommands (`validate`, `check`, `viz`) on top of the existing
`inspect`, and a benchmarks suite. The CI test matrix expands to the full
OS × Python cross product, and the package now ships a `CHANGELOG`, a SemVer /
versioning policy, and a measurable v1.0 release-criteria document.

Internally, `Flow.input_schema` / `output_schema` / `RetryPolicy.retryable_errors`
migrate from live class objects to `"module:qualname"` string references so
flow files stay JSON-compatible end-to-end. The executor's retry loop resolves
the refs through a new `resolve_class_ref` helper at run time, so the
deterministic guarantees (no LLM, no network I/O, no randomness in
`executor.py`) are unchanged.

## Changes

- **`chainweaver/serialization.py`** (new): JSON and optional YAML
  encoders/decoders for `Flow` and `DAGFlow` with a `"type"` discriminator.
  Module-level helpers `flow_to_dict` / `flow_from_dict` / `flow_to_json` /
  `flow_from_json` / `flow_to_yaml` / `flow_from_yaml`. JSON is dep-free; YAML
  routes through `pyyaml` (new optional extra `chainweaver[yaml]`). Schema and
  retry-error references round-trip as `"module:qualname"` strings — no live
  class objects in the payload. The module docstring spells out the trust
  boundary: deserialization calls `importlib.import_module` on user-controlled
  strings, so flow files must come from sources you trust.
- **`chainweaver/storage.py`** (new): `RegistryStore` `typing.Protocol`,
  `InMemoryStore` default (preserves prior in-process behaviour bit-for-bit),
  and `FileStore` that persists each flow as `{name}@{version}.flow.json`
  (atomic write via tmp + rename). `list_keys()` returns lexicographically
  sorted `(name, version)` pairs on both backends so iteration order is
  reproducible.
- **`chainweaver/registry.py`**: `FlowRegistry.__init__` accepts an optional
  `store=` parameter (defaults to `InMemoryStore()`); the latest-version
  pointer is rebuilt from `store.list_keys()` on construction so file-backed
  registries pick up flows that survived a process restart. All CRUD methods
  delegate to the configured store.
- **`chainweaver/flow.py`**: `Flow.version` and `DAGFlow.version` are now
  required fields (no `"0.0.0"` default). `input_schema` / `output_schema`
  move from `type[BaseModel] | None` fields to read-only properties that
  resolve new `input_schema_ref` / `output_schema_ref` fields holding
  `"module:qualname"` strings; `Flow.schema_ref_from(MySchema)` derives the
  ref. `RetryPolicy.retryable_errors` migrates from
  `tuple[type[BaseException], ...]` to `tuple[str, ...]` with the new default
  `("builtins:Exception",)`. `resolve_class_ref(ref, *, expected_base=None)`
  resolves refs to live classes and raises `FlowSerializationError` on missing
  modules, missing attributes, non-class refs, or wrong-base refs. Convenience
  methods `to_dot()`, `to_json()`, `to_yaml()`, `from_json()`, `from_yaml()`
  added to both `Flow` and `DAGFlow`.
- **`chainweaver/builder.py`**: `FlowBuilder.with_version(version)` for
  chainable version assignment; the builder picks a sensible `"0.1.0"`
  default when not called so quick prototypes and tests stay terse. `build()`
  translates configured schemas to `"module:qualname"` refs internally.
- **`chainweaver/executor.py`**: one-line change —
  `retry_if_exception_type(policy.resolved_retryable_errors())` resolves the
  new string refs to exception classes just before the retry loop. The three
  hard executor invariants (no LLM, no network I/O, no randomness in
  `executor.py`) are unchanged.
- **`chainweaver/exceptions.py`**: `FlowSerializationError(ChainWeaverError)`
  for malformed payloads, unknown `type` discriminators, unresolvable refs,
  and wrong-base refs.
- **`chainweaver/viz.py`**: `flow_to_dot()` renders `Flow` and `DAGFlow` as
  Graphviz DOT (pure string, no Graphviz dependency); `_dot_quote` /
  `_dot_identifier` helpers handle escaping and identifier sanitisation.
  `flow_to_ascii` (and the `Flow.to_ascii()` / `DAGFlow.to_ascii()` methods
  it backs) emits the unicode arrow `→` between steps so the ASCII output
  matches issue #46's acceptance criterion; the Mermaid renderer is unchanged
  (Mermaid grammar requires `-->`).
- **`chainweaver/cli.py`**: three new subcommands — `validate <file>`
  validates a single `.flow.yaml` / `.flow.yml` / `.flow.json` (exit codes
  0/1/2); `check <dir>` recursively scans for flow files and reports per-file
  status with `--format json` / `--quiet` (exit codes 0/1/2; JSON output is
  always emitted when explicitly requested, even under `--quiet`, because
  it's the machine-readable contract); `viz <flow>` renders a registered flow
  as ASCII (default) or DOT with `--format ascii|dot`.
- **`chainweaver/__init__.py`**: re-exports every new public symbol
  (`flow_to_dict`, `flow_from_dict`, `flow_to_json`, `flow_from_json`,
  `flow_to_yaml`, `flow_from_yaml`, `flow_to_dot`, `FileStore`,
  `InMemoryStore`, `RegistryStore`, `FlowSerializationError`) and
  alphabetises `__all__`. `__version__` bumped to `0.4.0`.
- **`pyproject.toml`**: project version bumped to `0.4.0`; new optional extra
  `[project.optional-dependencies.yaml] pyyaml>=6.0`; dev extras add
  `pyyaml>=6.0` and `types-pyyaml>=6.0` for round-trip testing and mypy.
- **`.github/workflows/ci.yml`**: pytest now runs across
  `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12, 3.13}`
  (12 jobs); lint, format, and mypy remain pinned to the canonical
  Python 3.10 / Ubuntu leg.
- **Documentation**:
  - `CHANGELOG.md` (new): full 0.4.0 entry with breaking-change details and a
    copy-pasteable migration guide.
  - `docs/versioning-policy.md` (new): SemVer policy, public-API scope, and
    deprecation process.
  - `docs/v1-release-criteria.md` (new): measurable v1.0 release bar and
    status checklist.
  - `AGENTS.md`: repo map updated with `storage.py` / `serialization.py`; CI
    section reflects the new matrix; new doc-map entries for the
    versioning-policy and v1 release-criteria docs.
  - `docs/agent-context/architecture.md`: module table updated with the two
    new modules and the registry's store delegation.
  - `docs/agent-context/workflows.md`: CI description matches the new
    OS × Python matrix.
  - `README.md`: error-handling table covers `FlowSerializationError`;
    Roadmap section replaced with the current milestone table.
- **`benchmarks/`** (new): `bench_naive_vs_compiled.py` plus
  `benchmarks/README.md` documenting how to read the JSON output.
- **Examples**: all five `examples/*.py` updated to set `version=` and use
  `Flow.schema_ref_from(...)` for input/output schemas.
- **Tests**: `test_serialization.py` (new, 367 LOC), `test_storage.py` (new,
  306 LOC), `test_cli.py` adds the `validate` and `check` test suites,
  `test_viz.py` adds the DOT renderer and `viz` CLI tests and uses `→` for
  ASCII expectations. Every other touched test file picks up the
  now-required `version=` argument.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`)
- [x] New tests added for new functionality

443 tests pass, 97.26% coverage. Both success and error paths covered for
every new feature. CI is green across all 12 jobs in the OS × Python matrix.

## Related Issues

Closes #14
Closes #16
Closes #29
Closes #34
Closes #45
Closes #46

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented
- [x] No secrets or credentials included

## Breaking changes

- `Flow.version` and `DAGFlow.version` are now required fields (no
  `"0.0.0"` default). Callers that previously relied on the implicit default
  must pass an explicit `version="..."`.
- `Flow.input_schema` / `output_schema` (and the `DAGFlow` equivalents) are
  no longer `type[BaseModel] | None` fields. They are read-only properties
  that lazy-resolve new `input_schema_ref` / `output_schema_ref` fields
  holding `"module:qualname"` strings. Use `Flow.schema_ref_from(MySchema)`
  to derive the ref. Schemas referenced by serialized flows must live at
  module top level — Python cannot reach `<locals>` through `importlib`.
- `RetryPolicy.retryable_errors` is now `tuple[str, ...]` of
  `"module:qualname"` references instead of `tuple[type[BaseException], ...]`.
  Default value is `("builtins:Exception",)`. Migrate
  `retryable_errors=(KeyError,)` to `retryable_errors=("builtins:KeyError",)`.
- `flow_to_ascii` (and the `Flow.to_ascii()` / `DAGFlow.to_ascii()` methods
  it backs) emits the unicode arrow `→` between steps instead of `-->`.
  Consumers that string-matched `[a] --> [b]` should update their expectations
  to `[a] → [b]`. The Mermaid renderer is unaffected.
- New optional runtime extra `chainweaver[yaml]` (`pyyaml>=6.0`) for YAML
  serialization; JSON works without extra deps.

See [`CHANGELOG.md`](CHANGELOG.md) for the full 0.4.0 entry and a copy-pasteable
migration guide.
