### PR TITLE
feat: add Tool.from_flow Flow-as-Tool adapter (#24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ chainweaver/
 ├── compat.py          schema_fingerprint() + check_flow_compatibility() + CompatibilityIssue
 ├── compiler.py        compile_flow(): static schema flow validation (CompilationResult)
 ├── decorators.py      @tool decorator for zero-boilerplate tool definition
-├── tools.py           Tool class: named callable with Pydantic I/O schemas + schema_hash
+├── tools.py           Tool class: named callable with Pydantic I/O schemas + schema_hash; Tool.from_flow() wraps a Flow as a Tool (#24)
 ├── flow.py            FlowStep + Flow + DAGFlow + FlowStatus enum + DriftInfo dataclass
 ├── registry.py        FlowRegistry: multi-version catalogue with status filtering (store-backed)
 ├── storage.py         RegistryStore protocol + InMemoryStore + FileStore (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Tool.from_flow`** (#24): wrap a registered `Flow` or `DAGFlow` as a
+  single `Tool` whose `fn` delegates back to a `FlowExecutor`.  The
+  resulting tool is registrable like any other tool, so a compiled flow
+  can be composed as a step inside another flow or exposed as one
+  capability to external consumers.  Schemas are derived from explicit
+  overrides, then the flow-level `input_schema_ref` / `output_schema_ref`,
+  then the first/last step's tool schema (or unique DAG sink).  Inner
+  flow failures surface as `FlowExecutionError`.  See
+  `examples/virtual_tool.py`.
+
 ## [0.4.0] - 2026-05-12
 
 ### Added

--- a/chainweaver/tools.py
+++ b/chainweaver/tools.py
@@ -20,7 +20,7 @@ or :class:`~chainweaver.flow.DAGFlow` as a single :class:`Tool` whose
 ``fn`` delegates back to a :class:`~chainweaver.executor.FlowExecutor`.  This
 collapses an N-step compiled flow into one tool-shaped capability that can be
 composed into other flows, exposed to external frameworks (OpenAI/Anthropic
-function schemas, MCP servers), or registered in a contextweaver catalog.
+function schemas, MCP servers), or registered in a weaver-spec catalog.
 """
 
 from __future__ import annotations
@@ -206,10 +206,13 @@ class Tool:
 
         Args:
             flow: A :class:`Flow` or :class:`DAGFlow` whose steps reference
-                tools registered on *executor*.  The flow itself does not
-                need to be registered on *executor*'s registry; the
-                returned tool calls ``executor.execute_flow(flow.name, …)``
-                so registration is the caller's responsibility.
+                tools registered on *executor*.  The flow **must** also be
+                registered on *executor*'s registry before the returned
+                tool is invoked, because its ``fn`` calls
+                ``executor.execute_flow(flow.name, …)`` to dispatch the
+                run.  ``from_flow`` itself does not register the flow;
+                registration is the caller's responsibility (typically
+                done immediately before or after this call).
             executor: The :class:`~chainweaver.executor.FlowExecutor` that
                 will run the wrapped flow.  Captured by reference; later
                 changes to its tool/flow registries are visible through
@@ -246,18 +249,23 @@ class Tool:
         tool_name = name if name is not None else flow.name
         tool_description = description if description is not None else flow.description
 
+        from chainweaver.exceptions import FlowSerializationError
+
         # --- Input schema resolution --------------------------------------
         if input_schema is not None:
             resolved_input = input_schema
         elif flow.input_schema_ref is not None:
-            flow_input = flow.input_schema
-            if flow_input is None:
+            # Flow.input_schema either returns a BaseModel subclass or
+            # raises FlowSerializationError when the ref is set; wrap that
+            # error in ToolDefinitionError to match this function's other
+            # "Cannot derive schema" branches.
+            try:
+                resolved_input = flow.input_schema  # type: ignore[assignment]
+            except FlowSerializationError as exc:
                 raise ToolDefinitionError(
                     flow.name,
-                    f"Flow.input_schema_ref '{flow.input_schema_ref}' did not "
-                    "resolve to a schema.",
-                )
-            resolved_input = flow_input
+                    f"Cannot resolve Flow.input_schema_ref '{flow.input_schema_ref}': {exc}",
+                ) from exc
         else:
             first_step = flow.steps[0]
             try:
@@ -275,14 +283,13 @@ class Tool:
         if output_schema is not None:
             resolved_output = output_schema
         elif flow.output_schema_ref is not None:
-            flow_output = flow.output_schema
-            if flow_output is None:
+            try:
+                resolved_output = flow.output_schema  # type: ignore[assignment]
+            except FlowSerializationError as exc:
                 raise ToolDefinitionError(
                     flow.name,
-                    f"Flow.output_schema_ref '{flow.output_schema_ref}' did not "
-                    "resolve to a schema.",
-                )
-            resolved_output = flow_output
+                    f"Cannot resolve Flow.output_schema_ref '{flow.output_schema_ref}': {exc}",
+                ) from exc
         else:
             terminal_step = _terminal_step(flow)
             try:
@@ -310,13 +317,13 @@ class Tool:
                 else:
                     detail = failed.error_message or failed.error_type or "Unknown error."
                     step_index = failed.step_index
-                raise FlowExecutionError(tool_name=flow_name, step_index=step_index, detail=detail)
+                raise FlowExecutionError(tool_name=tool_name, step_index=step_index, detail=detail)
             if result.final_output is None:
                 # Defensive: a successful run should always have a final_output,
                 # but the executor's contract allows None on failure paths and
                 # this is the only place the closure can guarantee non-None.
                 raise FlowExecutionError(
-                    tool_name=flow_name,
+                    tool_name=tool_name,
                     step_index=-1,
                     detail="Flow reported success but produced no final output.",
                 )

--- a/chainweaver/tools.py
+++ b/chainweaver/tools.py
@@ -14,6 +14,13 @@ misbehaving tools:
   the timeout only protects the *caller* from waiting.
 - ``max_output_size`` rejects oversized payloads after measuring the
   UTF-8 encoded JSON length of the raw output dict.
+
+``Tool.from_flow`` (issue #24) wraps a registered :class:`~chainweaver.flow.Flow`
+or :class:`~chainweaver.flow.DAGFlow` as a single :class:`Tool` whose
+``fn`` delegates back to a :class:`~chainweaver.executor.FlowExecutor`.  This
+collapses an N-step compiled flow into one tool-shaped capability that can be
+composed into other flows, exposed to external frameworks (OpenAI/Anthropic
+function schemas, MCP servers), or registered in a contextweaver catalog.
 """
 
 from __future__ import annotations
@@ -24,12 +31,16 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from functools import cached_property
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from chainweaver.compat import schema_fingerprint
-from chainweaver.exceptions import ToolOutputSizeError, ToolTimeoutError
+from chainweaver.exceptions import FlowExecutionError, ToolOutputSizeError, ToolTimeoutError
+from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
+
+if TYPE_CHECKING:
+    from chainweaver.executor import FlowExecutor
 
 
 class Tool:
@@ -158,3 +169,207 @@ class Tool:
 
     def __repr__(self) -> str:
         return f"Tool(name={self.name!r})"
+
+    # ------------------------------------------------------------------
+    # Flow-as-Tool adapter (issue #24)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_flow(
+        cls,
+        flow: Flow | DAGFlow,
+        executor: FlowExecutor,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        input_schema: type[BaseModel] | None = None,
+        output_schema: type[BaseModel] | None = None,
+    ) -> Tool:
+        """Wrap a registered flow as a :class:`Tool` (issue #24).
+
+        The returned tool behaves like any other ``Tool``: its ``fn``
+        validates inputs against the derived ``input_schema``, dispatches
+        the flow through *executor*, and returns the validated final
+        output.  This makes a compiled flow composable as a step inside
+        another flow, or exportable as a single capability to external
+        consumers (OpenAI / Anthropic / MCP / weaver-spec).
+
+        Schema derivation prefers, in order:
+
+        1. The explicit ``input_schema`` / ``output_schema`` keyword overrides.
+        2. The flow's own ``input_schema_ref`` / ``output_schema_ref`` (when set).
+        3. The first step's tool's ``input_schema`` (for inputs) and the
+           last step's tool's ``output_schema`` (for outputs).  For a
+           :class:`DAGFlow`, "last step" means the unique sink node; if
+           the DAG has multiple sinks, an ``output_schema`` override is
+           required.
+
+        Args:
+            flow: A :class:`Flow` or :class:`DAGFlow` whose steps reference
+                tools registered on *executor*.  The flow itself does not
+                need to be registered on *executor*'s registry; the
+                returned tool calls ``executor.execute_flow(flow.name, …)``
+                so registration is the caller's responsibility.
+            executor: The :class:`~chainweaver.executor.FlowExecutor` that
+                will run the wrapped flow.  Captured by reference; later
+                changes to its tool/flow registries are visible through
+                the returned tool.
+            name: Override for the resulting tool's name.  Defaults to
+                ``flow.name``.
+            description: Override for the resulting tool's description.
+                Defaults to ``flow.description``.
+            input_schema: Override for the derived input schema.  Useful
+                when the first step's tool input contains fields the
+                caller should not have to provide directly.
+            output_schema: Override for the derived output schema.
+                Required for DAG flows with multiple sink nodes when no
+                flow-level ``output_schema_ref`` is set.
+
+        Returns:
+            A :class:`Tool` instance whose ``fn`` executes *flow*.  The
+            tool can be registered via
+            :meth:`~chainweaver.executor.FlowExecutor.register_tool` just
+            like any other tool, enabling flow composition by name.
+
+        Raises:
+            ToolDefinitionError: When the flow has no steps, or when
+                neither the explicit override, the flow-level ref, nor a
+                step-level fallback can produce a required schema (or
+                when a DAG has multiple sinks without an explicit
+                ``output_schema`` override).
+        """
+        from chainweaver.exceptions import ToolDefinitionError, ToolNotFoundError
+
+        if not flow.steps:
+            raise ToolDefinitionError(flow.name, "Cannot wrap a flow with no steps as a tool.")
+
+        tool_name = name if name is not None else flow.name
+        tool_description = description if description is not None else flow.description
+
+        # --- Input schema resolution --------------------------------------
+        if input_schema is not None:
+            resolved_input = input_schema
+        elif flow.input_schema_ref is not None:
+            flow_input = flow.input_schema
+            if flow_input is None:
+                raise ToolDefinitionError(
+                    flow.name,
+                    f"Flow.input_schema_ref '{flow.input_schema_ref}' did not "
+                    "resolve to a schema.",
+                )
+            resolved_input = flow_input
+        else:
+            first_step = flow.steps[0]
+            try:
+                first_tool = executor.get_tool(first_step.tool_name)
+            except ToolNotFoundError as exc:
+                raise ToolDefinitionError(
+                    flow.name,
+                    f"Cannot derive input schema: first step's tool "
+                    f"'{first_step.tool_name}' is not registered on the executor. "
+                    "Pass input_schema=... or register the tool first.",
+                ) from exc
+            resolved_input = first_tool.input_schema
+
+        # --- Output schema resolution -------------------------------------
+        if output_schema is not None:
+            resolved_output = output_schema
+        elif flow.output_schema_ref is not None:
+            flow_output = flow.output_schema
+            if flow_output is None:
+                raise ToolDefinitionError(
+                    flow.name,
+                    f"Flow.output_schema_ref '{flow.output_schema_ref}' did not "
+                    "resolve to a schema.",
+                )
+            resolved_output = flow_output
+        else:
+            terminal_step = _terminal_step(flow)
+            try:
+                terminal_tool = executor.get_tool(terminal_step.tool_name)
+            except ToolNotFoundError as exc:
+                raise ToolDefinitionError(
+                    flow.name,
+                    f"Cannot derive output schema: terminal step's tool "
+                    f"'{terminal_step.tool_name}' is not registered on the executor. "
+                    "Pass output_schema=... or register the tool first.",
+                ) from exc
+            resolved_output = terminal_tool.output_schema
+
+        flow_name = flow.name
+
+        def _flow_fn(validated_input: BaseModel) -> dict[str, Any]:
+            result = executor.execute_flow(flow_name, validated_input.model_dump())
+            if not result.success:
+                # Surface the first failed step's context so the caller can
+                # diagnose without inspecting the full execution log.
+                failed = next((r for r in result.execution_log if not r.success), None)
+                if failed is None:
+                    detail = "Flow execution failed without recording a failing step."
+                    step_index = -1
+                else:
+                    detail = failed.error_message or failed.error_type or "Unknown error."
+                    step_index = failed.step_index
+                raise FlowExecutionError(tool_name=flow_name, step_index=step_index, detail=detail)
+            if result.final_output is None:
+                # Defensive: a successful run should always have a final_output,
+                # but the executor's contract allows None on failure paths and
+                # this is the only place the closure can guarantee non-None.
+                raise FlowExecutionError(
+                    tool_name=flow_name,
+                    step_index=-1,
+                    detail="Flow reported success but produced no final output.",
+                )
+            return result.final_output
+
+        return cls(
+            name=tool_name,
+            description=tool_description,
+            input_schema=resolved_input,
+            output_schema=resolved_output,
+            fn=_flow_fn,
+        )
+
+
+def _terminal_step(flow: Flow | DAGFlow) -> FlowStep:
+    """Return the sole terminal step of *flow* for output-schema derivation.
+
+    For a linear :class:`Flow` the terminal step is the last entry in
+    ``flow.steps``.  For a :class:`DAGFlow` the terminal step is the unique
+    sink node (a step that no other step depends on).  When the DAG has more
+    than one sink, deriving a single output schema is ambiguous; the caller
+    must supply ``output_schema=`` explicitly.
+
+    Args:
+        flow: The flow whose terminal step should be located.
+
+    Returns:
+        The terminal :class:`FlowStep` (or :class:`DAGFlowStep` for DAGs).
+
+    Raises:
+        ToolDefinitionError: When *flow* is a DAG with zero or multiple
+            sink nodes.
+    """
+    from chainweaver.exceptions import ToolDefinitionError
+
+    if not isinstance(flow, DAGFlow):
+        return flow.steps[-1]
+
+    referenced: set[str] = set()
+    for step in flow.steps:
+        referenced.update(step.depends_on)
+    sinks: list[DAGFlowStep] = [s for s in flow.steps if s.step_id not in referenced]
+    if len(sinks) == 1:
+        return sinks[0]
+    if len(sinks) == 0:
+        raise ToolDefinitionError(
+            flow.name,
+            "DAG has no sink node; cannot derive output schema. "
+            "Pass output_schema=... explicitly.",
+        )
+    sink_ids = ", ".join(f"'{s.step_id}'" for s in sinks)
+    raise ToolDefinitionError(
+        flow.name,
+        f"DAG has multiple sink nodes ({sink_ids}); output schema is ambiguous. "
+        "Pass output_schema=... explicitly.",
+    )

--- a/chainweaver/tools.py
+++ b/chainweaver/tools.py
@@ -36,7 +36,14 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from chainweaver.compat import schema_fingerprint
-from chainweaver.exceptions import FlowExecutionError, ToolOutputSizeError, ToolTimeoutError
+from chainweaver.exceptions import (
+    FlowExecutionError,
+    FlowSerializationError,
+    ToolDefinitionError,
+    ToolNotFoundError,
+    ToolOutputSizeError,
+    ToolTimeoutError,
+)
 from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
 
 if TYPE_CHECKING:
@@ -241,15 +248,11 @@ class Tool:
                 when a DAG has multiple sinks without an explicit
                 ``output_schema`` override).
         """
-        from chainweaver.exceptions import ToolDefinitionError, ToolNotFoundError
-
         if not flow.steps:
             raise ToolDefinitionError(flow.name, "Cannot wrap a flow with no steps as a tool.")
 
         tool_name = name if name is not None else flow.name
         tool_description = description if description is not None else flow.description
-
-        from chainweaver.exceptions import FlowSerializationError
 
         # --- Input schema resolution --------------------------------------
         if input_schema is not None:
@@ -322,9 +325,13 @@ class Tool:
                 # Defensive: a successful run should always have a final_output,
                 # but the executor's contract allows None on failure paths and
                 # this is the only place the closure can guarantee non-None.
+                # Use ``len(flow.steps)`` (the flow-output validation sentinel
+                # per AGENTS.md §5 StepRecord) — this anomaly is a flow-output
+                # contract violation, not a flow-input validation failure
+                # (which is what ``step_index=-1`` would denote).
                 raise FlowExecutionError(
                     tool_name=tool_name,
-                    step_index=-1,
+                    step_index=len(flow.steps),
                     detail="Flow reported success but produced no final output.",
                 )
             return result.final_output

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -25,7 +25,7 @@ and tools, the same flow produces the same output every time.
 | `compat.py` | `schema_fingerprint()`, `CompatibilityIssue`, `check_flow_compatibility()` | Pure utility; no execution or I/O |
 | `compiler.py` | `compile_flow()`: static schema flow validation pre-execution | Returns `CompilationResult`; no execution logic |
 | `decorators.py` | `@tool` decorator for zero-boilerplate tool definition | Returns a `Tool` subclass; introspects type hints |
-| `tools.py` | Define `Tool`: name + callable + Pydantic I/O schemas + `schema_hash` | Tool functions must be `fn(BaseModel) -> dict[str, Any]` |
+| `tools.py` | Define `Tool`: name + callable + Pydantic I/O schemas + `schema_hash`; `Tool.from_flow()` adapter (#24) | Tool functions must be `fn(BaseModel) -> dict[str, Any]`; `from_flow` reuses the same contract — its closure dispatches `FlowExecutor.execute_flow` and surfaces inner failures as `FlowExecutionError` |
 | `flow.py` | Define `FlowStep`, `Flow`, `DAGFlowStep`, `DAGFlow`, `FlowStatus`, `DriftInfo`, `validate_dag_topology` | Pure data definitions + topology validation; no execution logic |
 | `registry.py` | Store and retrieve `Flow`/`DAGFlow` by `(name, version)`; status filtering; multi-version support | Delegates persistence to a `RegistryStore`; defaults to `InMemoryStore` |
 | `storage.py` | `RegistryStore` Protocol + `InMemoryStore` (default) + `FileStore` (one JSON file per flow) | Filenames are `{name}@{version}.flow.json`; concurrent multi-process access not coordinated |

--- a/examples/virtual_tool.py
+++ b/examples/virtual_tool.py
@@ -96,7 +96,7 @@ format_tool = Tool(
 # ---------------------------------------------------------------------------
 
 inner_flow = Flow(
-    name="inner_pipeline",
+    name="inner_flow",
     version="0.1.0",
     description="Doubles a number, adds 10, formats the result.",
     steps=[
@@ -132,21 +132,21 @@ def main() -> None:
     executor.register_tool(wrapped)
 
     outer_flow = Flow(
-        name="outer_pipeline",
+        name="outer_flow",
         version="0.1.0",
-        description="Doubles, then runs inner_pipeline on the doubled value.",
+        description="Doubles, then runs inner_flow on the doubled value.",
         steps=[
             FlowStep(tool_name="double", input_mapping={"number": "number"}),
             # The wrapped inner flow is now usable as a single tool step.
             FlowStep(
-                tool_name="inner_pipeline",
+                tool_name="inner_flow",
                 input_mapping={"number": "value"},
             ),
         ],
     )
     registry.register_flow(outer_flow)
 
-    outer_result = executor.execute_flow("outer_pipeline", {"number": 5})
+    outer_result = executor.execute_flow("outer_flow", {"number": 5})
     assert outer_result.success
     assert outer_result.final_output is not None
     print(f"\nComposed outer flow result: {outer_result.final_output}")

--- a/examples/virtual_tool.py
+++ b/examples/virtual_tool.py
@@ -1,0 +1,160 @@
+"""Flow-as-Tool example for ChainWeaver (issue #24).
+
+This script demonstrates ``Tool.from_flow()`` — wrapping a registered flow
+as a single :class:`~chainweaver.tools.Tool` whose call site executes the
+entire flow through a :class:`~chainweaver.executor.FlowExecutor`.
+
+Two scenarios are shown:
+
+1. **Direct call** — invoke the wrapped flow like any other tool::
+
+       wrapped.run({"number": 5})  # → {"result": "Final value: 20"}
+
+2. **Composition** — register the wrapped flow on the executor and
+   reference it by name from another flow's ``FlowStep``.
+
+Run this script from the repository root with::
+
+    python examples/virtual_tool.py
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from chainweaver import Flow, FlowExecutor, FlowRegistry, FlowStep, Tool
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schemas + tool functions
+# ---------------------------------------------------------------------------
+
+
+class NumberInput(BaseModel):
+    number: int
+
+
+class ValueOutput(BaseModel):
+    value: int
+
+
+class ValueInput(BaseModel):
+    value: int
+
+
+class FormattedOutput(BaseModel):
+    result: str
+
+
+def double_fn(inp: NumberInput) -> dict:
+    return {"value": inp.number * 2}
+
+
+def add_ten_fn(inp: ValueInput) -> dict:
+    return {"value": inp.value + 10}
+
+
+def format_result_fn(inp: ValueInput) -> dict:
+    return {"result": f"Final value: {inp.value}"}
+
+
+double_tool = Tool(
+    name="double",
+    description="Doubles a number.",
+    input_schema=NumberInput,
+    output_schema=ValueOutput,
+    fn=double_fn,
+)
+
+add_ten_tool = Tool(
+    name="add_ten",
+    description="Adds 10 to a value.",
+    input_schema=ValueInput,
+    output_schema=ValueOutput,
+    fn=add_ten_fn,
+)
+
+format_tool = Tool(
+    name="format_result",
+    description="Formats a value as a string.",
+    input_schema=ValueInput,
+    output_schema=FormattedOutput,
+    fn=format_result_fn,
+)
+
+
+# ---------------------------------------------------------------------------
+# Inner flow: double → add_ten → format_result
+# ---------------------------------------------------------------------------
+
+inner_flow = Flow(
+    name="inner_pipeline",
+    version="0.1.0",
+    description="Doubles a number, adds 10, formats the result.",
+    steps=[
+        FlowStep(tool_name="double", input_mapping={"number": "number"}),
+        FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+        FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+    ],
+    input_schema_ref=Flow.schema_ref_from(NumberInput),
+    output_schema_ref=Flow.schema_ref_from(FormattedOutput),
+)
+
+
+def main() -> None:
+    registry = FlowRegistry()
+    registry.register_flow(inner_flow)
+
+    executor = FlowExecutor(registry=registry)
+    executor.register_tool(double_tool)
+    executor.register_tool(add_ten_tool)
+    executor.register_tool(format_tool)
+
+    # --- Scenario 1: direct call on the wrapped flow ---------------------
+    wrapped = Tool.from_flow(inner_flow, executor)
+    print(f"\nWrapped flow as Tool: name={wrapped.name!r}")
+    print(f"  input_schema  = {wrapped.input_schema.__name__}")
+    print(f"  output_schema = {wrapped.output_schema.__name__}")
+
+    direct_result = wrapped.run({"number": 5})
+    print(f"\nDirect call wrapped.run({{'number': 5}}) → {direct_result}")
+    assert direct_result == {"result": "Final value: 20"}
+
+    # --- Scenario 2: register the wrapped flow and call it from another flow.
+    executor.register_tool(wrapped)
+
+    outer_flow = Flow(
+        name="outer_pipeline",
+        version="0.1.0",
+        description="Doubles, then runs inner_pipeline on the doubled value.",
+        steps=[
+            FlowStep(tool_name="double", input_mapping={"number": "number"}),
+            # The wrapped inner flow is now usable as a single tool step.
+            FlowStep(
+                tool_name="inner_pipeline",
+                input_mapping={"number": "value"},
+            ),
+        ],
+    )
+    registry.register_flow(outer_flow)
+
+    outer_result = executor.execute_flow("outer_pipeline", {"number": 5})
+    assert outer_result.success
+    assert outer_result.final_output is not None
+    print(f"\nComposed outer flow result: {outer_result.final_output}")
+    # double(5)=10; inner(10): double→20, +10→30, format→"Final value: 30"
+    assert outer_result.final_output["result"] == "Final value: 30"
+
+    print("\n✓ Flow-as-Tool composition verified.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tool_from_flow.py
+++ b/tests/test_tool_from_flow.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 from helpers import FormattedOutput, NumberInput, ValueInput, ValueOutput
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from chainweaver.exceptions import FlowExecutionError, ToolDefinitionError
 from chainweaver.executor import FlowExecutor
@@ -154,9 +154,7 @@ class TestExecution:
 
         assert through_tool == {"result": "Final value: 20"}
 
-    def test_run_matches_execute_flow_on_terminal_fields(
-        self, executor: FlowExecutor
-    ) -> None:
+    def test_run_matches_execute_flow_on_terminal_fields(self, executor: FlowExecutor) -> None:
         flow = executor._registry.get_flow("double_add_format")
         wrapped = Tool.from_flow(flow, executor)
 
@@ -181,10 +179,8 @@ class TestExecution:
         flow = executor._registry.get_flow("double_add_format")
         wrapped = Tool.from_flow(flow, executor)
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ValidationError) as excinfo:
             wrapped.run({"wrong_field": 5})
-        # Pydantic's ValidationError inherits from ValueError; just confirm
-        # the message mentions the missing field.
         assert "number" in str(excinfo.value)
 
 
@@ -293,6 +289,44 @@ class TestErrorPropagation:
         assert excinfo.value.step_index == 1
         assert "intentional failure" in excinfo.value.detail
 
+    def test_failing_step_error_uses_overridden_tool_name(
+        self,
+        double_tool: Tool,
+    ) -> None:
+        # Regression: when ``name=`` is overridden, the FlowExecutionError
+        # raised on failure must surface the wrapper's name (the identity
+        # the caller knows), not the inner flow's name.
+        failing_tool = Tool(
+            name="boom",
+            description="Always fails.",
+            input_schema=ValueInput,
+            output_schema=ValueOutput,
+            fn=_failing_fn,
+        )
+        flow = Flow(
+            name="inner_flow_name",
+            version="0.1.0",
+            description="Has a failing step.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="boom", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(failing_tool)
+
+        wrapped = Tool.from_flow(flow, ex, name="my_alias")
+
+        with pytest.raises(FlowExecutionError) as excinfo:
+            wrapped.run({"number": 5})
+        assert excinfo.value.tool_name == "my_alias"
+        assert excinfo.value.tool_name != "inner_flow_name"
+        assert excinfo.value.step_index == 1
+        assert "intentional failure" in excinfo.value.detail
+
     def test_no_steps_raises_tool_definition_error(self) -> None:
         empty_flow = Flow(
             name="empty",
@@ -342,12 +376,7 @@ class TestErrorPropagation:
             Tool.from_flow(flow, ex)
         assert "phantom" in str(excinfo.value)
 
-    def test_unregistered_tool_skipped_when_input_schema_overridden(
-        self,
-        double_tool: Tool,
-        add_ten_tool: Tool,
-        format_tool: Tool,
-    ) -> None:
+    def test_unregistered_tool_skipped_when_input_schema_overridden(self) -> None:
         # When input_schema is overridden, we should NOT look up the first
         # step's tool. Same for output_schema and the last step.
         flow = Flow(
@@ -362,12 +391,10 @@ class TestErrorPropagation:
         registry = FlowRegistry()
         registry.register_flow(flow)
         ex = FlowExecutor(registry=registry)
-        # Intentionally register only one tool to prove the override path
-        # bypasses tool lookup for schema derivation.
-        ex.register_tool(double_tool)
-        ex.register_tool(add_ten_tool)
-        ex.register_tool(format_tool)
-
+        # Intentionally register zero tools to prove that when both schemas
+        # are overridden, ``Tool.from_flow`` never looks up the first or
+        # terminal step's tool for schema derivation.  If it did, the
+        # construction would raise ``ToolDefinitionError``.
         wrapped = Tool.from_flow(
             flow,
             ex,

--- a/tests/test_tool_from_flow.py
+++ b/tests/test_tool_from_flow.py
@@ -1,0 +1,502 @@
+"""Tests for ``Tool.from_flow`` (issue #24).
+
+These tests exercise the Flow-as-Tool adapter that wraps a registered
+:class:`~chainweaver.flow.Flow` or :class:`~chainweaver.flow.DAGFlow` as a
+single :class:`~chainweaver.tools.Tool` whose ``fn`` delegates to a
+:class:`~chainweaver.executor.FlowExecutor`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from helpers import FormattedOutput, NumberInput, ValueInput, ValueOutput
+from pydantic import BaseModel
+
+from chainweaver.exceptions import FlowExecutionError, ToolDefinitionError
+from chainweaver.executor import FlowExecutor
+from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
+from chainweaver.registry import FlowRegistry
+from chainweaver.tools import Tool
+
+# ---------------------------------------------------------------------------
+# Module-level schemas (must be importable by qualified name so that
+# Flow.input_schema_ref / output_schema_ref can resolve them).
+# ---------------------------------------------------------------------------
+
+
+class CustomInputOverride(BaseModel):
+    number: int
+
+
+class CustomOutputOverride(BaseModel):
+    result: str
+
+
+class FlowLevelInput(BaseModel):
+    number: int
+
+
+class FlowLevelOutput(BaseModel):
+    result: str
+
+
+def _failing_fn(inp: ValueInput) -> dict[str, Any]:
+    """Tool callable that always fails with a recognizable error."""
+    raise RuntimeError(f"intentional failure for input {inp.value}")
+
+
+# ---------------------------------------------------------------------------
+# Schema derivation from step tools (no flow-level refs)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDerivationFromSteps:
+    def test_input_schema_from_first_step(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+        assert wrapped.input_schema is NumberInput
+
+    def test_output_schema_from_last_step(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+        assert wrapped.output_schema is FormattedOutput
+
+    def test_name_defaults_to_flow_name(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+        assert wrapped.name == "double_add_format"
+
+    def test_description_defaults_to_flow_description(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+        assert wrapped.description == flow.description
+
+
+# ---------------------------------------------------------------------------
+# Schema derivation from flow-level refs
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDerivationFromFlowRefs:
+    def test_input_ref_preferred_over_first_step(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+        format_tool: Tool,
+    ) -> None:
+        flow = Flow(
+            name="ref_flow",
+            version="0.1.0",
+            description="Uses flow-level refs.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+            input_schema_ref=Flow.schema_ref_from(FlowLevelInput),
+            output_schema_ref=Flow.schema_ref_from(FlowLevelOutput),
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+        ex.register_tool(format_tool)
+
+        wrapped = Tool.from_flow(flow, ex)
+        assert wrapped.input_schema is FlowLevelInput
+        assert wrapped.output_schema is FlowLevelOutput
+
+
+# ---------------------------------------------------------------------------
+# Explicit kwarg overrides
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitOverrides:
+    def test_name_override(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor, name="my_alias")
+        assert wrapped.name == "my_alias"
+
+    def test_description_override(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor, description="A combined flow.")
+        assert wrapped.description == "A combined flow."
+
+    def test_input_schema_override_beats_first_step(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor, input_schema=CustomInputOverride)
+        assert wrapped.input_schema is CustomInputOverride
+
+    def test_output_schema_override_beats_last_step(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor, output_schema=CustomOutputOverride)
+        assert wrapped.output_schema is CustomOutputOverride
+
+
+# ---------------------------------------------------------------------------
+# Execution: end-to-end behavior
+# ---------------------------------------------------------------------------
+
+
+class TestExecution:
+    def test_run_returns_output_schema_shape(self, executor: FlowExecutor) -> None:
+        # The wrapped tool narrows the executor's full merged context down
+        # to the derived output_schema (FormattedOutput), so it returns
+        # only the schema's fields — not the entire context.
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+
+        through_tool = wrapped.run({"number": 5})
+
+        assert through_tool == {"result": "Final value: 20"}
+
+    def test_run_matches_execute_flow_on_terminal_fields(
+        self, executor: FlowExecutor
+    ) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+
+        direct = executor.execute_flow("double_add_format", {"number": 5})
+        through_tool = wrapped.run({"number": 5})
+
+        assert direct.success is True
+        assert direct.final_output is not None
+        # Terminal fields agree; the wrapped tool simply drops upstream
+        # context entries that aren't part of its output schema.
+        assert through_tool["result"] == direct.final_output["result"]
+
+    def test_returned_dict_matches_output_schema(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+
+        output = wrapped.run({"number": 7})
+        # Validates without raising.
+        FormattedOutput.model_validate(output)
+
+    def test_invalid_input_raises_validation_error(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor)
+
+        with pytest.raises(Exception) as excinfo:
+            wrapped.run({"wrong_field": 5})
+        # Pydantic's ValidationError inherits from ValueError; just confirm
+        # the message mentions the missing field.
+        assert "number" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Composition: a wrapped flow as a step in another flow
+# ---------------------------------------------------------------------------
+
+
+class TestComposition:
+    def test_wrapped_flow_registers_as_tool(self, executor: FlowExecutor) -> None:
+        flow = executor._registry.get_flow("double_add_format")
+        wrapped = Tool.from_flow(flow, executor, name="combined")
+        executor.register_tool(wrapped)
+
+        retrieved = executor.get_tool("combined")
+        assert retrieved is wrapped
+
+    def test_outer_flow_calls_wrapped_flow_as_step(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+        format_tool: Tool,
+    ) -> None:
+        # Inner flow: double → add_ten → format
+        inner = Flow(
+            name="inner",
+            version="0.1.0",
+            description="Inner flow.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(inner)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+        ex.register_tool(format_tool)
+
+        # Wrap inner as a Tool and register it.
+        wrapped = Tool.from_flow(inner, ex, name="inner_tool")
+        ex.register_tool(wrapped)
+
+        # Outer flow: pre_double → inner_tool (treated as a regular tool).
+        outer = Flow(
+            name="outer",
+            version="0.1.0",
+            description="Outer flow that calls the wrapped inner flow.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                # After "double", context has {"number": N, "value": 2*N}.
+                # inner_tool's input_schema is NumberInput (one field: number).
+                # We pass the doubled value as the new number.
+                FlowStep(tool_name="inner_tool", input_mapping={"number": "value"}),
+            ],
+        )
+        ex._registry.register_flow(outer)
+
+        result = ex.execute_flow("outer", {"number": 5})
+        # double(5) -> value=10; inner_tool(number=10): double->20, +10->30,
+        # format -> "Final value: 30".
+        assert result.success is True
+        assert result.final_output is not None
+        assert result.final_output["result"] == "Final value: 30"
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    def test_failing_step_raises_flow_execution_error(
+        self,
+        double_tool: Tool,
+    ) -> None:
+        failing_tool = Tool(
+            name="boom",
+            description="Always fails.",
+            input_schema=ValueInput,
+            output_schema=ValueOutput,
+            fn=_failing_fn,
+        )
+        flow = Flow(
+            name="failing_flow",
+            version="0.1.0",
+            description="Has a failing step.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="boom", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(failing_tool)
+
+        wrapped = Tool.from_flow(flow, ex)
+
+        with pytest.raises(FlowExecutionError) as excinfo:
+            wrapped.run({"number": 5})
+        assert excinfo.value.tool_name == "failing_flow"
+        assert excinfo.value.step_index == 1
+        assert "intentional failure" in excinfo.value.detail
+
+    def test_no_steps_raises_tool_definition_error(self) -> None:
+        empty_flow = Flow(
+            name="empty",
+            version="0.1.0",
+            description="Empty.",
+            steps=[],
+        )
+        ex = FlowExecutor(registry=FlowRegistry())
+
+        with pytest.raises(ToolDefinitionError) as excinfo:
+            Tool.from_flow(empty_flow, ex)
+        assert "no steps" in str(excinfo.value).lower()
+
+    def test_unregistered_first_step_tool_raises(self) -> None:
+        flow = Flow(
+            name="unreg",
+            version="0.1.0",
+            description="References a missing tool.",
+            steps=[
+                FlowStep(tool_name="ghost", input_mapping={"number": "number"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+
+        with pytest.raises(ToolDefinitionError) as excinfo:
+            Tool.from_flow(flow, ex)
+        assert "ghost" in str(excinfo.value)
+
+    def test_unregistered_last_step_tool_raises(self, double_tool: Tool) -> None:
+        flow = Flow(
+            name="unreg_last",
+            version="0.1.0",
+            description="First step OK, last step missing.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="phantom", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+
+        with pytest.raises(ToolDefinitionError) as excinfo:
+            Tool.from_flow(flow, ex)
+        assert "phantom" in str(excinfo.value)
+
+    def test_unregistered_tool_skipped_when_input_schema_overridden(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+        format_tool: Tool,
+    ) -> None:
+        # When input_schema is overridden, we should NOT look up the first
+        # step's tool. Same for output_schema and the last step.
+        flow = Flow(
+            name="overridden",
+            version="0.1.0",
+            description="Tools registered but we override schemas anyway.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        # Intentionally register only one tool to prove the override path
+        # bypasses tool lookup for schema derivation.
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+        ex.register_tool(format_tool)
+
+        wrapped = Tool.from_flow(
+            flow,
+            ex,
+            input_schema=CustomInputOverride,
+            output_schema=CustomOutputOverride,
+        )
+        assert wrapped.input_schema is CustomInputOverride
+        assert wrapped.output_schema is CustomOutputOverride
+
+
+# ---------------------------------------------------------------------------
+# DAG support
+# ---------------------------------------------------------------------------
+
+
+class TestDAGSupport:
+    def test_dag_single_sink_derives_output_schema(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+    ) -> None:
+        dag = DAGFlow(
+            name="dag_linear",
+            version="0.1.0",
+            description="A -> B (single sink).",
+            steps=[
+                DAGFlowStep(
+                    tool_name="double",
+                    step_id="A",
+                    depends_on=[],
+                    input_mapping={"number": "number"},
+                ),
+                DAGFlowStep(
+                    tool_name="add_ten",
+                    step_id="B",
+                    depends_on=["A"],
+                    input_mapping={"value": "value"},
+                ),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(dag)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+
+        wrapped = Tool.from_flow(dag, ex)
+        assert wrapped.input_schema is NumberInput
+        assert wrapped.output_schema is ValueOutput
+
+    def test_dag_multiple_sinks_requires_explicit_output_schema(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+        format_tool: Tool,
+    ) -> None:
+        dag = DAGFlow(
+            name="dag_diamond_sinks",
+            version="0.1.0",
+            description="A -> (B, C), two sinks.",
+            steps=[
+                DAGFlowStep(
+                    tool_name="double",
+                    step_id="A",
+                    depends_on=[],
+                    input_mapping={"number": "number"},
+                ),
+                DAGFlowStep(
+                    tool_name="add_ten",
+                    step_id="B",
+                    depends_on=["A"],
+                    input_mapping={"value": "value"},
+                ),
+                DAGFlowStep(
+                    tool_name="format_result",
+                    step_id="C",
+                    depends_on=["A"],
+                    input_mapping={"value": "value"},
+                ),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(dag)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+        ex.register_tool(format_tool)
+
+        with pytest.raises(ToolDefinitionError) as excinfo:
+            Tool.from_flow(dag, ex)
+        assert "multiple sink" in str(excinfo.value).lower()
+
+        # Providing output_schema= bypasses the ambiguity.
+        wrapped = Tool.from_flow(dag, ex, output_schema=FormattedOutput)
+        assert wrapped.output_schema is FormattedOutput
+
+
+# ---------------------------------------------------------------------------
+# Smoke test that the executor reference is captured live (closure semantics)
+# ---------------------------------------------------------------------------
+
+
+class TestClosureCapturesExecutor:
+    def test_late_tool_registration_visible(
+        self,
+        double_tool: Tool,
+        add_ten_tool: Tool,
+        format_tool: Tool,
+    ) -> None:
+        flow = Flow(
+            name="late_reg",
+            version="0.1.0",
+            description="Tools registered after Tool.from_flow().",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        ex = FlowExecutor(registry=registry)
+        ex.register_tool(double_tool)
+        ex.register_tool(add_ten_tool)
+        # format_result deliberately not yet registered — we override the
+        # output schema so from_flow succeeds without it.
+        wrapped = Tool.from_flow(flow, ex, output_schema=FormattedOutput)
+        # Register the missing tool now.
+        ex.register_tool(format_tool)
+
+        result = wrapped.run({"number": 3})
+        assert result == {"result": "Final value: 16"}


### PR DESCRIPTION
## Summary

Adds `Tool.from_flow` — a classmethod on the existing `Tool` class that wraps
a registered `Flow` or `DAGFlow` as a single, schema-validated tool whose
callable delegates back to `FlowExecutor.execute_flow`. The resulting tool
can be registered on any executor like a hand-written tool, which makes a
compiled flow composable as a step inside another flow and exportable as one
capability to downstream consumers (OpenAI / Anthropic function schemas,
MCP servers, weaver-spec catalogs).

The adapter lives on the existing `Tool` class rather than a separate
`VirtualTool` type so that the timeout, output-size, and schema-fingerprint
machinery already on `Tool` apply automatically; callers get one tool API
surface across hand-written tools and flow-wrapped tools.

## Changes

- **`chainweaver/tools.py`**: new `Tool.from_flow` classmethod plus a private
  `_terminal_step` helper. Schema-derivation precedence is explicit kwarg
  override > flow-level `input_schema_ref` / `output_schema_ref` > first
  step's tool `input_schema` (for inputs) and terminal step's tool
  `output_schema` (for outputs). For a linear `Flow` the terminal step is
  the last entry in `flow.steps`; for a `DAGFlow` it is the unique sink
  node — DAGs with multiple sinks require an explicit `output_schema=`
  override (otherwise `ToolDefinitionError`). The wrapper closure dispatches
  the inner run, surfaces inner step failures as `FlowExecutionError` with
  `tool_name` set to the wrapper's name (so callers see the identity they
  registered), `step_index` from the failing step, and `detail` from the
  inner `error_message` / `error_type`. A successful run that reports
  `final_output is None` raises `FlowExecutionError` with
  `step_index=len(flow.steps)` using the canonical flow-output validation
  sentinel per `AGENTS.md §5 (StepRecord)`. Schema-ref resolution wraps
  `FlowSerializationError` in `ToolDefinitionError` so the documented
  exception contract holds. The wrapped flow **must** be registered on the
  executor's registry before invocation, because `fn` calls
  `executor.execute_flow(flow.name, …)` — `from_flow` itself never
  registers the flow.
- **`tests/test_tool_from_flow.py`** (new): 24 tests covering schema
  derivation from step tools, schema derivation from flow-level refs,
  explicit kwarg overrides, end-to-end execution, composition (wrapped
  flow as a step in another flow), error propagation (failing step, no
  steps, unregistered tools, overridden `tool_name` surfaces correctly in
  `FlowExecutionError`), DAG support (single sink / multiple sinks), and
  closure semantics (late tool registration is visible through the captured
  executor reference).
- **`examples/virtual_tool.py`** (new): standalone runnable example.
  Defines `double`, `add_ten`, `format_result` tools, registers an
  `inner_flow` that chains them, wraps it as a `Tool` via
  `Tool.from_flow`, demonstrates direct invocation, then composes the
  wrapper into a second `outer_flow` to show flow-of-flows composition.
- **`AGENTS.md`**: repo map entry for `tools.py` mentions `Tool.from_flow`.
- **`docs/agent-context/architecture.md`**: module table entry for
  `tools.py` mentions the adapter and notes that the closure dispatches
  `FlowExecutor.execute_flow` and surfaces inner failures as
  `FlowExecutionError`.
- **`CHANGELOG.md`**: new entry under `[Unreleased] → Added`.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`)
- [x] New tests added for new functionality

467 tests pass, 96.89% coverage. CI is green across all 12 jobs in the
OS × Python matrix.

## Related Issues

Closes #24

## Out of scope

- **Tool-level safety contracts**: issue #24 lists a `safety` contract
  derivation acceptance criterion. The current `Tool` class has no
  `safety` attribute, so derivation has no source to derive from. Tracked
  separately as #125 (priority:medium, complexity:average, milestone v0.6.0).
- **Strict-required `Flow.output_schema_ref`**: this PR enforces
  output-schema resolvability inside the factory rather than promoting
  `Flow.output_schema_ref` to a strictly required field. The strict-required
  migration would ripple to ~30 files of existing tests, examples, and
  benchmarks; deferring keeps this PR single-purpose.

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented
- [x] No secrets or credentials included

https://claude.ai/code/session_01G9gGx2Yr6sfJmCBkoAahrL
