### PR TITLE
feat: add `chainweaver profile <traces...>` CLI for bottleneck analysis (#147)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ chainweaver/
 ├── observation.py     TraceRecorder + ObservedTrace for ad-hoc capture
 ├── viz.py             ASCII + Mermaid renderers for Flow/ExecutionResult
 ├── serialization.py   YAML + JSON encode/decode for Flow and DAGFlow
-├── cli.py             typer-based CLI: 'chainweaver inspect' (flow visualization), 'chainweaver run' (execute from disk), 'chainweaver profile' (bottleneck analysis)
+├── cli.py             typer-based CLI: inspect, validate, check, viz, run, profile
 └── py.typed           PEP 561 marker
 tests/
 ├── conftest.py        Pytest fixtures (import schemas/functions from helpers.py)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ chainweaver/
 ├── observation.py     TraceRecorder + ObservedTrace for ad-hoc capture
 ├── viz.py             ASCII + Mermaid renderers for Flow/ExecutionResult
 ├── serialization.py   YAML + JSON encode/decode for Flow and DAGFlow
-├── cli.py             typer-based 'chainweaver inspect' entry point
+├── cli.py             typer-based CLI: 'chainweaver inspect' (flow visualization), 'chainweaver run' (execute from disk), 'chainweaver profile' (bottleneck analysis)
 └── py.typed           PEP 561 marker
 tests/
 ├── conftest.py        Pytest fixtures (import schemas/functions from helpers.py)

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -18,6 +18,9 @@ Available commands
   an image (issue #46).
 - ``chainweaver run <file>`` — load a flow file from disk, register tools
   from one or more Python modules, and execute the flow (issue #129).
+- ``chainweaver profile <traces...>`` — analyze one or more
+  ``ExecutionResult`` JSON files; surface bottlenecks and (multi-file)
+  per-step p50/p95/p99 (issue #147).
 
 Programmatic registration entry point
 -------------------------------------
@@ -67,12 +70,12 @@ from chainweaver.exceptions import (
     FlowNotFoundError,
     FlowSerializationError,
 )
-from chainweaver.executor import FlowExecutor
+from chainweaver.executor import ExecutionResult, FlowExecutor
 from chainweaver.flow import DAGFlow, Flow
 from chainweaver.registry import FlowRegistry
 from chainweaver.serialization import flow_from_json, flow_from_yaml
 from chainweaver.tools import Tool
-from chainweaver.viz import flow_to_ascii, flow_to_dot
+from chainweaver.viz import _render_step_bar_chart, flow_to_ascii, flow_to_dot
 
 app = typer.Typer(
     name="chainweaver",
@@ -588,6 +591,259 @@ def run_command(
 
     if not result.success:
         raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# profile command (issue #147)
+# ---------------------------------------------------------------------------
+
+
+def _load_execution_result(path: Path) -> ExecutionResult:
+    """Deserialize an ``ExecutionResult`` JSON file with helpful errors.
+
+    Raises a :class:`typer.Exit` with code 1 on malformed input and code 2
+    on missing files — matching the documented CLI exit-code contract.
+    """
+    _require_existing_file(path)
+    text = path.read_text(encoding="utf-8")
+    try:
+        return ExecutionResult.model_validate_json(text)
+    except ValueError as exc:
+        typer.echo(f"chainweaver: malformed trace file {path}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _percentiles(values: list[float]) -> dict[str, float]:
+    """Return ``{"p50", "p95", "p99", "mean", "stdev"}`` for *values*.
+
+    Computed via :mod:`statistics`.  For a single value all percentiles
+    collapse to that value and ``stdev`` is ``0.0``.  Returns zeros for
+    an empty input — caller decides whether that is meaningful.
+    """
+    import statistics
+
+    if not values:
+        return {"p50": 0.0, "p95": 0.0, "p99": 0.0, "mean": 0.0, "stdev": 0.0}
+    if len(values) == 1:
+        only = values[0]
+        return {"p50": only, "p95": only, "p99": only, "mean": only, "stdev": 0.0}
+    sorted_vals = sorted(values)
+    return {
+        "p50": float(statistics.median(sorted_vals)),
+        "p95": _quantile(sorted_vals, 0.95),
+        "p99": _quantile(sorted_vals, 0.99),
+        "mean": float(statistics.fmean(sorted_vals)),
+        "stdev": float(statistics.pstdev(sorted_vals)),
+    }
+
+
+def _quantile(sorted_vals: list[float], q: float) -> float:
+    """Linear-interpolation quantile for a pre-sorted list (no numpy).
+
+    Matches :func:`statistics.quantiles(method='inclusive')` semantics for
+    arbitrary q so single-call p95/p99 don't require allocating the
+    decile list.
+    """
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    pos = q * (len(sorted_vals) - 1)
+    lower = int(pos)
+    upper = min(lower + 1, len(sorted_vals) - 1)
+    fraction = pos - lower
+    return sorted_vals[lower] + (sorted_vals[upper] - sorted_vals[lower]) * fraction
+
+
+def _profile_single(result: ExecutionResult, *, top: int) -> tuple[dict[str, Any], str]:
+    """Build the JSON + table view for a single ``ExecutionResult``."""
+    rows = [(r.step_index, r.tool_name, r.duration_ms, r.success) for r in result.execution_log]
+    sum_step_ms = sum(r.duration_ms for r in result.execution_log)
+    overhead_ms = result.total_duration_ms - sum_step_ms
+
+    payload = {
+        "trace_count": 1,
+        "flow_name": result.flow_name,
+        "trace_id": result.trace_id,
+        "success": result.success,
+        "total_duration_ms": result.total_duration_ms,
+        "sum_step_ms": sum_step_ms,
+        "overhead_ms": overhead_ms,
+        "step_count": len(result.execution_log),
+        "steps": [
+            {
+                "step_index": r.step_index,
+                "tool_name": r.tool_name,
+                "duration_ms": r.duration_ms,
+                "success": r.success,
+            }
+            for r in result.execution_log
+        ],
+    }
+
+    # Table view: sort steps by duration desc, take top-N, render bar chart.
+    sorted_rows = sorted(rows, key=lambda r: r[2], reverse=True)
+    shown = sorted_rows[:top]
+    hidden = max(0, len(sorted_rows) - top)
+    header = [
+        f"flow: {result.flow_name}  (trace_id={result.trace_id})",
+        "─" * 70,
+        f"Total: {result.total_duration_ms:.1f} ms  ·  "
+        f"sum of steps: {sum_step_ms:.1f} ms  ·  "
+        f"overhead: {overhead_ms:.1f} ms",
+        "─" * 70,
+        " idx  tool                       duration_ms",
+    ]
+    body = _render_step_bar_chart(shown)
+    footer = []
+    if hidden:
+        footer.append(f"... {hidden} more step(s) not shown (use --top to see more)")
+    table = "\n".join([*header, body, *footer])
+    return payload, table
+
+
+def _profile_multi(results: list[ExecutionResult], *, top: int) -> tuple[dict[str, Any], str]:
+    """Aggregate p50/p95/p99 over N traces of the same flow."""
+    flow_names = {r.flow_name for r in results}
+    if len(flow_names) > 1:
+        typer.echo(
+            f"chainweaver: mixed flow names across traces: {sorted(flow_names)}. "
+            "Aggregation requires all traces share the same flow_name.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    flow_name = next(iter(flow_names))
+
+    step_counts = {len(r.execution_log) for r in results}
+    if len(step_counts) > 1:
+        typer.echo(
+            "chainweaver: traces have different step counts; "
+            "aggregation requires identical step structure.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    step_count = next(iter(step_counts))
+
+    # Per-step percentiles across the N traces.
+    per_step: list[dict[str, Any]] = []
+    chart_rows: list[tuple[int, str, float, bool]] = []
+    for step_index in range(step_count):
+        durations = [r.execution_log[step_index].duration_ms for r in results]
+        tool_name = results[0].execution_log[step_index].tool_name
+        all_success = all(r.execution_log[step_index].success for r in results)
+        stats = _percentiles(durations)
+        consistency_warning = stats["mean"] > 0 and stats["stdev"] > 0.5 * stats["mean"]
+        per_step.append(
+            {
+                "step_index": step_index,
+                "tool_name": tool_name,
+                "duration_ms": stats,
+                "consistency_warning": consistency_warning,
+                "success": all_success,
+            }
+        )
+        # Bar chart uses p50 as the representative duration.
+        chart_rows.append((step_index, tool_name, stats["p50"], all_success))
+
+    totals = [r.total_duration_ms for r in results]
+    total_stats = _percentiles(totals)
+
+    payload = {
+        "trace_count": len(results),
+        "flow_name": flow_name,
+        "step_count": step_count,
+        "total_duration_ms": total_stats,
+        "steps": per_step,
+    }
+
+    # Table view: sort by p50 desc, top-N bar chart.
+    sorted_rows = sorted(chart_rows, key=lambda r: r[2], reverse=True)
+    shown = sorted_rows[:top]
+    hidden = max(0, len(sorted_rows) - top)
+    header = [
+        f"flow: {flow_name}  (aggregated over {len(results)} traces)",
+        "─" * 70,
+        f"Total p50: {total_stats['p50']:.1f} ms  ·  "
+        f"p95: {total_stats['p95']:.1f} ms  ·  "
+        f"p99: {total_stats['p99']:.1f} ms",
+        "─" * 70,
+        " idx  tool                       p50 duration_ms",
+    ]
+    body = _render_step_bar_chart(shown)
+    warnings = [
+        f"⚠ step {s['step_index']} ({s['tool_name']}) is inconsistent "
+        f"(stdev {s['duration_ms']['stdev']:.1f} ms > 50% of mean "
+        f"{s['duration_ms']['mean']:.1f} ms)"
+        for s in per_step
+        if s["consistency_warning"]
+    ]
+    footer = []
+    if hidden:
+        footer.append(f"... {hidden} more step(s) not shown (use --top to see more)")
+    if warnings:
+        footer.append("")
+        footer.extend(warnings)
+    table = "\n".join([*header, body, *footer])
+    return payload, table
+
+
+_PROFILE_PATHS_ARG = typer.Argument(
+    ...,
+    help="One or more ExecutionResult JSON files to analyze.",
+)
+_PROFILE_TOP_OPTION = typer.Option(
+    10,
+    "--top",
+    "-n",
+    help="Show only the top-N slowest steps in the bar chart (default 10).",
+)
+_PROFILE_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("profile")
+def profile_command(
+    trace_paths: list[Path] = _PROFILE_PATHS_ARG,
+    top: int = _PROFILE_TOP_OPTION,
+    output_format: OutputFormat = _PROFILE_FORMAT_OPTION,
+) -> None:
+    """Analyze ``ExecutionResult`` JSON files and surface bottlenecks.
+
+    Single file:
+        Renders a per-step bar chart sorted by ``duration_ms`` (descending),
+        plus total / sum-of-steps / orchestration-overhead metrics.
+
+    Multiple files (must share ``flow_name`` and step count):
+        Computes per-step p50 / p95 / p99 / mean / stdev across the N
+        traces.  Surfaces a "consistency" warning when a step's stdev
+        exceeds 50% of its mean.
+
+    Exit codes: 0 = ok, 1 = malformed trace or incompatible aggregation,
+    2 = file not found.
+    """
+    if top < 1:
+        typer.echo("chainweaver: --top must be >= 1.", err=True)
+        raise typer.Exit(code=1)
+
+    results = [_load_execution_result(path) for path in trace_paths]
+    if not results:
+        typer.echo("chainweaver: no trace files supplied.", err=True)
+        raise typer.Exit(code=1)
+
+    if len(results) == 1:
+        payload, table = _profile_single(results[0], top=top)
+    else:
+        payload, table = _profile_multi(results, top=top)
+
+    if output_format is OutputFormat.JSON:
+        _emit_json(payload)
+    else:
+        typer.echo(table)
 
 
 # ---------------------------------------------------------------------------

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import statistics
 import sys
 from enum import Enum
 from pathlib import Path
@@ -620,8 +621,6 @@ def _percentiles(values: list[float]) -> dict[str, float]:
     collapse to that value and ``stdev`` is ``0.0``.  Returns zeros for
     an empty input — caller decides whether that is meaningful.
     """
-    import statistics
-
     if not values:
         return {"p50": 0.0, "p95": 0.0, "p99": 0.0, "mean": 0.0, "stdev": 0.0}
     if len(values) == 1:
@@ -633,7 +632,7 @@ def _percentiles(values: list[float]) -> dict[str, float]:
         "p95": _quantile(sorted_vals, 0.95),
         "p99": _quantile(sorted_vals, 0.99),
         "mean": float(statistics.fmean(sorted_vals)),
-        "stdev": float(statistics.pstdev(sorted_vals)),
+        "stdev": float(statistics.stdev(sorted_vals)),
     }
 
 

--- a/chainweaver/viz.py
+++ b/chainweaver/viz.py
@@ -221,6 +221,45 @@ def flow_to_dot(flow: Flow | DAGFlow) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Step bar chart (issue #147)
+# ---------------------------------------------------------------------------
+
+
+def _render_step_bar_chart(
+    rows: list[tuple[int, str, float, bool]],
+    *,
+    bar_width: int = 30,
+    name_width: int = 22,
+) -> str:
+    """Render a list of (step_index, tool_name, duration_ms, success) rows
+    as an ASCII bar chart.
+
+    Bars are scaled to ``bar_width`` characters relative to the longest
+    ``duration_ms`` in *rows*.  Tool names are right-truncated to
+    ``name_width`` characters.  A trailing ``ERR`` marker follows the bar
+    when ``success`` is ``False``.  Returns ``"(no steps)"`` when *rows*
+    is empty.
+
+    Used by :class:`~chainweaver.cli.profile_command` and is intentionally
+    side-effect free (pure string output).
+    """
+    if not rows:
+        return "(no steps)"
+    longest = max((r[2] for r in rows), default=0.0) or 1.0
+    lines: list[str] = []
+    for step_index, tool_name, duration_ms, success in rows:
+        bar_len = round((duration_ms / longest) * bar_width)
+        bar = "█" * bar_len + " " * (bar_width - bar_len)
+        short = tool_name[: name_width - 1] + "…"
+        truncated = tool_name if len(tool_name) <= name_width else short
+        status = "" if success else "  ERR"
+        lines.append(
+            f"{step_index:>4}  {truncated:<{name_width}}  {duration_ms:>9.1f} ms  |{bar}|{status}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # ExecutionResult → Mermaid (status overlay)
 # ---------------------------------------------------------------------------
 

--- a/examples/example_trace.json
+++ b/examples/example_trace.json
@@ -1,0 +1,145 @@
+{
+  "flow_name": "etl-pipeline",
+  "success": true,
+  "final_output": {
+    "records": [
+      {
+        "id": 1
+      },
+      {
+        "id": 2
+      },
+      {
+        "id": 3
+      }
+    ],
+    "transformed": [
+      {
+        "id": 1,
+        "processed": true
+      },
+      {
+        "id": 2,
+        "processed": true
+      },
+      {
+        "id": 3,
+        "processed": true
+      }
+    ],
+    "stored_count": 3
+  },
+  "execution_log": [
+    {
+      "step_index": 0,
+      "tool_name": "fetch_data",
+      "inputs": {
+        "source": "api"
+      },
+      "outputs": {
+        "records": [
+          {
+            "id": 1
+          },
+          {
+            "id": 2
+          },
+          {
+            "id": 3
+          }
+        ]
+      },
+      "error_type": null,
+      "error_message": null,
+      "success": true,
+      "started_at": "2026-05-18T10:00:00Z",
+      "ended_at": "2026-05-18T10:00:00Z",
+      "duration_ms": 45.2,
+      "retry_count": 0,
+      "retry_errors": [],
+      "skipped": false
+    },
+    {
+      "step_index": 1,
+      "tool_name": "transform_records",
+      "inputs": {
+        "records": [
+          {
+            "id": 1
+          },
+          {
+            "id": 2
+          },
+          {
+            "id": 3
+          }
+        ]
+      },
+      "outputs": {
+        "transformed": [
+          {
+            "id": 1,
+            "processed": true
+          },
+          {
+            "id": 2,
+            "processed": true
+          },
+          {
+            "id": 3,
+            "processed": true
+          }
+        ]
+      },
+      "error_type": null,
+      "error_message": null,
+      "success": true,
+      "started_at": "2026-05-18T10:00:00Z",
+      "ended_at": "2026-05-18T10:00:00Z",
+      "duration_ms": 12.8,
+      "retry_count": 0,
+      "retry_errors": [],
+      "skipped": false
+    },
+    {
+      "step_index": 2,
+      "tool_name": "store_results",
+      "inputs": {
+        "transformed": [
+          {
+            "id": 1,
+            "processed": true
+          },
+          {
+            "id": 2,
+            "processed": true
+          },
+          {
+            "id": 3,
+            "processed": true
+          }
+        ]
+      },
+      "outputs": {
+        "stored_count": 3
+      },
+      "error_type": null,
+      "error_message": null,
+      "success": true,
+      "started_at": "2026-05-18T10:00:00Z",
+      "ended_at": "2026-05-18T10:00:00Z",
+      "duration_ms": 31.5,
+      "retry_count": 0,
+      "retry_errors": [],
+      "skipped": false
+    }
+  ],
+  "trace_id": "a1b2c3d4e5f60718192021222324252",
+  "started_at": "2026-05-18T10:00:00Z",
+  "ended_at": "2026-05-18T10:00:00Z",
+  "total_duration_ms": 91.0,
+  "cost_report": null,
+  "initial_input": {
+    "source": "api"
+  }
+}

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -1,0 +1,302 @@
+"""Tests for the ``chainweaver profile`` CLI subcommand (issue #147)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from chainweaver import cli
+from chainweaver.executor import ExecutionResult, StepRecord
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    cli.set_default_registry(None)
+
+
+def _make_step_record(
+    *,
+    step_index: int,
+    tool_name: str,
+    duration_ms: float,
+    success: bool = True,
+) -> StepRecord:
+    """Minimal :class:`StepRecord` with the fields ``profile`` cares about."""
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    return StepRecord(
+        step_index=step_index,
+        tool_name=tool_name,
+        inputs={},
+        outputs={} if success else None,
+        success=success,
+        error_type=None if success else "FlowExecutionError",
+        error_message=None if success else "boom",
+        started_at=now,
+        ended_at=now,
+        duration_ms=duration_ms,
+    )
+
+
+def _make_result(
+    *,
+    flow_name: str = "etl",
+    trace_id: str = "abc123",
+    success: bool = True,
+    durations: list[tuple[str, float]] | None = None,
+    total_duration_ms: float | None = None,
+) -> ExecutionResult:
+    """Build an :class:`ExecutionResult` with deterministic timestamps."""
+    if durations is None:
+        durations = [("fetch", 40.0), ("transform", 10.0), ("store", 20.0)]
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    log = [
+        _make_step_record(step_index=i, tool_name=name, duration_ms=ms, success=success)
+        for i, (name, ms) in enumerate(durations)
+    ]
+    if total_duration_ms is not None:
+        total = total_duration_ms
+    else:
+        total = sum(d for _, d in durations) + 1.0
+    return ExecutionResult(
+        flow_name=flow_name,
+        success=success,
+        final_output={"ok": True} if success else None,
+        execution_log=log,
+        trace_id=trace_id,
+        started_at=now,
+        ended_at=now,
+        total_duration_ms=total,
+        initial_input={},
+    )
+
+
+def _write_trace(path: Path, result: ExecutionResult) -> None:
+    path.write_text(result.model_dump_json(), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Single-trace mode
+# ---------------------------------------------------------------------------
+
+
+class TestProfileSingle:
+    def test_table_output_shows_flow_and_durations(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        trace = tmp_path / "t.trace.json"
+        _write_trace(trace, _make_result())
+        exit_code = cli.main(["profile", str(trace)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "etl" in captured.out
+        assert "abc123" in captured.out
+        # Per-step rows present:
+        assert "fetch" in captured.out
+        assert "transform" in captured.out
+        assert "store" in captured.out
+        # Total / overhead summary line:
+        assert "Total:" in captured.out
+        assert "overhead:" in captured.out
+
+    def test_json_output_shape(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        trace = tmp_path / "t.trace.json"
+        _write_trace(trace, _make_result(total_duration_ms=71.5))
+        exit_code = cli.main(["profile", str(trace), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["trace_count"] == 1
+        assert payload["flow_name"] == "etl"
+        assert payload["trace_id"] == "abc123"
+        assert payload["step_count"] == 3
+        assert payload["total_duration_ms"] == 71.5
+        assert payload["sum_step_ms"] == 70.0
+        assert payload["overhead_ms"] == pytest.approx(1.5, abs=1e-9)
+        assert [s["tool_name"] for s in payload["steps"]] == ["fetch", "transform", "store"]
+        assert payload["steps"][0]["duration_ms"] == 40.0
+
+    def test_top_truncation_surfaces_hidden_count(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        trace = tmp_path / "t.trace.json"
+        durations = [(f"step_{i}", float(i + 1)) for i in range(5)]
+        _write_trace(trace, _make_result(durations=durations, total_duration_ms=20.0))
+        exit_code = cli.main(["profile", str(trace), "--top", "2"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        # Slowest two are step_4 (5ms) and step_3 (4ms); rest hidden.
+        assert "step_4" in captured.out
+        assert "step_3" in captured.out
+        assert "3 more step" in captured.out
+
+    def test_top_must_be_positive(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        trace = tmp_path / "t.trace.json"
+        _write_trace(trace, _make_result())
+        exit_code = cli.main(["profile", str(trace), "--top", "0"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "--top must be >= 1" in captured.err
+
+    def test_failed_step_marked_in_table(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        trace = tmp_path / "t.trace.json"
+        _write_trace(trace, _make_result(success=False))
+        exit_code = cli.main(["profile", str(trace)])
+        captured = capsys.readouterr()
+        # Profile is read-only; even for failed flows it exits 0 because the
+        # analysis itself succeeded. Failure is signalled in the rows.
+        assert exit_code == 0
+        assert "ERR" in captured.out
+
+    def test_missing_file_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["profile", str(tmp_path / "nope.json")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_malformed_trace_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bad = tmp_path / "bad.trace.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        exit_code = cli.main(["profile", str(bad)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "malformed trace file" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Multi-trace aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestProfileMulti:
+    def _write_three_traces(self, tmp_path: Path) -> list[Path]:
+        paths: list[Path] = []
+        for i, factor in enumerate([1.0, 1.1, 0.9]):
+            path = tmp_path / f"trace_{i}.json"
+            _write_trace(
+                path,
+                _make_result(
+                    trace_id=f"trace{i}",
+                    durations=[("fetch", 40.0 * factor), ("store", 20.0 * factor)],
+                    total_duration_ms=60.0 * factor + 1.0,
+                ),
+            )
+            paths.append(path)
+        return paths
+
+    def test_json_output_includes_percentiles(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        paths = self._write_three_traces(tmp_path)
+        exit_code = cli.main(["profile", *[str(p) for p in paths], "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["trace_count"] == 3
+        assert payload["flow_name"] == "etl"
+        assert payload["step_count"] == 2
+        # Percentiles must be present and ordered consistently.
+        total_stats = payload["total_duration_ms"]
+        assert {"p50", "p95", "p99", "mean", "stdev"} == set(total_stats.keys())
+        assert total_stats["p50"] <= total_stats["p95"] <= total_stats["p99"]
+        # Per-step percentiles.
+        first_step = payload["steps"][0]
+        assert first_step["tool_name"] == "fetch"
+        fetch_p50 = first_step["duration_ms"]["p50"]
+        assert fetch_p50 == pytest.approx(40.0, abs=0.5)
+
+    def test_table_output_aggregated(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        paths = self._write_three_traces(tmp_path)
+        exit_code = cli.main(["profile", *[str(p) for p in paths]])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "aggregated over 3 traces" in captured.out
+        assert "p95" in captured.out
+        assert "fetch" in captured.out
+
+    def test_mixed_flow_names_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path_a = tmp_path / "a.json"
+        path_b = tmp_path / "b.json"
+        _write_trace(path_a, _make_result(flow_name="etl"))
+        _write_trace(path_b, _make_result(flow_name="other"))
+        exit_code = cli.main(["profile", str(path_a), str(path_b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "mixed flow names" in captured.err
+
+    def test_mismatched_step_counts_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path_a = tmp_path / "a.json"
+        path_b = tmp_path / "b.json"
+        _write_trace(path_a, _make_result(durations=[("fetch", 40.0)]))
+        _write_trace(
+            path_b,
+            _make_result(durations=[("fetch", 40.0), ("store", 20.0)]),
+        )
+        exit_code = cli.main(["profile", str(path_a), str(path_b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "different step counts" in captured.err
+
+    def test_consistency_warning_surfaces(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Step "wobble" has very high stdev: 1ms, 100ms, 200ms → stdev >> 50% of mean.
+        paths: list[Path] = []
+        for i, ms in enumerate([1.0, 100.0, 200.0]):
+            path = tmp_path / f"trace_{i}.json"
+            _write_trace(
+                path,
+                _make_result(
+                    trace_id=f"trace{i}",
+                    durations=[("wobble", ms)],
+                    total_duration_ms=ms + 1.0,
+                ),
+            )
+            paths.append(path)
+        exit_code = cli.main(["profile", *[str(p) for p in paths]])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "inconsistent" in captured.out
+        assert "wobble" in captured.out


### PR DESCRIPTION
## Summary

Adds `chainweaver profile <traces...>` so operators can answer "which step is slow? is it always slow?" from `ExecutionResult` JSON files — without writing custom Python. Self-hosted, dep-free.

Stacked on top of #158 (run CLI); base auto-retargets through `#158 → #157 → main` as those merge.

Closes #147.

## Changes

- `chainweaver/viz.py` — private `_render_step_bar_chart(rows, ...)` helper using unicode block characters; scales bars to the longest row and right-truncates tool names that exceed `name_width`.
- `chainweaver/cli.py` — new `profile_command`, three private helpers (`_load_execution_result`, `_percentiles`, `_quantile`), single-trace and multi-trace renderers, module-docstring update. Uses `statistics.stdev` (sample standard deviation).
- `tests/test_cli_profile.py` — new test file (12 cases).
- `examples/example_trace.json` — 3-step ETL fixture (`etl-pipeline`: `fetch_data`, `transform_records`, `store_results`) for smoke-testing the command locally.
- `AGENTS.md` — repo map entry for `cli.py` updated to include `profile` in the verb list.

### Behavior

**Single trace:**
- Total wall-clock + sum-of-step ms + orchestration overhead.
- Per-step ASCII bar chart sorted by `duration_ms` descending.
- `--top N` (default 10) truncates and surfaces `"M more step(s) not shown"`.

**Multi trace:**
- Verifies all traces share `flow_name` and step count (exits 1 with a clear message otherwise).
- Per-step p50 / p95 / p99 / mean / stdev via stdlib `statistics`.
- "Consistency" warning when a step's stdev > 50 % of its mean.

`--format json` emits a stable, machine-readable shape (single-trace + multi-trace branches differ by `trace_count`).

### Exit codes

- `0` — analysis ran. Note: a failed flow still exits `0` because `profile` is read-only; the failure is signalled in the per-step rows (`ERR`).
- `1` — malformed trace, mixed flow names, mismatched step counts across traces, or invalid `--top`.
- `2` — file not found.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
- [x] All existing tests pass — **493/493 passed**
- [x] New tests added for new functionality

```text
$ ruff check chainweaver/ tests/ examples/
All checks passed!
$ ruff format --check chainweaver/ tests/ examples/
50 files already formatted
$ python -m mypy chainweaver/ tests/
Success: no issues found in 43 source files
$ python -m pytest tests/ -q --no-cov
493 passed in 6.28s
```

Diff stat: `5 files changed, 744 insertions(+), 3 deletions(-)`.

## Related Issues

Closes #147. Sister tool to the upcoming `chainweaver diff` (#148).

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented — CLI docstring updated; `_render_step_bar_chart` is intentionally private (single in-package consumer)
- [x] No secrets or credentials included

## Tradeoffs / risks

- **Single test file per verb** (`tests/test_cli_profile.py`) rather than appending to `tests/test_cli.py`. Justification: the existing `test_cli.py` is now 778 lines after `run`; splitting per verb keeps each file tractable. Owner-mode scope-delta call.
- **Inline `_quantile` instead of `statistics.quantiles(..., n=100)`**: cheaper for single p95/p99 reads (avoids allocating the 99-element decile list). Linear interpolation matches the `inclusive` method semantics.
- **`profile` on a failed flow exits 0**: the analysis itself succeeded; the failure shows up as `ERR` in the rows. This matches the read-only contract of `inspect` / `viz` and avoids conflating "couldn't analyze" with "the analyzed flow failed."

## Scope notes

Closes #147 only. Adjacent items deferred: `chainweaver diff` (#148, next PR in this stack) and the planned MkDocs site (`docs/cli.md` — depends on #133).