### PR TITLE
feat: add `chainweaver suggest <flow>` static optimizer (#155)

### DIFF
--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import logging
 
 from chainweaver import cli
-from chainweaver.analyzer import ChainAnalyzer, ToolChain
+from chainweaver.analyzer import ChainAnalyzer, Suggestion, ToolChain, suggest_optimizations
 from chainweaver.attest import AttestationInputError, AttestationReport, attest_flow
 from chainweaver.builder import FlowBuilder, FlowBuilderError
 from chainweaver.cache import FileStepCache, InMemoryStepCache, StepCache, StepCacheKey
@@ -201,6 +201,7 @@ __all__ = [
     "StepPlan",
     "StepRecord",
     "StepStartContext",
+    "Suggestion",
     "Tool",
     "ToolChain",
     "ToolDefinitionError",
@@ -223,6 +224,7 @@ __all__ = [
     "flow_to_yaml",
     "result_to_mermaid",
     "schema_fingerprint",
+    "suggest_optimizations",
     "tool",
     "validate_dag_topology",
 ]

--- a/chainweaver/analyzer.py
+++ b/chainweaver/analyzer.py
@@ -322,9 +322,10 @@ def _suggest_wasteful_passthroughs(flow: Flow) -> list[Suggestion]:
     A step that uses ``input_mapping={}`` receives the entire
     accumulated context.  When the tool's ``input_schema`` declares a
     small subset of fields this works (Pydantic ignores extras) but
-    obscures the data flow.  We flag empty mappings on steps that have
-    at least one declared input field so the author can opt into an
-    explicit wiring.
+    obscures the data flow.  We flag every step with an empty
+    ``input_mapping`` so the author can opt into explicit wiring for
+    readability — regardless of whether the tool declares input fields
+    (tool schemas are not available in this function).
     """
     out: list[Suggestion] = []
     for idx, step in enumerate(flow.steps):
@@ -359,10 +360,16 @@ def _suggest_parallelizable_pairs(
 ) -> list[Suggestion]:
     """CW002 — adjacent independent steps could run in a DAG level.
 
-    Two consecutive steps are flagged when step ``N+1``'s declared
-    input fields don't overlap with step ``N``'s declared output
-    fields: the data dependency from N to N+1 is empty, so moving them
-    into the same DAG level is safe.
+    Two consecutive steps are flagged when step ``N+1``'s actual reads
+    don't overlap with step ``N``'s declared output fields: the data
+    dependency from N to N+1 is empty, so moving them into the same
+    DAG level is safe.
+
+    The consumer's actual reads are determined by its ``input_mapping``:
+    - Empty mapping (full-context passthrough): the step implicitly
+      reads all fields declared in its ``input_schema``.
+    - Non-empty mapping: only the string values in the mapping are
+      context reads.
 
     Skipped when *tools* is ``None`` — without per-tool schemas there
     is no reliable way to compute the actual data dependency.
@@ -378,10 +385,13 @@ def _suggest_parallelizable_pairs(
         if tool_a is None or tool_b is None:
             continue
         a_outputs = set(tool_a.output_schema.model_fields)
-        b_inputs = set(tool_b.input_schema.model_fields)
-        if not a_outputs or not b_inputs:
+        # Determine what step b actually reads from context.
+        # Empty mapping = full-context passthrough → reads declared
+        # input_schema fields; non-empty → reads mapped sources.
+        b_reads = set(tool_b.input_schema.model_fields) if not b.input_mapping else _step_reads(b)
+        if not a_outputs or not b_reads:
             continue
-        if a_outputs.isdisjoint(b_inputs):
+        if a_outputs.isdisjoint(b_reads):
             out.append(
                 Suggestion(
                     code="CW002",
@@ -404,6 +414,11 @@ def _suggest_dead_steps(flow: Flow, tools: dict[str, Tool] | None) -> list[Sugge
     Requires the per-tool schemas to compute output keys.  Skipped when
     *tools* is ``None``.  The last step is exempt — its outputs land in
     ``final_output`` rather than feeding another step.
+
+    For downstream steps with empty ``input_mapping`` (full-context
+    passthrough), we treat their declared ``input_schema`` fields as
+    implicit reads — since the executor passes the full context and
+    Pydantic validates against the schema.
     """
     if tools is None:
         return []
@@ -412,8 +427,16 @@ def _suggest_dead_steps(flow: Flow, tools: dict[str, Tool] | None) -> list[Sugge
     downstream_reads: list[set[str]] = []
     accum: set[str] = set()
     for idx in range(len(flow.steps) - 1, -1, -1):
+        step = flow.steps[idx]
         downstream_reads.append(accum.copy())
-        accum |= _step_reads(flow.steps[idx])
+        if not step.input_mapping:
+            # Empty mapping = full-context passthrough; the step
+            # implicitly reads its declared input_schema fields.
+            tool = tools.get(step.tool_name)
+            if tool is not None:
+                accum |= set(tool.input_schema.model_fields)
+        else:
+            accum |= _step_reads(step)
     downstream_reads.reverse()
     for idx, step in enumerate(flow.steps[:-1]):
         tool = tools.get(step.tool_name)

--- a/chainweaver/analyzer.py
+++ b/chainweaver/analyzer.py
@@ -527,8 +527,8 @@ def suggest_optimizations(
             inputs return an empty list (no suggestions are emitted —
             most families don't apply to topologically-ordered graphs).
         tools: Optional iterable of :class:`Tool` objects keyed by name.
-            Required for CW003 (dead-step) which needs per-tool output
-            schemas; the other families are tool-free.
+            Required for CW002 (parallelizable-pair) and CW003
+            (dead-step) which need per-tool I/O schemas.
         traces: Optional list of :class:`ExecutionResult` objects from
             prior runs.  Required for CW004 (cacheable-step).
 

--- a/chainweaver/analyzer.py
+++ b/chainweaver/analyzer.py
@@ -1,10 +1,19 @@
-"""Offline static analysis of tool combinations (issue #77).
+"""Offline static analysis for ChainWeaver flows (issues #77, #155).
 
-The :class:`ChainAnalyzer` discovers which :class:`~chainweaver.tools.Tool`
-objects can legitimately follow each other in a flow, purely by inspecting
-their Pydantic ``input_schema`` and ``output_schema``.  No tool is invoked
-and no LLM is consulted — this is the static "what *could* be compiled?"
-companion to the deterministic runtime side of ChainWeaver.
+This module hosts two complementary tools:
+
+* :class:`ChainAnalyzer` (issue #77) discovers which
+  :class:`~chainweaver.tools.Tool` objects can legitimately follow each
+  other in a flow, purely by inspecting their Pydantic ``input_schema``
+  and ``output_schema``.
+* :func:`suggest_optimizations` (issue #155) reads a :class:`Flow`
+  (optionally paired with recorded
+  :class:`~chainweaver.executor.ExecutionResult` traces) and emits
+  advisory :class:`Suggestion` objects with stable codes.
+
+Both are pure static passes — no tool is invoked and no LLM is
+consulted — the static "what *could* be compiled?" companion to the
+deterministic runtime side of ChainWeaver.
 
 The analyzer answers three questions:
 
@@ -40,11 +49,16 @@ Invariants
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
 from chainweaver.flow import Flow, FlowStep
 from chainweaver.tools import Tool
+
+if TYPE_CHECKING:
+    from chainweaver.executor import ExecutionResult
+    from chainweaver.flow import DAGFlow
 
 ToolChain = tuple[str, ...]
 """An ordered tuple of tool names representing a valid execution order."""
@@ -258,3 +272,259 @@ class ChainAnalyzer:
                 )
             )
         return flows
+
+
+# ---------------------------------------------------------------------------
+# suggest_optimizations (issue #155)
+# ---------------------------------------------------------------------------
+
+
+SUGGESTION_CODES = {
+    "CW001": "wasteful-passthrough",
+    "CW002": "parallelizable-pair",
+    "CW003": "dead-step",
+    "CW004": "cacheable-step",
+}
+"""Stable suggestion code → short slug, for filtering and grouping.
+
+The code itself is the contract: downstream CI consumers gate on the
+``code`` field of a :class:`Suggestion`, not on the slug or the
+human-readable message.
+"""
+
+
+class Suggestion(BaseModel):
+    """One advisory suggestion produced by :func:`suggest_optimizations`.
+
+    Attributes:
+        code: Stable suggestion code (e.g. ``"CW001"``).  See
+            :data:`SUGGESTION_CODES` for the registered set.
+        title: Short slug matching :data:`SUGGESTION_CODES[code]`.
+        step_index: Position of the offending step in the flow, or
+            ``None`` for flow-level suggestions.
+        tool_name: Name of the offending tool, or ``None`` for
+            flow-level suggestions.
+        message: Human-readable explanation.  Stable enough to be
+            grep'd by tooling but not stable enough to assert on
+            verbatim — code + title are the durable contract.
+    """
+
+    code: str
+    title: str
+    step_index: int | None = None
+    tool_name: str | None = None
+    message: str
+
+
+def _suggest_wasteful_passthroughs(flow: Flow) -> list[Suggestion]:
+    """CW001 — explicit input mapping recommended.
+
+    A step that uses ``input_mapping={}`` receives the entire
+    accumulated context.  When the tool's ``input_schema`` declares a
+    small subset of fields this works (Pydantic ignores extras) but
+    obscures the data flow.  We flag empty mappings on steps that have
+    at least one declared input field so the author can opt into an
+    explicit wiring.
+    """
+    out: list[Suggestion] = []
+    for idx, step in enumerate(flow.steps):
+        if step.input_mapping:
+            continue
+        out.append(
+            Suggestion(
+                code="CW001",
+                title=SUGGESTION_CODES["CW001"],
+                step_index=idx,
+                tool_name=step.tool_name,
+                message=(
+                    f"Step {idx} ('{step.tool_name}') uses an empty input_mapping. "
+                    "Consider an explicit mapping so the data flow is visible to readers."
+                ),
+            )
+        )
+    return out
+
+
+def _step_reads(step: FlowStep) -> set[str]:
+    """Return the set of context keys *step* reads (string values only).
+
+    Literal-constant mappings (non-string values) aren't context reads.
+    """
+    return {v for v in step.input_mapping.values() if isinstance(v, str)}
+
+
+def _suggest_parallelizable_pairs(
+    flow: Flow,
+    tools: dict[str, Tool] | None,
+) -> list[Suggestion]:
+    """CW002 — adjacent independent steps could run in a DAG level.
+
+    Two consecutive steps are flagged when step ``N+1``'s declared
+    input fields don't overlap with step ``N``'s declared output
+    fields: the data dependency from N to N+1 is empty, so moving them
+    into the same DAG level is safe.
+
+    Skipped when *tools* is ``None`` — without per-tool schemas there
+    is no reliable way to compute the actual data dependency.
+    """
+    if tools is None:
+        return []
+    out: list[Suggestion] = []
+    for idx in range(len(flow.steps) - 1):
+        a = flow.steps[idx]
+        b = flow.steps[idx + 1]
+        tool_a = tools.get(a.tool_name)
+        tool_b = tools.get(b.tool_name)
+        if tool_a is None or tool_b is None:
+            continue
+        a_outputs = set(tool_a.output_schema.model_fields)
+        b_inputs = set(tool_b.input_schema.model_fields)
+        if not a_outputs or not b_inputs:
+            continue
+        if a_outputs.isdisjoint(b_inputs):
+            out.append(
+                Suggestion(
+                    code="CW002",
+                    title=SUGGESTION_CODES["CW002"],
+                    step_index=idx,
+                    tool_name=a.tool_name,
+                    message=(
+                        f"Steps {idx} ('{a.tool_name}') and {idx + 1} ('{b.tool_name}') "
+                        "have disjoint output/input fields; they're DAG-eligible "
+                        "(promote to DAGFlow for parallel execution)."
+                    ),
+                )
+            )
+    return out
+
+
+def _suggest_dead_steps(flow: Flow, tools: dict[str, Tool] | None) -> list[Suggestion]:
+    """CW003 — step output unread downstream.
+
+    Requires the per-tool schemas to compute output keys.  Skipped when
+    *tools* is ``None``.  The last step is exempt — its outputs land in
+    ``final_output`` rather than feeding another step.
+    """
+    if tools is None:
+        return []
+    out: list[Suggestion] = []
+    # Read sets per step (union across all downstream steps).
+    downstream_reads: list[set[str]] = []
+    accum: set[str] = set()
+    for idx in range(len(flow.steps) - 1, -1, -1):
+        downstream_reads.append(accum.copy())
+        accum |= _step_reads(flow.steps[idx])
+    downstream_reads.reverse()
+    for idx, step in enumerate(flow.steps[:-1]):
+        tool = tools.get(step.tool_name)
+        if tool is None:
+            continue
+        produced = set(tool.output_schema.model_fields)
+        if not produced:
+            continue
+        if produced.isdisjoint(downstream_reads[idx]):
+            out.append(
+                Suggestion(
+                    code="CW003",
+                    title=SUGGESTION_CODES["CW003"],
+                    step_index=idx,
+                    tool_name=step.tool_name,
+                    message=(
+                        f"Step {idx} ('{step.tool_name}') outputs "
+                        f"{sorted(produced)} but no downstream step reads them. "
+                        "Remove the step or wire it into a downstream input_mapping."
+                    ),
+                )
+            )
+    return out
+
+
+def _suggest_cacheable_steps(
+    flow: Flow,
+    traces: list[ExecutionResult],
+) -> list[Suggestion]:
+    """CW004 — step produced identical outputs across all observed traces.
+
+    Requires at least two traces.  For each step index that appears in
+    every trace, check whether the step's outputs are byte-identical
+    (after canonical JSON encoding) across all of them.  Identity is
+    strong evidence the step is a pure function of its inputs and a
+    cache candidate.
+    """
+    import json as _json
+
+    if len(traces) < 2:
+        return []
+    out: list[Suggestion] = []
+    step_count = len(flow.steps)
+    for idx in range(step_count):
+        signatures: set[str] = set()
+        complete = True
+        for trace in traces:
+            if idx >= len(trace.execution_log):
+                complete = False
+                break
+            record = trace.execution_log[idx]
+            if not record.success:
+                complete = False
+                break
+            signatures.add(
+                _json.dumps(record.outputs, sort_keys=True, separators=(",", ":"), default=str)
+            )
+        if not complete:
+            continue
+        if len(signatures) == 1:
+            tool_name = flow.steps[idx].tool_name
+            out.append(
+                Suggestion(
+                    code="CW004",
+                    title=SUGGESTION_CODES["CW004"],
+                    step_index=idx,
+                    tool_name=tool_name,
+                    message=(
+                        f"Step {idx} ('{tool_name}') returned identical output across all "
+                        f"{len(traces)} observed traces — candidate for caching."
+                    ),
+                )
+            )
+    return out
+
+
+def suggest_optimizations(
+    flow: Flow | DAGFlow,
+    *,
+    tools: Iterable[Tool] | None = None,
+    traces: list[ExecutionResult] | None = None,
+) -> list[Suggestion]:
+    """Return advisory :class:`Suggestion` objects for *flow*.
+
+    Args:
+        flow: The flow to analyze.  Currently linear :class:`Flow`
+            objects are supported; :class:`~chainweaver.flow.DAGFlow`
+            inputs return an empty list (no suggestions are emitted —
+            most families don't apply to topologically-ordered graphs).
+        tools: Optional iterable of :class:`Tool` objects keyed by name.
+            Required for CW003 (dead-step) which needs per-tool output
+            schemas; the other families are tool-free.
+        traces: Optional list of :class:`ExecutionResult` objects from
+            prior runs.  Required for CW004 (cacheable-step).
+
+    Returns:
+        A flat list of :class:`Suggestion` objects in family + index
+        order.  Empty when the flow looks clean (or when *flow* is a
+        DAGFlow).
+    """
+    from chainweaver.flow import DAGFlow as _DAGFlow
+
+    if isinstance(flow, _DAGFlow):
+        return []
+    tools_by_name: dict[str, Tool] | None = None
+    if tools is not None:
+        tools_by_name = {t.name: t for t in tools}
+    out: list[Suggestion] = []
+    out.extend(_suggest_wasteful_passthroughs(flow))
+    out.extend(_suggest_parallelizable_pairs(flow, tools_by_name))
+    out.extend(_suggest_dead_steps(flow, tools_by_name))
+    if traces:
+        out.extend(_suggest_cacheable_steps(flow, traces))
+    return out

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -26,6 +26,9 @@ Available commands
 - ``chainweaver attest <flow>`` — observed-determinism attestation:
   run a flow N x M times and emit a reproducible JSON artifact
   (issue #154).
+- ``chainweaver suggest <flow>`` — emit advisory optimization
+  suggestions for a flow file, optionally informed by trace files
+  (issue #155).
 
 Programmatic registration entry point
 -------------------------------------
@@ -1235,6 +1238,124 @@ def _attest_report_to_table(report: AttestationReport) -> str:
             step_str = f"step {step}" if step is not None else "(step unknown)"
             lines.append(f"  input #{div['input_index']} @ {step_str}: {div['error_message']}")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# suggest command (issue #155)
+# ---------------------------------------------------------------------------
+
+
+_SUGGEST_FLOW_ARG = typer.Argument(
+    ...,
+    help="Path to a .flow.yaml, .flow.yml, or .flow.json file.",
+)
+_SUGGEST_TOOLS_OPTION = typer.Option(
+    [],
+    "--tools",
+    "-t",
+    help=(
+        "Python module path that exposes Tool instances at top level. "
+        "Required for CW003 (dead-step) suggestions. Repeatable."
+    ),
+)
+_SUGGEST_TRACES_OPTION = typer.Option(
+    [],
+    "--trace",
+    help=(
+        "Path to a recorded ExecutionResult JSON file. Required (>= 2 traces) "
+        "for CW004 (cacheable-step) suggestions. Repeatable."
+    ),
+)
+_SUGGEST_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("suggest")
+def suggest_command(
+    flow_file: Path = _SUGGEST_FLOW_ARG,
+    tools: list[str] = _SUGGEST_TOOLS_OPTION,
+    trace: list[Path] = _SUGGEST_TRACES_OPTION,
+    output_format: OutputFormat = _SUGGEST_FORMAT_OPTION,
+) -> None:
+    """Emit advisory optimization suggestions for a flow file.
+
+    Suggestion families (stable codes):
+
+    - ``CW001`` — wasteful-passthrough (empty input_mapping).
+    - ``CW002`` — parallelizable-pair (adjacent steps reading disjoint
+      context keys).
+    - ``CW003`` — dead-step (step outputs are not read downstream).
+      Requires ``--tools``.
+    - ``CW004`` — cacheable-step (identical outputs across observed
+      traces).  Requires two or more ``--trace`` files.
+
+    Exit code 0 is always returned — the suggester is advisory.
+    Machine consumers should gate on the ``suggestions`` array length
+    in ``--format json``.  Use a non-zero exit code from your own
+    wrapper when desired.
+
+    Exit codes: 0 = ran successfully (regardless of suggestion count),
+    1 = malformed input, 2 = file not found.
+    """
+    _require_existing_file(flow_file)
+    try:
+        flow = _load_flow_file(flow_file)
+    except FlowSerializationError as exc:
+        typer.echo(f"chainweaver: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    tool_objs: list[Tool] = []
+    seen_tool_names: set[str] = set()
+    for module_name in tools:
+        for tool_obj in _import_tools_from(module_name):
+            if tool_obj.name in seen_tool_names:
+                continue
+            tool_objs.append(tool_obj)
+            seen_tool_names.add(tool_obj.name)
+
+    trace_results: list[ExecutionResult] = []
+    for path in trace:
+        trace_results.append(_load_execution_result(path))
+
+    from chainweaver.analyzer import suggest_optimizations
+
+    if isinstance(flow, DAGFlow):
+        suggestions = []
+    else:
+        suggestions = suggest_optimizations(
+            flow,
+            tools=tool_objs if tool_objs else None,
+            traces=trace_results if trace_results else None,
+        )
+
+    if output_format is OutputFormat.JSON:
+        _emit_json(
+            {
+                "flow_name": flow.name,
+                "flow_version": flow.version,
+                "suggestion_count": len(suggestions),
+                "suggestions": [json.loads(s.model_dump_json()) for s in suggestions],
+            }
+        )
+        return
+
+    if not suggestions:
+        typer.echo(f"No suggestions for flow '{flow.name}'.")
+        return
+    lines = [
+        f"Suggestions for flow '{flow.name}' v{flow.version}:",
+        "─" * 60,
+    ]
+    for s in suggestions:
+        loc = f"step {s.step_index} ({s.tool_name})" if s.step_index is not None else "(flow)"
+        lines.append(f"  [{s.code} {s.title}] {loc}")
+        lines.append(f"    {s.message}")
+    typer.echo("\n".join(lines))
 
 
 # ---------------------------------------------------------------------------

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -1288,7 +1288,7 @@ def suggest_command(
 
     - ``CW001`` — wasteful-passthrough (empty input_mapping).
     - ``CW002`` — parallelizable-pair (adjacent steps reading disjoint
-      context keys).
+      context keys).  Requires ``--tools``.
     - ``CW003`` — dead-step (step outputs are not read downstream).
       Requires ``--tools``.
     - ``CW004`` — cacheable-step (identical outputs across observed

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -61,6 +61,7 @@
     "StepPlan",
     "StepRecord",
     "StepStartContext",
+    "Suggestion",
     "Tool",
     "ToolChain",
     "ToolDefinitionError",
@@ -83,6 +84,7 @@
     "flow_to_yaml",
     "result_to_mermaid",
     "schema_fingerprint",
+    "suggest_optimizations",
     "tool",
     "validate_dag_topology"
   ],
@@ -667,6 +669,19 @@
       "qualname": "StepStartContext",
       "signature": "(*, trace_id: str, flow_name: str, step_index: int, tool_name: str, inputs: dict[str, Any], started_at: datetime.datetime) -> None"
     },
+    "Suggestion": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "code": "str",
+        "message": "str",
+        "step_index": "int | NoneType",
+        "title": "str",
+        "tool_name": "str | NoneType"
+      },
+      "module": "chainweaver.analyzer",
+      "qualname": "Suggestion",
+      "signature": "(*, code: str, title: str, step_index: int | NoneType = None, tool_name: str | NoneType = None, message: str) -> None"
+    },
     "Tool": {
       "kind": "class",
       "module": "chainweaver.tools",
@@ -796,6 +811,12 @@
       "module": "chainweaver.compat",
       "qualname": "schema_fingerprint",
       "signature": "(model: type[BaseModel]) -> str"
+    },
+    "suggest_optimizations": {
+      "kind": "function",
+      "module": "chainweaver.analyzer",
+      "qualname": "suggest_optimizations",
+      "signature": "(flow: Flow | DAGFlow, *, tools: Iterable[Tool] | None = None, traces: list[ExecutionResult] | None = None) -> list[Suggestion]"
     },
     "tool": {
       "kind": "function",

--- a/tests/test_cli_suggest.py
+++ b/tests/test_cli_suggest.py
@@ -1,0 +1,483 @@
+"""Tests for ``suggest_optimizations`` + the ``chainweaver suggest`` CLI (#155)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from chainweaver import (
+    Flow,
+    FlowStep,
+    Suggestion,
+    Tool,
+    cli,
+    suggest_optimizations,
+)
+from chainweaver.executor import ExecutionResult, StepRecord
+
+# ---------------------------------------------------------------------------
+# Shared schemas
+# ---------------------------------------------------------------------------
+
+
+class NumberIn(BaseModel):
+    number: int
+
+
+class ValueOut(BaseModel):
+    value: int
+
+
+class ValueIn(BaseModel):
+    value: int
+
+
+class FormattedOut(BaseModel):
+    result: str
+
+
+def _identity(inp: BaseModel) -> dict[str, Any]:
+    return inp.model_dump()
+
+
+def _double_tool() -> Tool:
+    return Tool(
+        name="double",
+        description="Doubles.",
+        input_schema=NumberIn,
+        output_schema=ValueOut,
+        fn=_identity,
+    )
+
+
+def _format_tool() -> Tool:
+    return Tool(
+        name="format_result",
+        description="Formats.",
+        input_schema=ValueIn,
+        output_schema=FormattedOut,
+        fn=_identity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Programmatic suggest_optimizations()
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestStatic:
+    def test_clean_flow_has_no_suggestions(self) -> None:
+        flow = Flow(
+            name="clean",
+            version="0.1.0",
+            description="Clean.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        assert suggest_optimizations(flow) == []
+
+    def test_cw001_flagged_for_empty_mapping(self) -> None:
+        flow = Flow(
+            name="wasteful",
+            version="0.1.0",
+            description="Wasteful mapping.",
+            steps=[
+                FlowStep(tool_name="double"),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        suggestions = suggest_optimizations(flow)
+        codes = [s.code for s in suggestions]
+        assert "CW001" in codes
+        cw001 = next(s for s in suggestions if s.code == "CW001")
+        assert cw001.step_index == 0
+        assert cw001.tool_name == "double"
+
+    def test_cw002_flagged_for_disjoint_io(self) -> None:
+        # double outputs {value}; double inputs {number}. Output ∩ Input = ∅
+        # so an adjacent (double → double) pair is DAG-eligible. CW002 now
+        # requires tools because the check needs schemas.
+        flow = Flow(
+            name="parallelizable",
+            version="0.1.0",
+            description="Two independent steps.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "left"}),
+                FlowStep(tool_name="double", input_mapping={"number": "right"}),
+            ],
+        )
+        # Without tools: no CW002 (we can't tell).
+        without_tools = suggest_optimizations(flow)
+        assert all(s.code != "CW002" for s in without_tools)
+        # With tools: CW002 fires.
+        with_tools = suggest_optimizations(flow, tools=[_double_tool()])
+        codes = [s.code for s in with_tools]
+        assert "CW002" in codes
+        cw002 = next(s for s in with_tools if s.code == "CW002")
+        assert cw002.step_index == 0
+
+    def test_cw003_requires_tools(self) -> None:
+        # Without tools: no CW003.
+        flow = Flow(
+            name="dead",
+            version="0.1.0",
+            description="Step 0 output is unread.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "other"}),
+            ],
+        )
+        no_tools = suggest_optimizations(flow)
+        assert all(s.code != "CW003" for s in no_tools)
+
+        # With tools: CW003 fires because 'double' outputs 'value' but the next
+        # step reads 'other'.
+        with_tools = suggest_optimizations(flow, tools=[_double_tool(), _format_tool()])
+        codes = [s.code for s in with_tools]
+        assert "CW003" in codes
+        cw003 = next(s for s in with_tools if s.code == "CW003")
+        assert cw003.step_index == 0
+
+    def test_dagflow_returns_no_suggestions(self) -> None:
+        from chainweaver.flow import DAGFlow, DAGFlowStep
+
+        dag = DAGFlow(
+            name="dag",
+            version="0.1.0",
+            description=".",
+            steps=[
+                DAGFlowStep(tool_name="double", step_id="A", depends_on=[]),
+                DAGFlowStep(tool_name="format_result", step_id="B", depends_on=["A"]),
+            ],
+        )
+        assert suggest_optimizations(dag) == []
+
+
+# ---------------------------------------------------------------------------
+# Cacheable-step (CW004) — requires traces
+# ---------------------------------------------------------------------------
+
+
+def _make_trace(
+    *,
+    flow_name: str,
+    outputs_per_step: list[dict[str, Any]],
+    trace_id: str,
+) -> ExecutionResult:
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    log = [
+        StepRecord(
+            step_index=i,
+            tool_name=f"tool_{i}",
+            inputs={},
+            outputs=out,
+            success=True,
+            started_at=now,
+            ended_at=now,
+            duration_ms=1.0,
+        )
+        for i, out in enumerate(outputs_per_step)
+    ]
+    return ExecutionResult(
+        flow_name=flow_name,
+        success=True,
+        final_output=outputs_per_step[-1] if outputs_per_step else None,
+        execution_log=log,
+        trace_id=trace_id,
+        started_at=now,
+        ended_at=now,
+        total_duration_ms=10.0,
+        initial_input={},
+    )
+
+
+class TestSuggestCacheable:
+    def test_cw004_fires_on_identical_outputs(self) -> None:
+        flow = Flow(
+            name="cachey",
+            version="0.1.0",
+            description=".",
+            steps=[
+                FlowStep(tool_name="tool_0", input_mapping={"x": "x"}),
+                FlowStep(tool_name="tool_1", input_mapping={"y": "y"}),
+            ],
+        )
+        # Three traces; step 0 output identical, step 1 differs.
+        traces = [
+            _make_trace(
+                flow_name="cachey",
+                outputs_per_step=[{"value": 1}, {"other": 10}],
+                trace_id=f"t{i}",
+            )
+            for i in range(3)
+        ]
+        # Mutate step 1 outputs so they differ across traces.
+        traces[1].execution_log[1].outputs = {"other": 11}
+        traces[2].execution_log[1].outputs = {"other": 12}
+        suggestions = suggest_optimizations(flow, traces=traces)
+        cw004 = [s for s in suggestions if s.code == "CW004"]
+        assert len(cw004) == 1
+        assert cw004[0].step_index == 0
+        assert cw004[0].tool_name == "tool_0"
+
+    def test_cw004_needs_two_or_more_traces(self) -> None:
+        flow = Flow(
+            name="one_trace",
+            version="0.1.0",
+            description=".",
+            steps=[FlowStep(tool_name="tool_0", input_mapping={"x": "x"})],
+        )
+        one_trace = [
+            _make_trace(
+                flow_name="one_trace",
+                outputs_per_step=[{"value": 1}],
+                trace_id="t0",
+            )
+        ]
+        assert all(s.code != "CW004" for s in suggest_optimizations(flow, traces=one_trace))
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    cli.set_default_registry(None)
+
+
+def _write_flow(path: Path, flow: Flow) -> None:
+    path.write_text(flow.to_yaml(), encoding="utf-8")
+
+
+def _write_trace(path: Path, result: ExecutionResult) -> None:
+    path.write_text(result.model_dump_json(), encoding="utf-8")
+
+
+def _write_tools_module(dir_path: Path, name: str) -> str:
+    module_name = f"suggestmod_{name}_{dir_path.stem.replace('.', '_')}"
+    module_path = dir_path / f"{module_name}.py"
+    module_path.write_text(
+        "from __future__ import annotations\n"
+        "from typing import Any\n"
+        "from pydantic import BaseModel\n"
+        "from chainweaver import Tool\n"
+        "\n"
+        "class _NumberInput(BaseModel):\n"
+        "    number: int\n"
+        "\n"
+        "class _ValueOutput(BaseModel):\n"
+        "    value: int\n"
+        "\n"
+        "class _ValueInput(BaseModel):\n"
+        "    value: int\n"
+        "\n"
+        "class _FormattedOutput(BaseModel):\n"
+        "    result: str\n"
+        "\n"
+        "def _double_fn(inp: _NumberInput) -> dict[str, Any]:\n"
+        "    return {'value': inp.number * 2}\n"
+        "\n"
+        "def _format_fn(inp: _ValueInput) -> dict[str, Any]:\n"
+        "    return {'result': str(inp.value)}\n"
+        "\n"
+        "double = Tool(name='double', description='.', "
+        "input_schema=_NumberInput, output_schema=_ValueOutput, fn=_double_fn)\n"
+        "format_result = Tool(name='format_result', description='.', "
+        "input_schema=_ValueInput, output_schema=_FormattedOutput, fn=_format_fn)\n",
+        encoding="utf-8",
+    )
+    return module_name
+
+
+@pytest.fixture()
+def _module_sys_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for key in list(sys.modules):
+        if key.startswith("suggestmod_"):
+            sys.modules.pop(key, None)
+    return tmp_path
+
+
+class TestSuggestCLI:
+    def test_clean_flow_table_says_no_suggestions(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow = Flow(
+            name="clean",
+            version="0.1.0",
+            description=".",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+            ],
+        )
+        path = tmp_path / "clean.flow.yaml"
+        _write_flow(path, flow)
+        exit_code = cli.main(["suggest", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "No suggestions" in captured.out
+
+    def test_cw001_table_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow = Flow(
+            name="wasteful",
+            version="0.1.0",
+            description=".",
+            steps=[FlowStep(tool_name="double")],
+        )
+        path = tmp_path / "w.flow.yaml"
+        _write_flow(path, flow)
+        exit_code = cli.main(["suggest", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "CW001" in captured.out
+        assert "wasteful-passthrough" in captured.out
+        assert "double" in captured.out
+
+    def test_json_output_shape(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow = Flow(
+            name="wasteful",
+            version="0.1.0",
+            description=".",
+            steps=[FlowStep(tool_name="double")],
+        )
+        path = tmp_path / "w.flow.yaml"
+        _write_flow(path, flow)
+        exit_code = cli.main(["suggest", str(path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["flow_name"] == "wasteful"
+        assert payload["suggestion_count"] == 1
+        assert payload["suggestions"][0]["code"] == "CW001"
+        assert payload["suggestions"][0]["title"] == "wasteful-passthrough"
+
+    def test_with_tools_enables_cw003(
+        self,
+        _module_sys_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Dead-step flow: step 0 outputs 'value', step 1 reads 'other' (so nothing
+        # reads step 0's output).
+        flow = Flow(
+            name="dead",
+            version="0.1.0",
+            description=".",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result", input_mapping={"value": "other"}),
+            ],
+        )
+        path = _module_sys_path / "dead.flow.yaml"
+        _write_flow(path, flow)
+        module = _write_tools_module(_module_sys_path, "two")
+        exit_code = cli.main(["suggest", str(path), "--tools", module, "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        codes = [s["code"] for s in payload["suggestions"]]
+        assert "CW003" in codes
+
+    def test_with_traces_enables_cw004(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        flow = Flow(
+            name="cachey",
+            version="0.1.0",
+            description=".",
+            steps=[
+                FlowStep(tool_name="tool_0", input_mapping={"x": "x"}),
+                FlowStep(tool_name="tool_1", input_mapping={"y": "y"}),
+            ],
+        )
+        flow_path = tmp_path / "c.flow.yaml"
+        _write_flow(flow_path, flow)
+        # Three traces with identical step 0 outputs.
+        trace_paths: list[str] = []
+        for i in range(3):
+            tp = tmp_path / f"t{i}.json"
+            outputs = [{"value": 1}, {"other": i}]
+            _write_trace(
+                tp, _make_trace(flow_name="cachey", outputs_per_step=outputs, trace_id=f"t{i}")
+            )
+            trace_paths.append(str(tp))
+        exit_code = cli.main(
+            [
+                "suggest",
+                str(flow_path),
+                "--trace",
+                trace_paths[0],
+                "--trace",
+                trace_paths[1],
+                "--trace",
+                trace_paths[2],
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        codes = [s["code"] for s in payload["suggestions"]]
+        assert "CW004" in codes
+
+    def test_missing_flow_file_returns_two(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = cli.main(["suggest", str(tmp_path / "nope.flow.yaml")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_malformed_flow_returns_one(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bad = tmp_path / "bad.flow.json"
+        bad.write_text("{not valid", encoding="utf-8")
+        exit_code = cli.main(["suggest", str(bad)])
+        capsys.readouterr()
+        assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Suggestion data class
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestion:
+    def test_round_trips_via_pydantic(self) -> None:
+        s = Suggestion(
+            code="CW001",
+            title="wasteful-passthrough",
+            step_index=2,
+            tool_name="double",
+            message="hello",
+        )
+        round_tripped = Suggestion.model_validate_json(s.model_dump_json())
+        assert round_tripped == s

--- a/tests/test_cli_suggest.py
+++ b/tests/test_cli_suggest.py
@@ -146,6 +146,39 @@ class TestSuggestStatic:
         cw003 = next(s for s in with_tools if s.code == "CW003")
         assert cw003.step_index == 0
 
+    def test_cw002_not_flagged_when_consumer_uses_empty_mapping(self) -> None:
+        """Steps with overlapping schema fields via empty mapping are not parallel."""
+        # double outputs {value}; format_result input_schema declares {value}.
+        # With empty mapping on step 1, it reads 'value' from context (passthrough)
+        # so the pair is NOT independent.
+        flow = Flow(
+            name="dependent_via_passthrough",
+            version="0.1.0",
+            description="Consumer reads via empty mapping.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result"),  # empty input_mapping
+            ],
+        )
+        with_tools = suggest_optimizations(flow, tools=[_double_tool(), _format_tool()])
+        assert all(s.code != "CW002" for s in with_tools)
+
+    def test_cw003_not_flagged_when_downstream_uses_empty_mapping(self) -> None:
+        """Step output consumed via empty-mapping passthrough is not dead."""
+        # double outputs {value}; downstream format_result has empty mapping
+        # and input_schema declares {value} → step 0 output is implicitly read.
+        flow = Flow(
+            name="alive_via_passthrough",
+            version="0.1.0",
+            description="Downstream reads via passthrough.",
+            steps=[
+                FlowStep(tool_name="double", input_mapping={"number": "number"}),
+                FlowStep(tool_name="format_result"),  # empty input_mapping
+            ],
+        )
+        with_tools = suggest_optimizations(flow, tools=[_double_tool(), _format_tool()])
+        assert all(s.code != "CW003" for s in with_tools)
+
     def test_dagflow_returns_no_suggestions(self) -> None:
         from chainweaver.flow import DAGFlow, DAGFlowStep
 


### PR DESCRIPTION
## Summary

Adds `suggest_optimizations()` — a pure-static advisory pass that inspects a `Flow` and emits `Suggestion` objects with stable codes, plus a `chainweaver suggest <flow>` CLI subcommand for operator access.

Closes #155.

---

## Suggestion families

| Code | Slug | Requires |
|------|------|----------|
| **CW001** | `wasteful-passthrough` | — |
| **CW002** | `parallelizable-pair` | `--tools` |
| **CW003** | `dead-step` | `--tools` |
| **CW004** | `cacheable-step` | ≥ 2 `--trace` files |

---

## Changes

### `chainweaver/analyzer.py`
- `Suggestion` Pydantic model with `code`, `title`, `step_index`, `tool_name`, `message`.
- `suggest_optimizations(flow, *, tools=None, traces=None)` public entry point.
- Four private helpers (`_suggest_wasteful_passthroughs`, `_suggest_parallelizable_pairs`, `_suggest_dead_steps`, `_suggest_cacheable_steps`).
- Empty-mapping (full-context passthrough) correctly treated as reading the tool's `input_schema` fields for CW002/CW003.

### `chainweaver/cli.py`
- `chainweaver suggest <flow>` command with `--tools`, `--trace`, `--format` options.
- Always exits 0 (advisory); exit 1 for malformed input, 2 for missing file.

### `chainweaver/__init__.py`
- Exports `Suggestion` and `suggest_optimizations` in `__all__`.

### `tests/test_cli_suggest.py`
- Programmatic tests for all four families + edge cases (DAGFlow, missing tools, single trace).
- CLI integration tests (table output, JSON output, `--tools` module loading, `--trace` loading, error exits).
- Regression tests for CW002/CW003 false positives on empty `input_mapping`.

---

## Validation

All four commands pass:
```
ruff check ✓ | ruff format --check ✓ | mypy ✓ | pytest 654 passed (94% coverage) ✓
```