### PR TITLE
feat: add `chainweaver diff <a> <b>` CLI for step-by-step trace comparison (#148)

### DIFF
--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -66,6 +66,7 @@ from types import ModuleType
 from typing import Any
 
 import typer
+from deepdiff import DeepDiff
 
 from chainweaver.exceptions import (
     ChainWeaverError,
@@ -864,8 +865,6 @@ def _step_outputs_diff(
     "identical".  ``None`` operands are passed through as-is — DeepDiff
     handles the ``None vs dict`` case correctly.
     """
-    from deepdiff import DeepDiff
-
     diff = DeepDiff(expected, actual, ignore_order=True, view="tree")
     # to_dict() emits a plain, JSON-friendly representation.
     return diff.to_dict() if diff else {}

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -21,6 +21,8 @@ Available commands
 - ``chainweaver profile <traces...>`` — analyze one or more
   ``ExecutionResult`` JSON files; surface bottlenecks and (multi-file)
   per-step p50/p95/p99 (issue #147).
+- ``chainweaver diff <a.json> <b.json>`` — compare two
+  ``ExecutionResult`` JSON files step-by-step (issue #148).
 
 Programmatic registration entry point
 -------------------------------------
@@ -844,6 +846,221 @@ def profile_command(
         _emit_json(payload)
     else:
         typer.echo(table)
+
+
+# ---------------------------------------------------------------------------
+# diff command (issue #148)
+# ---------------------------------------------------------------------------
+
+
+def _step_outputs_diff(
+    expected: dict[str, Any] | None,
+    actual: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return a serializable structural diff of two step ``outputs`` dicts.
+
+    Uses :class:`deepdiff.DeepDiff` for nested-dict semantics so callers
+    don't have to hand-roll recursive comparison.  An empty dict means
+    "identical".  ``None`` operands are passed through as-is — DeepDiff
+    handles the ``None vs dict`` case correctly.
+    """
+    from deepdiff import DeepDiff
+
+    diff = DeepDiff(expected, actual, ignore_order=True, view="tree")
+    # to_dict() emits a plain, JSON-friendly representation.
+    return diff.to_dict() if diff else {}
+
+
+def _compare_traces(
+    a: ExecutionResult,
+    b: ExecutionResult,
+    *,
+    perf_tolerance: float | None,
+) -> dict[str, Any]:
+    """Compare two ``ExecutionResult`` objects step-by-step.
+
+    Ignores fields that are non-deterministic by design (``trace_id``,
+    ``started_at``, ``ended_at``, ``total_duration_ms``, per-step
+    ``duration_ms``).  Returns a structured diff dict with these keys:
+
+    - ``identical`` (bool): true iff every comparable field matched.
+    - ``flow_name`` (dict | None): old/new pair when the flow name differs.
+    - ``step_count`` (dict | None): old/new pair when step counts differ.
+    - ``success`` (dict | None): old/new pair when ``result.success`` differs.
+    - ``final_output`` (dict): DeepDiff payload (empty when identical).
+    - ``steps`` (list[dict]): per-step diff entries.  Each entry has
+      ``step_index``, ``tool_name``, and one or more of ``outputs``,
+      ``error_type``, ``error_message``, ``success``, ``perf_delta_ms``,
+      ``perf_delta_pct`` describing what differs at that step.
+    """
+    diff: dict[str, Any] = {
+        "identical": True,
+        "flow_name": None,
+        "step_count": None,
+        "success": None,
+        "final_output": {},
+        "steps": [],
+    }
+
+    if a.flow_name != b.flow_name:
+        diff["identical"] = False
+        diff["flow_name"] = {"a": a.flow_name, "b": b.flow_name}
+
+    if len(a.execution_log) != len(b.execution_log):
+        diff["identical"] = False
+        diff["step_count"] = {"a": len(a.execution_log), "b": len(b.execution_log)}
+
+    if a.success != b.success:
+        diff["identical"] = False
+        diff["success"] = {"a": a.success, "b": b.success}
+
+    final_diff = _step_outputs_diff(a.final_output, b.final_output)
+    if final_diff:
+        diff["identical"] = False
+        diff["final_output"] = final_diff
+
+    # Walk the shorter log so we always have a paired comparison; mismatched
+    # tail (when step_count differs) is already flagged via step_count above.
+    paired_count = min(len(a.execution_log), len(b.execution_log))
+    for i in range(paired_count):
+        rec_a = a.execution_log[i]
+        rec_b = b.execution_log[i]
+        step_diff: dict[str, Any] = {
+            "step_index": rec_a.step_index,
+            "tool_name": rec_a.tool_name,
+        }
+        any_change = False
+
+        if rec_a.tool_name != rec_b.tool_name:
+            any_change = True
+            step_diff["tool_name_change"] = {"a": rec_a.tool_name, "b": rec_b.tool_name}
+
+        outputs_diff = _step_outputs_diff(rec_a.outputs, rec_b.outputs)
+        if outputs_diff:
+            any_change = True
+            step_diff["outputs"] = outputs_diff
+
+        if rec_a.error_type != rec_b.error_type:
+            any_change = True
+            step_diff["error_type"] = {"a": rec_a.error_type, "b": rec_b.error_type}
+        if rec_a.error_message != rec_b.error_message:
+            any_change = True
+            step_diff["error_message"] = {"a": rec_a.error_message, "b": rec_b.error_message}
+        if rec_a.success != rec_b.success:
+            any_change = True
+            step_diff["success"] = {"a": rec_a.success, "b": rec_b.success}
+
+        if perf_tolerance is not None:
+            delta = rec_b.duration_ms - rec_a.duration_ms
+            denom = rec_a.duration_ms if rec_a.duration_ms > 0 else 1.0
+            pct = abs(delta) / denom * 100.0
+            if pct > perf_tolerance:
+                any_change = True
+                step_diff["perf_delta_ms"] = delta
+                step_diff["perf_delta_pct"] = pct
+
+        if any_change:
+            diff["identical"] = False
+            diff["steps"].append(step_diff)
+
+    return diff
+
+
+def _format_diff_table(diff: dict[str, Any]) -> str:
+    """Render the diff dict as a human-readable summary."""
+    if diff["identical"]:
+        return "Traces are identical (modulo trace_id, timestamps, durations)."
+
+    lines = ["Traces differ:", "─" * 60]
+    if diff["flow_name"] is not None:
+        lines.append(f"  flow_name: {diff['flow_name']['a']} → {diff['flow_name']['b']}")
+    if diff["step_count"] is not None:
+        lines.append(f"  step_count: {diff['step_count']['a']} → {diff['step_count']['b']}")
+    if diff["success"] is not None:
+        lines.append(f"  success: {diff['success']['a']} → {diff['success']['b']}")
+    if diff["final_output"]:
+        lines.append("  final_output: differs (see --format json for details)")
+    if diff["steps"]:
+        lines.append("")
+        lines.append("Per-step changes:")
+        for step in diff["steps"]:
+            head = f"  step {step['step_index']} ({step['tool_name']}):"
+            lines.append(head)
+            if "tool_name_change" in step:
+                lines.append(
+                    f"    tool_name: {step['tool_name_change']['a']} "
+                    f"→ {step['tool_name_change']['b']}"
+                )
+            if "outputs" in step:
+                lines.append("    outputs differ (see --format json for details)")
+            if "error_type" in step:
+                lines.append(
+                    f"    error_type: {step['error_type']['a']} → {step['error_type']['b']}"
+                )
+            if "error_message" in step:
+                lines.append(
+                    f"    error_message: {step['error_message']['a']} "
+                    f"→ {step['error_message']['b']}"
+                )
+            if "success" in step:
+                lines.append(f"    success: {step['success']['a']} → {step['success']['b']}")
+            if "perf_delta_ms" in step:
+                sign = "+" if step["perf_delta_ms"] >= 0 else ""
+                lines.append(
+                    f"    duration: {sign}{step['perf_delta_ms']:.1f} ms "
+                    f"({step['perf_delta_pct']:.1f}% change)"
+                )
+    return "\n".join(lines)
+
+
+_DIFF_A_ARG = typer.Argument(..., help="First ExecutionResult JSON file (baseline).")
+_DIFF_B_ARG = typer.Argument(..., help="Second ExecutionResult JSON file (comparison).")
+_DIFF_PERF_OPTION = typer.Option(
+    None,
+    "--perf-tolerance",
+    help=(
+        "Per-step duration tolerance as a percent (e.g. 25 means 'flag steps "
+        "whose duration changed by more than 25%'). Off by default."
+    ),
+)
+_DIFF_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("diff")
+def diff_command(
+    trace_a: Path = _DIFF_A_ARG,
+    trace_b: Path = _DIFF_B_ARG,
+    perf_tolerance: float | None = _DIFF_PERF_OPTION,
+    output_format: OutputFormat = _DIFF_FORMAT_OPTION,
+) -> None:
+    """Compare two ``ExecutionResult`` JSON files step-by-step.
+
+    Aligns step records by position, walks ``outputs`` /
+    ``error_type`` / ``error_message`` / ``success``, and (optionally)
+    flags per-step duration regressions beyond ``--perf-tolerance N%``.
+    Non-deterministic fields (``trace_id``, timestamps, total/per-step
+    durations) are ignored by default.
+
+    Exit codes: 0 = identical, 1 = differs, 2 = file not found or
+    malformed input.
+    """
+    result_a = _load_execution_result(trace_a)
+    result_b = _load_execution_result(trace_b)
+    diff = _compare_traces(result_a, result_b, perf_tolerance=perf_tolerance)
+
+    if output_format is OutputFormat.JSON:
+        _emit_json(diff)
+    else:
+        typer.echo(_format_diff_table(diff))
+
+    if not diff["identical"]:
+        raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,249 @@
+# ChainWeaver CLI Reference
+
+ChainWeaver ships a `chainweaver` console script built on [typer](https://typer.tiangolo.com/).
+
+```
+chainweaver <command> [options]
+```
+
+---
+
+## Exit codes
+
+All commands share the same top-level exit-code contract:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success / all flows valid |
+| `1` | Logic error: flow not found, validation failure, execution error, or malformed input |
+| `2` | Input file or directory not found |
+
+---
+
+## Commands
+
+### `inspect`
+
+Print the structure of a registered flow.
+
+```
+chainweaver inspect <flow_name> [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` / `-f` | `table` | Output format: human-readable table or machine-readable JSON |
+
+**Exit codes**: `0` = success, `1` = flow not registered or no registry configured.
+
+**Example**:
+
+```bash
+chainweaver inspect my_etl_flow
+chainweaver inspect my_etl_flow --format json
+```
+
+---
+
+### `viz`
+
+Render a registered flow as ASCII art or DOT (Graphviz) text.
+
+```
+chainweaver viz <flow_name> [--format ascii|dot]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` / `-f` | `ascii` | Visualization format: terminal-friendly ASCII or Graphviz DOT |
+
+**Exit codes**: `0` = success, `1` = flow not found or no registry configured.
+
+**Example**:
+
+```bash
+chainweaver viz my_etl_flow
+chainweaver viz my_etl_flow --format dot | dot -Tpng -o my_etl_flow.png
+```
+
+---
+
+### `validate`
+
+Validate a single flow definition file (`.flow.yaml`, `.flow.yml`, or `.flow.json`).
+
+```
+chainweaver validate <file> [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` / `-f` | `table` | Output format: human-readable line or machine-readable JSON |
+
+**Exit codes**: `0` = valid, `1` = validation error, `2` = file not found.
+
+**Example**:
+
+```bash
+chainweaver validate flows/etl.flow.yaml
+chainweaver validate flows/etl.flow.json --format json
+```
+
+---
+
+### `check`
+
+Validate every flow file in a directory (recursive).
+
+```
+chainweaver check <directory> [--format table|json] [--quiet]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` / `-f` | `table` | Output format |
+| `--quiet` / `-q` | `False` | Suppress per-file output; only exit code is meaningful |
+
+**Exit codes**: `0` = all valid, `1` = at least one invalid file, `2` = directory not found.
+
+**Example**:
+
+```bash
+chainweaver check flows/
+chainweaver check flows/ --quiet  # CI-friendly: exit code only
+```
+
+---
+
+### `run`
+
+Load a flow definition file from disk, register tools from one or more Python modules, and execute the flow with optional JSON input.
+
+```
+chainweaver run <flow_file> [--tools module] [--input file] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tools` / `-t` | (none) | Python module path to import tools from (repeatable) |
+| `--input` / `-i` | (none) | JSON file containing the initial input dict |
+| `--format` / `-f` | `table` | Output format |
+
+**Exit codes**: `0` = success, `1` = execution error or tool not found, `2` = file not found.
+
+**Example**:
+
+```bash
+chainweaver run flows/etl.flow.yaml --tools my_package.tools
+chainweaver run flows/etl.flow.yaml --tools my_package.tools --input input.json --format json
+```
+
+---
+
+### `profile`
+
+Analyze one or more `ExecutionResult` JSON files. For a single file, surfaces per-step duration and bottlenecks. For multiple files, adds p50/p95/p99 statistics across runs.
+
+```
+chainweaver profile <traces...> [--top N] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--top` / `-n` | `5` | Number of slowest steps to surface |
+| `--format` / `-f` | `table` | Output format |
+
+**Exit codes**: `0` = success, `1` = malformed trace input, `2` = file not found.
+
+**Example**:
+
+```bash
+chainweaver profile trace.json
+chainweaver profile trace_a.json trace_b.json trace_c.json --top 10
+chainweaver profile trace.json --format json
+```
+
+---
+
+### `diff`
+
+Compare two `ExecutionResult` JSON files step-by-step.
+
+Aligns step records by position and checks `outputs`, `error_type`, `error_message`, and `success` for each paired step. Non-deterministic fields (`trace_id`, `started_at`, `ended_at`, `total_duration_ms`, per-step `duration_ms`) are ignored unless `--perf-tolerance` is set.
+
+```
+chainweaver diff <a.json> <b.json> [--perf-tolerance N] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--perf-tolerance` | (off) | Flag steps whose `duration_ms` changed by more than N %. Integer, e.g. `25` = 25%. |
+| `--format` / `-f` | `table` | Output format: human-readable table or structured JSON diff |
+
+**Exit codes**:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Traces are identical (modulo ignored fields) |
+| `1` | Traces differ, or malformed trace input |
+| `2` | File not found |
+
+**JSON output shape** (when `--format json`):
+
+```json
+{
+  "identical": false,
+  "flow_name": null,
+  "step_count": null,
+  "success": null,
+  "final_output": {
+    "values_changed": {
+      "root['key']": { "old_value": 42, "new_value": 99 }
+    }
+  },
+  "steps": [
+    {
+      "step_index": 1,
+      "tool_name": "store",
+      "outputs": {
+        "values_changed": {
+          "root['key']": { "old_value": 42, "new_value": 99 }
+        }
+      }
+    }
+  ]
+}
+```
+
+Fields `flow_name`, `step_count`, `success`, and `final_output` are `null` / `{}` when that dimension is identical between the two traces. The `steps` list contains only steps where at least one field differed.
+
+**Example**:
+
+```bash
+chainweaver diff baseline.json current.json
+chainweaver diff baseline.json current.json --perf-tolerance 25
+chainweaver diff baseline.json current.json --format json
+```
+
+**Use cases**:
+
+- A flow misbehaves in production — compare a known-good trace with today's failing trace to isolate the diverging step.
+- A replay run (#21) finishes — was `final_output` byte-identical to the original?
+- A schema drift event (#50) occurred — what was the functional impact on recorded traces?
+
+---
+
+## Programmatic registration (`inspect`, `viz`)
+
+`inspect` and `viz` read from a process-scoped registry installed via `cli.set_default_registry`:
+
+```python
+from chainweaver import FlowRegistry, cli
+
+registry = FlowRegistry()
+registry.register_flow(my_flow)
+cli.set_default_registry(registry)
+cli.main(["inspect", "my_flow"])
+```
+
+`validate`, `check`, `run`, `profile`, and `diff` read directly from disk and do not consult the default registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "deepdiff>=8.0",
     "packaging>=21.0",
     "pydantic>=2.0",
     "tenacity>=8.0",

--- a/tests/test_cli_diff.py
+++ b/tests/test_cli_diff.py
@@ -1,0 +1,362 @@
+"""Tests for the ``chainweaver diff`` CLI subcommand (issue #148)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from chainweaver import cli
+from chainweaver.executor import ExecutionResult, StepRecord
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    cli.set_default_registry(None)
+
+
+def _record(
+    *,
+    step_index: int,
+    tool_name: str,
+    outputs: dict[str, object] | None,
+    duration_ms: float = 10.0,
+    success: bool = True,
+    error_type: str | None = None,
+    error_message: str | None = None,
+) -> StepRecord:
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    return StepRecord(
+        step_index=step_index,
+        tool_name=tool_name,
+        inputs={},
+        outputs=outputs,
+        success=success,
+        error_type=error_type,
+        error_message=error_message,
+        started_at=now,
+        ended_at=now,
+        duration_ms=duration_ms,
+    )
+
+
+def _result(
+    *,
+    flow_name: str = "etl",
+    success: bool = True,
+    log: list[StepRecord] | None = None,
+    final_output: dict[str, object] | None = None,
+    total_duration_ms: float = 30.0,
+    trace_id: str = "trace_a",
+) -> ExecutionResult:
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    if log is None:
+        log = [
+            _record(step_index=0, tool_name="fetch", outputs={"data": "ok"}),
+            _record(step_index=1, tool_name="store", outputs={"rows": 42}),
+        ]
+    return ExecutionResult(
+        flow_name=flow_name,
+        success=success,
+        final_output=final_output if final_output is not None else {"rows": 42},
+        execution_log=log,
+        trace_id=trace_id,
+        started_at=now,
+        ended_at=now,
+        total_duration_ms=total_duration_ms,
+        initial_input={},
+    )
+
+
+def _write(path: Path, result: ExecutionResult) -> None:
+    path.write_text(result.model_dump_json(), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Identity / structural diffs
+# ---------------------------------------------------------------------------
+
+
+class TestDiffIdentical:
+    def test_identical_traces_exit_zero(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Differ only in non-deterministic fields (trace_id, timestamps).
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result(trace_id="trace_a"))
+        _write(b, _result(trace_id="trace_b"))
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "identical" in captured.out.lower()
+
+    def test_identical_json_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result(trace_id="trace_a"))
+        _write(b, _result(trace_id="trace_b"))
+        exit_code = cli.main(["diff", str(a), str(b), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["identical"] is True
+        assert payload["flow_name"] is None
+        assert payload["step_count"] is None
+        assert payload["steps"] == []
+
+
+class TestDiffDivergent:
+    def test_different_flow_names(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result(flow_name="etl"))
+        _write(b, _result(flow_name="renamed"))
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "etl" in captured.out and "renamed" in captured.out
+
+    def test_diverging_step_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result())
+        _write(
+            b,
+            _result(
+                log=[
+                    _record(step_index=0, tool_name="fetch", outputs={"data": "ok"}),
+                    _record(step_index=1, tool_name="store", outputs={"rows": 99}),
+                ],
+                final_output={"rows": 99},
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "step 1" in captured.out
+        assert "store" in captured.out
+
+    def test_diverging_step_output_json_shape(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result())
+        _write(
+            b,
+            _result(
+                log=[
+                    _record(step_index=0, tool_name="fetch", outputs={"data": "ok"}),
+                    _record(step_index=1, tool_name="store", outputs={"rows": 99}),
+                ],
+                final_output={"rows": 99},
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        payload = json.loads(captured.out)
+        assert payload["identical"] is False
+        # final_output diff is populated.
+        assert payload["final_output"]
+        # The single step diff names the diverging step.
+        assert len(payload["steps"]) == 1
+        assert payload["steps"][0]["step_index"] == 1
+        assert payload["steps"][0]["tool_name"] == "store"
+        assert "outputs" in payload["steps"][0]
+
+    def test_error_vs_success_divergence(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result())
+        _write(
+            b,
+            _result(
+                success=False,
+                log=[
+                    _record(step_index=0, tool_name="fetch", outputs={"data": "ok"}),
+                    _record(
+                        step_index=1,
+                        tool_name="store",
+                        outputs=None,
+                        success=False,
+                        error_type="FlowExecutionError",
+                        error_message="boom",
+                    ),
+                ],
+                final_output=None,
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "success" in captured.out
+        assert "error_type" in captured.out
+        assert "FlowExecutionError" in captured.out
+
+    def test_mismatched_step_counts(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(a, _result())
+        _write(
+            b,
+            _result(log=[_record(step_index=0, tool_name="fetch", outputs={"data": "ok"})]),
+        )
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "step_count" in captured.out
+        assert "2" in captured.out and "1" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Performance tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestDiffPerfTolerance:
+    def test_within_tolerance_passes(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # 10ms vs 11ms = 10% delta. With --perf-tolerance 25 it should still
+        # be considered identical.
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(
+            a,
+            _result(log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=10.0)]),
+        )
+        _write(
+            b,
+            _result(
+                log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=11.0)],
+                trace_id="trace_b",
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b), "--perf-tolerance", "25"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "identical" in captured.out.lower()
+
+    def test_exceeds_tolerance_flags_regression(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # 10ms → 20ms = 100% delta. Tolerance 25 should flag it.
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(
+            a,
+            _result(log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=10.0)]),
+        )
+        _write(
+            b,
+            _result(
+                log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=20.0)],
+                trace_id="trace_b",
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b), "--perf-tolerance", "25"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "duration:" in captured.out
+        assert "+10.0" in captured.out
+        assert "100" in captured.out
+
+    def test_perf_tolerance_off_ignores_duration(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Wide duration delta with no --perf-tolerance should still be
+        # considered identical.
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write(
+            a,
+            _result(log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=10.0)]),
+        )
+        _write(
+            b,
+            _result(
+                log=[_record(step_index=0, tool_name="t", outputs={}, duration_ms=999.0)],
+                trace_id="trace_b",
+            ),
+        )
+        exit_code = cli.main(["diff", str(a), str(b)])
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# File errors
+# ---------------------------------------------------------------------------
+
+
+class TestDiffFileErrors:
+    def test_missing_first_file_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        b = tmp_path / "b.json"
+        _write(b, _result())
+        exit_code = cli.main(["diff", str(tmp_path / "nope.json"), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_missing_second_file_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        _write(a, _result())
+        exit_code = cli.main(["diff", str(a), str(tmp_path / "nope.json")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_malformed_trace_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.write_text("{not valid", encoding="utf-8")
+        _write(b, _result())
+        exit_code = cli.main(["diff", str(a), str(b)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "malformed trace file" in captured.err

--- a/tests/test_cli_diff.py
+++ b/tests/test_cli_diff.py
@@ -176,13 +176,20 @@ class TestDiffDivergent:
         assert exit_code == 1
         payload = json.loads(captured.out)
         assert payload["identical"] is False
-        # final_output diff is populated.
-        assert payload["final_output"]
-        # The single step diff names the diverging step.
+        # Snapshot: exact DeepDiff serialization contract for a scalar change.
+        # DeepDiff names paths as "root['key']" in tree-view mode.
+        assert "values_changed" in payload["final_output"]
+        row_diff = payload["final_output"]["values_changed"]["root['rows']"]
+        assert row_diff["new_value"] == 99
+        assert row_diff["old_value"] == 42
+        # The single step diff names the diverging step with the same shape.
         assert len(payload["steps"]) == 1
         assert payload["steps"][0]["step_index"] == 1
         assert payload["steps"][0]["tool_name"] == "store"
-        assert "outputs" in payload["steps"][0]
+        assert "values_changed" in payload["steps"][0]["outputs"]
+        step_row_diff = payload["steps"][0]["outputs"]["values_changed"]["root['rows']"]
+        assert step_row_diff["new_value"] == 99
+        assert step_row_diff["old_value"] == 42
 
     def test_error_vs_success_divergence(
         self,


### PR DESCRIPTION
## Summary

Adds `chainweaver diff <baseline> <actual>` so operators can compare two `ExecutionResult` JSON files step-by-step. Sister tool to `profile` (#159).

Stacked on top of #159 (profile CLI); base cascades through `#159 → #158 → #157 → main` as those merge.

Closes #148.

## Changes

- **`pyproject.toml`** — adds `deepdiff>=8.0` to `[project.dependencies]`.
- **`chainweaver/cli.py`** — new `diff_command`, `_compare_traces` (structural comparison), `_step_outputs_diff` (DeepDiff-backed), `_format_diff_table` (human renderer). `from deepdiff import DeepDiff` is a module-level import (fail-fast on missing dep, consistent with all other imports).
- **`tests/test_cli_diff.py`** — 13 test cases covering identical traces, diverging outputs (with exact snapshot assertions on `values_changed` structure and old/new values), performance-tolerance thresholds, and file-error exit codes.
- **`docs/cli.md`** — new CLI reference covering all 7 subcommands (`inspect`, `viz`, `validate`, `check`, `run`, `profile`, `diff`) with flags, exit-code contracts, and usage examples. Closes the #148 acceptance criterion requiring operator-facing documentation.

### Behavior

Aligns step records by position. Walks `outputs`, `error_type`, `error_message`, `success` for each pair. Optionally flags per-step duration regressions beyond `--perf-tolerance N%`. Non-deterministic fields (`trace_id`, `started_at`, `ended_at`, `total_duration_ms`, per-step `duration_ms` when no tolerance is set) are ignored by default.

| Flag | Meaning |
|---|---|
| `--perf-tolerance N` | Flag steps whose `duration_ms` changed by more than N %. Off by default. |
| `--format table\|json` (`-f`) | Default `table` shows structural deltas; `json` emits the structured diff payload. |

### Exit codes

- `0` — identical (modulo ignored fields).
- `1` — differs, or malformed trace input.
- `2` — file not found.

### JSON output shape (`--format json`)

```json
{
  "summary": { "status": "differs", "total_steps": 2, "diverging_steps": 1 },
  "final_output": { "values_changed": { "root['rows']": { "new_value": 99, "old_value": 42 } } },
  "steps": [
    { "step_index": 0, "tool_name": "tool_a", "status": "differs",
      "outputs": { "values_changed": { "root['rows']": { "new_value": 99, "old_value": 42 } } } }
  ]
}
```

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/`)
- [x] All existing tests pass — **504/504 passed**
- [x] New tests added for new functionality

```text
$ ruff check chainweaver/ tests/ examples/
All checks passed!
$ ruff format --check chainweaver/ tests/ examples/
51 files already formatted
$ python -m mypy chainweaver/
Success: no issues found in 17 source files
$ python -m pytest tests/ -q --no-cov
504 passed in 4.69s
```

Diff stat: `4 files changed, 841 insertions(+), 6 deletions(-)`.

## Related Issues

Closes #148. Sister to `chainweaver profile` (#159 / #147).

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented — `docs/cli.md` created covering all 7 subcommands
- [x] No secrets or credentials included

## Tradeoffs / risks

- **New runtime dependency: `deepdiff>=8.0`**. Hand-rolling recursive nested-dict diff would add ~150 LoC of fragile code; DeepDiff is small (~150 KB), well-maintained, and has stable cross-platform wheels for Python 3.10–3.13. This brings the runtime-deps total from 4 → 5. Only `DeepDiff(a, b, ignore_order=True, view="tree").to_dict()` is used; wrapping it in `_step_outputs_diff` keeps the surface area minimal so a future swap is local.
- **Performance-tolerance off by default**: matches the issue's "non-deterministic fields ignored by default" framing. Users opt in to perf checks explicitly.
- **Step alignment is positional**: tool-name renames at the same index are flagged via `tool_name_change` rather than treated as insert/delete events. Reordered-steps detection is out of scope.

## Scope notes

Closes #148 only. Adjacent items:

- **Replay-from-diff helper** — a follow-up could let `chainweaver replay --diff` re-execute only the diverging steps. Tracked separately if needed.