### PR TITLE
test: add public API snapshot guard

### DIFF
--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -39,6 +39,7 @@
 ## Public API
 
 - [ ] New public symbols added to `chainweaver/__init__.py` `__all__`.
+- [ ] Intentional public API changes regenerate `tests/fixtures/public_api.json` with `python tests/scripts/regen_public_api.py`.
 - [ ] New exceptions: `__init__.py` + `__all__` + README error table — all updated.
 - [ ] `StepRecord` / `ExecutionResult` remain as dataclasses (not converted to Pydantic).
 

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -1,0 +1,576 @@
+{
+  "__all__": [
+    "ChainWeaverError",
+    "CompatibilityIssue",
+    "CompilationError",
+    "CompilationResult",
+    "CompilationWarning",
+    "CostProfile",
+    "CostReport",
+    "DAGDefinitionError",
+    "DAGFlow",
+    "DAGFlowStep",
+    "DriftInfo",
+    "ExecutionPlan",
+    "ExecutionResult",
+    "FileStore",
+    "Flow",
+    "FlowAlreadyExistsError",
+    "FlowBuilder",
+    "FlowBuilderError",
+    "FlowExecutionError",
+    "FlowExecutor",
+    "FlowNotFoundError",
+    "FlowRegistry",
+    "FlowSerializationError",
+    "FlowStatus",
+    "FlowStatusError",
+    "FlowStep",
+    "InMemoryStore",
+    "InputMappingError",
+    "InvalidFlowVersionError",
+    "ObservedStep",
+    "ObservedTrace",
+    "RedactionPolicy",
+    "RegistryStore",
+    "ReplayMode",
+    "ReplayResult",
+    "RetryPolicy",
+    "SchemaValidationError",
+    "StepDiff",
+    "StepPlan",
+    "StepRecord",
+    "Tool",
+    "ToolDefinitionError",
+    "ToolNotFoundError",
+    "ToolOutputSizeError",
+    "ToolTimeoutError",
+    "TraceRecorder",
+    "check_flow_compatibility",
+    "cli",
+    "compile_flow",
+    "flow_from_dict",
+    "flow_from_json",
+    "flow_from_yaml",
+    "flow_to_ascii",
+    "flow_to_dict",
+    "flow_to_dot",
+    "flow_to_json",
+    "flow_to_mermaid",
+    "flow_to_yaml",
+    "result_to_mermaid",
+    "schema_fingerprint",
+    "tool",
+    "validate_dag_topology"
+  ],
+  "symbols": {
+    "ChainWeaverError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "ChainWeaverError",
+      "signature": null
+    },
+    "CompatibilityIssue": {
+      "kind": "class",
+      "module": "chainweaver.compat",
+      "qualname": "CompatibilityIssue",
+      "signature": "(flow_name: str, step_index: int, tool_name: str, issue_type: str, detail: str) -> None"
+    },
+    "CompilationError": {
+      "kind": "class",
+      "module": "chainweaver.compiler",
+      "qualname": "CompilationError",
+      "signature": "(step_index: int, tool_name: str, field_name: str | None, issue_type: str, detail: str) -> None"
+    },
+    "CompilationResult": {
+      "kind": "class",
+      "module": "chainweaver.compiler",
+      "qualname": "CompilationResult",
+      "signature": "(success: bool, errors: list[CompilationError] = <factory>, warnings: list[CompilationWarning] = <factory>) -> None"
+    },
+    "CompilationWarning": {
+      "kind": "class",
+      "module": "chainweaver.compiler",
+      "qualname": "CompilationWarning",
+      "signature": "(step_index: int, tool_name: str, field_name: str | None, issue_type: str, detail: str) -> None"
+    },
+    "CostProfile": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "avg_llm_latency_ms": "float",
+        "avg_tokens_per_call": "float",
+        "cost_per_token_usd": "float"
+      },
+      "module": "chainweaver.cost",
+      "qualname": "CostProfile",
+      "signature": "(*, avg_llm_latency_ms: Annotated[float, annotated_types.Ge(ge=0)] = 300.0, avg_tokens_per_call: Annotated[float, annotated_types.Ge(ge=0)] = 750.0, cost_per_token_usd: Annotated[float, annotated_types.Ge(ge=0)] = 4e-05) -> None"
+    },
+    "CostReport": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "actual_execution_ms": "float",
+        "cost_saved_usd": "float",
+        "latency_saved_ms": "float",
+        "llm_calls_avoided": "int",
+        "profile": "chainweaver.cost.CostProfile",
+        "steps_executed": "int"
+      },
+      "module": "chainweaver.cost",
+      "qualname": "CostReport",
+      "signature": "(*, steps_executed: int, llm_calls_avoided: int, latency_saved_ms: float, cost_saved_usd: float, actual_execution_ms: float, profile: chainweaver.cost.CostProfile) -> None"
+    },
+    "DAGDefinitionError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "DAGDefinitionError",
+      "signature": "(flow_name: str, reason: str, detail: str) -> None"
+    },
+    "DAGFlow": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "description": "str",
+        "deterministic": "bool",
+        "input_schema_ref": "str | NoneType",
+        "name": "str",
+        "output_schema_ref": "str | NoneType",
+        "status": "chainweaver.flow.FlowStatus",
+        "steps": "list[chainweaver.flow.DAGFlowStep]",
+        "tool_schema_hashes": "dict[str, str] | NoneType",
+        "trigger_conditions": "dict[str, Any] | NoneType",
+        "version": "str"
+      },
+      "module": "chainweaver.flow",
+      "qualname": "DAGFlow",
+      "signature": "(*, name: str, version: str, description: str, steps: list[chainweaver.flow.DAGFlowStep], deterministic: bool = True, status: chainweaver.flow.FlowStatus = chainweaver.flow.FlowStatus.ACTIVE, trigger_conditions: dict[str, Any] | NoneType = None, input_schema_ref: str | NoneType = None, output_schema_ref: str | NoneType = None, tool_schema_hashes: dict[str, str] | NoneType = None) -> None"
+    },
+    "DAGFlowStep": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "capability_id": "str | NoneType",
+        "depends_on": "list[str]",
+        "input_mapping": "dict[str, Any]",
+        "on_error": "str",
+        "retry": "chainweaver.flow.RetryPolicy | NoneType",
+        "step_id": "str",
+        "step_type": "Literal['tool', 'capability']",
+        "tool_name": "str"
+      },
+      "module": "chainweaver.flow",
+      "qualname": "DAGFlowStep",
+      "signature": "(*, tool_name: str, input_mapping: dict[str, Any] = <factory>, retry: chainweaver.flow.RetryPolicy | NoneType = None, on_error: str = 'fail', step_id: str, depends_on: list[str] = <factory>, step_type: Literal['tool', 'capability'] = 'tool', capability_id: str | NoneType = None) -> None"
+    },
+    "DriftInfo": {
+      "kind": "class",
+      "module": "chainweaver.flow",
+      "qualname": "DriftInfo",
+      "signature": "(flow_name: str, tool_name: str, expected_hash: str, actual_hash: str) -> None"
+    },
+    "ExecutionPlan": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "all_resolvable": "bool",
+        "final_context_shape": "dict[str, str]",
+        "flow_name": "str",
+        "step_count": "int",
+        "steps": "list[chainweaver.executor.StepPlan]"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "ExecutionPlan",
+      "signature": "(*, flow_name: str, step_count: int, steps: list[chainweaver.executor.StepPlan] = <factory>, final_context_shape: dict[str, str] = <factory>, all_resolvable: bool = True) -> None"
+    },
+    "ExecutionResult": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "cost_report": "chainweaver.cost.CostReport | NoneType",
+        "ended_at": "datetime.datetime",
+        "execution_log": "list[chainweaver.executor.StepRecord]",
+        "final_output": "dict[str, Any] | NoneType",
+        "flow_name": "str",
+        "initial_input": "dict[str, Any]",
+        "started_at": "datetime.datetime",
+        "success": "bool",
+        "total_duration_ms": "float",
+        "trace_id": "str"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "ExecutionResult",
+      "signature": "(*, flow_name: str, success: bool, final_output: dict[str, Any] | NoneType, execution_log: list[chainweaver.executor.StepRecord] = <factory>, trace_id: str, started_at: datetime.datetime, ended_at: datetime.datetime, total_duration_ms: float, cost_report: chainweaver.cost.CostReport | NoneType = None, initial_input: dict[str, Any] = <factory>) -> None"
+    },
+    "FileStore": {
+      "kind": "class",
+      "module": "chainweaver.storage",
+      "qualname": "FileStore",
+      "signature": "(base_dir: Path | str) -> None"
+    },
+    "Flow": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "description": "str",
+        "deterministic": "bool",
+        "input_schema_ref": "str | NoneType",
+        "name": "str",
+        "output_schema_ref": "str | NoneType",
+        "status": "chainweaver.flow.FlowStatus",
+        "steps": "list[chainweaver.flow.FlowStep]",
+        "tool_schema_hashes": "dict[str, str] | NoneType",
+        "trigger_conditions": "dict[str, Any] | NoneType",
+        "version": "str"
+      },
+      "module": "chainweaver.flow",
+      "qualname": "Flow",
+      "signature": "(*, name: str, version: str, description: str, steps: list[chainweaver.flow.FlowStep], deterministic: bool = True, status: chainweaver.flow.FlowStatus = chainweaver.flow.FlowStatus.ACTIVE, trigger_conditions: dict[str, Any] | NoneType = None, input_schema_ref: str | NoneType = None, output_schema_ref: str | NoneType = None, tool_schema_hashes: dict[str, str] | NoneType = None) -> None"
+    },
+    "FlowAlreadyExistsError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "FlowAlreadyExistsError",
+      "signature": "(flow_name: str) -> None"
+    },
+    "FlowBuilder": {
+      "kind": "class",
+      "module": "chainweaver.builder",
+      "qualname": "FlowBuilder",
+      "signature": "(name: str, description: str) -> None"
+    },
+    "FlowBuilderError": {
+      "kind": "class",
+      "module": "chainweaver.builder",
+      "qualname": "FlowBuilderError",
+      "signature": "(detail: str) -> None"
+    },
+    "FlowExecutionError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "FlowExecutionError",
+      "signature": "(tool_name: str, step_index: int, detail: str) -> None"
+    },
+    "FlowExecutor": {
+      "kind": "class",
+      "module": "chainweaver.executor",
+      "qualname": "FlowExecutor",
+      "signature": "(registry: FlowRegistry, *, cost_profile: CostProfile | None = None, redaction_policy: RedactionPolicy | None = None, trace_recorder: TraceRecorder | None = None) -> None"
+    },
+    "FlowNotFoundError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "FlowNotFoundError",
+      "signature": "(flow_name: str, *, version: str | None = None) -> None"
+    },
+    "FlowRegistry": {
+      "kind": "class",
+      "module": "chainweaver.registry",
+      "qualname": "FlowRegistry",
+      "signature": "(store: RegistryStore | None = None) -> None"
+    },
+    "FlowSerializationError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "FlowSerializationError",
+      "signature": "(detail: str, *, source: str | None = None) -> None"
+    },
+    "FlowStatus": {
+      "kind": "enum",
+      "module": "chainweaver.flow",
+      "qualname": "FlowStatus",
+      "signature": "(*values)"
+    },
+    "FlowStatusError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "FlowStatusError",
+      "signature": "(flow_name: str, status: str) -> None"
+    },
+    "FlowStep": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "input_mapping": "dict[str, Any]",
+        "on_error": "str",
+        "retry": "chainweaver.flow.RetryPolicy | NoneType",
+        "tool_name": "str"
+      },
+      "module": "chainweaver.flow",
+      "qualname": "FlowStep",
+      "signature": "(*, tool_name: str, input_mapping: dict[str, Any] = <factory>, retry: chainweaver.flow.RetryPolicy | NoneType = None, on_error: str = 'fail') -> None"
+    },
+    "InMemoryStore": {
+      "kind": "class",
+      "module": "chainweaver.storage",
+      "qualname": "InMemoryStore",
+      "signature": "() -> None"
+    },
+    "InputMappingError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "InputMappingError",
+      "signature": "(tool_name: str, step_index: int, key: str) -> None"
+    },
+    "InvalidFlowVersionError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "InvalidFlowVersionError",
+      "signature": "(flow_name: str, version: str, detail: str) -> None"
+    },
+    "ObservedStep": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "duration_ms": "float",
+        "inputs": "dict[str, Any]",
+        "outputs": "dict[str, Any] | NoneType",
+        "recorded_at": "datetime.datetime",
+        "tool_name": "str"
+      },
+      "module": "chainweaver.observation",
+      "qualname": "ObservedStep",
+      "signature": "(*, tool_name: str, inputs: dict[str, Any], outputs: dict[str, Any] | NoneType = None, recorded_at: datetime.datetime, duration_ms: float = 0.0) -> None"
+    },
+    "ObservedTrace": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "ended_at": "datetime.datetime | NoneType",
+        "source": "str",
+        "started_at": "datetime.datetime",
+        "steps": "list[chainweaver.observation.ObservedStep]",
+        "trace_id": "str"
+      },
+      "module": "chainweaver.observation",
+      "qualname": "ObservedTrace",
+      "signature": "(*, trace_id: str, source: str, started_at: datetime.datetime, ended_at: datetime.datetime | NoneType = None, steps: list[chainweaver.observation.ObservedStep] = <factory>) -> None"
+    },
+    "RedactionPolicy": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "max_value_length": "int | NoneType",
+        "redact_keys": "frozenset[str]",
+        "redact_pattern": "re.Pattern[str] | NoneType",
+        "redact_replacement": "str"
+      },
+      "module": "chainweaver.log_utils",
+      "qualname": "RedactionPolicy",
+      "signature": "(*, redact_keys: frozenset[str] = frozenset({'api_key', 'apikey', 'authorization', 'password', 'secret', 'token'}), redact_pattern: re.Pattern[str] | NoneType = None, max_value_length: int | NoneType = None, redact_replacement: str = '***REDACTED***') -> None"
+    },
+    "RegistryStore": {
+      "kind": "class",
+      "module": "chainweaver.storage",
+      "qualname": "RegistryStore",
+      "signature": "(*args, **kwargs)"
+    },
+    "ReplayMode": {
+      "kind": "enum",
+      "module": "chainweaver.executor",
+      "qualname": "ReplayMode",
+      "signature": "(*values)"
+    },
+    "ReplayResult": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "all_steps_match": "bool",
+        "diffs": "list[chainweaver.executor.StepDiff]",
+        "mode": "chainweaver.executor.ReplayMode",
+        "new_result": "ForwardRef('ExecutionResult')",
+        "original_trace_id": "str"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "ReplayResult",
+      "signature": "(**data: Any) -> None"
+    },
+    "RetryPolicy": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "backoff_multiplier": "float",
+        "backoff_seconds": "float",
+        "jitter": "bool",
+        "max_retries": "int",
+        "retryable_errors": "tuple[str, Ellipsis]"
+      },
+      "module": "chainweaver.flow",
+      "qualname": "RetryPolicy",
+      "signature": "(*, max_retries: Annotated[int, annotated_types.Ge(ge=0)] = 3, backoff_seconds: Annotated[float, annotated_types.Ge(ge=0)] = 1.0, backoff_multiplier: Annotated[float, annotated_types.Ge(ge=1)] = 2.0, jitter: bool = False, retryable_errors: tuple[str, Ellipsis] = ('builtins:Exception',)) -> None"
+    },
+    "SchemaValidationError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "SchemaValidationError",
+      "signature": "(tool_name: str, step_index: int, detail: str, *, context: str = 'tool') -> None"
+    },
+    "StepDiff": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "actual": "Any",
+        "expected": "Any",
+        "field": "str",
+        "step_index": "int",
+        "tool_name": "str"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "StepDiff",
+      "signature": "(*, step_index: int, tool_name: str, field: str, expected: Any, actual: Any) -> None"
+    },
+    "StepPlan": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "input_schema": "dict[str, str]",
+        "input_sources": "dict[str, str]",
+        "output_schema": "dict[str, str]",
+        "step_index": "int",
+        "tool_name": "str",
+        "unresolved_keys": "list[str]",
+        "warnings": "list[str]"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "StepPlan",
+      "signature": "(*, step_index: int, tool_name: str, input_sources: dict[str, str], input_schema: dict[str, str] = <factory>, output_schema: dict[str, str] = <factory>, unresolved_keys: list[str] = <factory>, warnings: list[str] = <factory>) -> None"
+    },
+    "StepRecord": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "duration_ms": "float",
+        "ended_at": "datetime.datetime",
+        "error_message": "str | NoneType",
+        "error_type": "str | NoneType",
+        "inputs": "dict[str, Any]",
+        "outputs": "dict[str, Any] | NoneType",
+        "retry_count": "int",
+        "retry_errors": "list[str]",
+        "skipped": "bool",
+        "started_at": "datetime.datetime",
+        "step_index": "int",
+        "success": "bool",
+        "tool_name": "str"
+      },
+      "module": "chainweaver.executor",
+      "qualname": "StepRecord",
+      "signature": "(*, step_index: int, tool_name: str, inputs: dict[str, Any], outputs: dict[str, Any] | NoneType = None, error_type: str | NoneType = None, error_message: str | NoneType = None, success: bool = True, started_at: datetime.datetime, ended_at: datetime.datetime, duration_ms: float, retry_count: int = 0, retry_errors: list[str] = <factory>, skipped: bool = False) -> None"
+    },
+    "Tool": {
+      "kind": "class",
+      "module": "chainweaver.tools",
+      "qualname": "Tool",
+      "signature": "(*, name: str, description: str, input_schema: type[BaseModel], output_schema: type[BaseModel], fn: Callable[[Any], dict[str, Any]], timeout_seconds: float | None = None, max_output_size: int | None = None, schema_version: str = '0.0.0') -> None"
+    },
+    "ToolDefinitionError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "ToolDefinitionError",
+      "signature": "(function_name: str, detail: str) -> None"
+    },
+    "ToolNotFoundError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "ToolNotFoundError",
+      "signature": "(tool_name: str) -> None"
+    },
+    "ToolOutputSizeError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "ToolOutputSizeError",
+      "signature": "(tool_name: str, size: int, max_size: int) -> None"
+    },
+    "ToolTimeoutError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "ToolTimeoutError",
+      "signature": "(tool_name: str, timeout_seconds: float) -> None"
+    },
+    "TraceRecorder": {
+      "kind": "class",
+      "module": "chainweaver.observation",
+      "qualname": "TraceRecorder",
+      "signature": "() -> None"
+    },
+    "check_flow_compatibility": {
+      "kind": "function",
+      "module": "chainweaver.compat",
+      "qualname": "check_flow_compatibility",
+      "signature": "(flow: Flow, tools: dict[str, Tool]) -> list[CompatibilityIssue]"
+    },
+    "cli": {
+      "kind": "module",
+      "module": null,
+      "qualname": "chainweaver.cli"
+    },
+    "compile_flow": {
+      "kind": "function",
+      "module": "chainweaver.compiler",
+      "qualname": "compile_flow",
+      "signature": "(flow: Flow, tools: dict[str, Tool]) -> CompilationResult"
+    },
+    "flow_from_dict": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_from_dict",
+      "signature": "(data: dict[str, Any]) -> AnyFlow"
+    },
+    "flow_from_json": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_from_json",
+      "signature": "(data: str) -> AnyFlow"
+    },
+    "flow_from_yaml": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_from_yaml",
+      "signature": "(data: str) -> AnyFlow"
+    },
+    "flow_to_ascii": {
+      "kind": "function",
+      "module": "chainweaver.viz",
+      "qualname": "flow_to_ascii",
+      "signature": "(flow: Flow | DAGFlow) -> str"
+    },
+    "flow_to_dict": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_to_dict",
+      "signature": "(flow: AnyFlow) -> dict[str, Any]"
+    },
+    "flow_to_dot": {
+      "kind": "function",
+      "module": "chainweaver.viz",
+      "qualname": "flow_to_dot",
+      "signature": "(flow: Flow | DAGFlow) -> str"
+    },
+    "flow_to_json": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_to_json",
+      "signature": "(flow: AnyFlow, *, indent: int | None = 2) -> str"
+    },
+    "flow_to_mermaid": {
+      "kind": "function",
+      "module": "chainweaver.viz",
+      "qualname": "flow_to_mermaid",
+      "signature": "(flow: Flow | DAGFlow, *, direction: str = 'LR', show_schemas: bool = False) -> str"
+    },
+    "flow_to_yaml": {
+      "kind": "function",
+      "module": "chainweaver.serialization",
+      "qualname": "flow_to_yaml",
+      "signature": "(flow: AnyFlow) -> str"
+    },
+    "result_to_mermaid": {
+      "kind": "function",
+      "module": "chainweaver.viz",
+      "qualname": "result_to_mermaid",
+      "signature": "(result: ExecutionResult, *, direction: str = 'LR') -> str"
+    },
+    "schema_fingerprint": {
+      "kind": "function",
+      "module": "chainweaver.compat",
+      "qualname": "schema_fingerprint",
+      "signature": "(model: type[BaseModel]) -> str"
+    },
+    "tool": {
+      "kind": "function",
+      "module": "chainweaver.decorators",
+      "qualname": "tool",
+      "signature": "(fn: Callable[..., Any] | None = None, *, name: str | None = None, description: str | None = None) -> _DecoratedTool | Callable[[Callable[..., Any]], _DecoratedTool]"
+    },
+    "validate_dag_topology": {
+      "kind": "function",
+      "module": "chainweaver.flow",
+      "qualname": "validate_dag_topology",
+      "signature": "(flow: DAGFlow) -> None"
+    }
+  }
+}

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -271,8 +271,7 @@
     "FlowStatus": {
       "kind": "enum",
       "module": "chainweaver.flow",
-      "qualname": "FlowStatus",
-      "signature": "(*values)"
+      "qualname": "FlowStatus"
     },
     "FlowStatusError": {
       "kind": "class",
@@ -357,8 +356,7 @@
     "ReplayMode": {
       "kind": "enum",
       "module": "chainweaver.executor",
-      "qualname": "ReplayMode",
-      "signature": "(*values)"
+      "qualname": "ReplayMode"
     },
     "ReplayResult": {
       "kind": "pydantic-model",

--- a/tests/public_api_snapshot.py
+++ b/tests/public_api_snapshot.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import inspect
+import json
+import types
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Any, Literal, Union, cast, get_args, get_origin
+
+from pydantic import BaseModel
+
+import chainweaver
+
+SNAPSHOT_PATH = Path(__file__).resolve().parent / "fixtures" / "public_api.json"
+
+Snapshot = dict[str, Any]
+
+
+def build_public_api_snapshot() -> Snapshot:
+    """Return the current ChainWeaver public API surface in a stable shape."""
+    public_names = sorted(chainweaver.__all__)
+    return {
+        "__all__": public_names,
+        "symbols": {name: _snapshot_symbol(getattr(chainweaver, name)) for name in public_names},
+    }
+
+
+def load_public_api_snapshot(path: Path = SNAPSHOT_PATH) -> Snapshot:
+    return cast(Snapshot, json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_public_api_snapshot(snapshot: Snapshot, path: Path = SNAPSHOT_PATH) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _snapshot_symbol(obj: object) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "kind": _symbol_kind(obj),
+        "module": getattr(obj, "__module__", None),
+        "qualname": getattr(obj, "__qualname__", getattr(obj, "__name__", None)),
+    }
+
+    if inspect.isclass(obj) or inspect.isfunction(obj):
+        entry["signature"] = _safe_signature(obj)
+
+    if _is_pydantic_model(obj):
+        model = cast(type[BaseModel], obj)
+        entry["model_fields"] = {
+            name: _annotation_repr(field.annotation)
+            for name, field in sorted(model.model_fields.items())
+        }
+
+    return entry
+
+
+def _symbol_kind(obj: object) -> str:
+    if inspect.ismodule(obj):
+        return "module"
+    if inspect.isclass(obj):
+        if issubclass(obj, Enum):
+            return "enum"
+        if issubclass(obj, BaseModel):
+            return "pydantic-model"
+        return "class"
+    if inspect.isfunction(obj):
+        return "function"
+    return type(obj).__name__
+
+
+def _is_pydantic_model(obj: object) -> bool:
+    return inspect.isclass(obj) and issubclass(obj, BaseModel)
+
+
+def _safe_signature(obj: object) -> str | None:
+    try:
+        return _signature_repr(inspect.signature(cast(Any, obj)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _signature_repr(signature: inspect.Signature) -> str:
+    params = list(signature.parameters.values())
+    has_var_positional = any(param.kind is inspect.Parameter.VAR_POSITIONAL for param in params)
+    seen_keyword_only = False
+    parts: list[str] = []
+
+    for index, param in enumerate(params):
+        if (
+            param.kind is inspect.Parameter.KEYWORD_ONLY
+            and not has_var_positional
+            and not seen_keyword_only
+        ):
+            parts.append("*")
+            seen_keyword_only = True
+
+        parts.append(_parameter_repr(param))
+
+        next_param = params[index + 1] if index + 1 < len(params) else None
+        if param.kind is inspect.Parameter.POSITIONAL_ONLY and (
+            next_param is None or next_param.kind is not inspect.Parameter.POSITIONAL_ONLY
+        ):
+            parts.append("/")
+
+    return_annotation = _annotation_repr(signature.return_annotation)
+    suffix = f" -> {return_annotation}" if return_annotation else ""
+    return f"({', '.join(parts)}){suffix}"
+
+
+def _parameter_repr(param: inspect.Parameter) -> str:
+    prefix = ""
+    if param.kind is inspect.Parameter.VAR_POSITIONAL:
+        prefix = "*"
+    elif param.kind is inspect.Parameter.VAR_KEYWORD:
+        prefix = "**"
+
+    text = f"{prefix}{param.name}"
+    annotation = _annotation_repr(param.annotation)
+    if annotation:
+        text = f"{text}: {annotation}"
+
+    default = _default_repr(param.default)
+    if default:
+        text = f"{text} = {default}"
+
+    return text
+
+
+def _annotation_repr(value: object) -> str:
+    if value is inspect.Signature.empty:
+        return ""
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "None"
+    if value is Any:
+        return "Any"
+
+    origin = get_origin(value)
+    args = get_args(value)
+
+    if origin is None:
+        return _name_or_repr(value)
+
+    if origin in {Union, types.UnionType}:
+        return " | ".join(_annotation_repr(arg) for arg in args)
+    if origin is Annotated:
+        return (
+            "Annotated["
+            + ", ".join([_annotation_repr(args[0]), *(_default_repr(arg) for arg in args[1:])])
+            + "]"
+        )
+    if origin is Literal:
+        return "Literal[" + ", ".join(_default_repr(arg) for arg in args) + "]"
+
+    origin_name = _name_or_repr(origin)
+    if not args:
+        return origin_name
+    return f"{origin_name}[{', '.join(_annotation_repr(arg) for arg in args)}]"
+
+
+def _name_or_repr(value: object) -> str:
+    module = getattr(value, "__module__", "")
+    qualname = getattr(value, "__qualname__", getattr(value, "__name__", None))
+
+    if qualname is not None:
+        if module in {"", "builtins", "typing"}:
+            return str(qualname)
+        return f"{module}.{qualname}"
+
+    text = repr(value)
+    if text.startswith("typing."):
+        return text.removeprefix("typing.")
+    return text
+
+
+def _default_repr(value: object) -> str:
+    if value is inspect.Signature.empty:
+        return ""
+    if value is Ellipsis:
+        return "..."
+    if is_dataclass(value) and value.__class__.__module__ == "annotated_types":
+        return _dataclass_repr(value)
+    if isinstance(value, Enum):
+        return f"{_name_or_repr(value.__class__)}.{value.name}"
+    if inspect.isclass(value):
+        return _name_or_repr(value)
+    if isinstance(value, str):
+        return repr(value)
+    if isinstance(value, (int, float, bool, type(None))):
+        return repr(value)
+    if isinstance(value, frozenset):
+        return _sequence_repr("frozenset", sorted(value, key=repr))
+    if isinstance(value, set):
+        return _sequence_repr("set", sorted(value, key=repr))
+    if isinstance(value, tuple):
+        return _sequence_repr("tuple", value)
+    if isinstance(value, list):
+        return _sequence_repr("list", value)
+    if isinstance(value, Mapping):
+        return _mapping_repr(value)
+
+    text = repr(value)
+    if text == "<factory>":
+        return text
+    return text
+
+
+def _dataclass_repr(value: object) -> str:
+    items = []
+    for field in fields(cast(Any, value)):
+        field_value = getattr(value, field.name)
+        items.append(f"{field.name}={_metadata_value_repr(field_value)}")
+    return f"{_name_or_repr(value.__class__)}({', '.join(items)})"
+
+
+def _metadata_value_repr(value: object) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return _default_repr(value)
+
+
+def _sequence_repr(kind: str, values: Sequence[object]) -> str:
+    inner = ", ".join(_default_repr(item) for item in values)
+    if kind == "tuple":
+        if len(values) == 1:
+            inner = f"{inner},"
+        return f"({inner})"
+    if kind == "list":
+        return f"[{inner}]"
+    return f"{kind}({{{inner}}})"
+
+
+def _mapping_repr(values: Mapping[object, object]) -> str:
+    items = sorted(values.items(), key=lambda item: repr(item[0]))
+    inner = ", ".join(f"{_default_repr(key)}: {_default_repr(value)}" for key, value in items)
+    return f"{{{inner}}}"

--- a/tests/public_api_snapshot.py
+++ b/tests/public_api_snapshot.py
@@ -46,7 +46,7 @@ def _snapshot_symbol(obj: object) -> dict[str, Any]:
         "qualname": getattr(obj, "__qualname__", getattr(obj, "__name__", None)),
     }
 
-    if inspect.isclass(obj) or inspect.isfunction(obj):
+    if (inspect.isclass(obj) and not issubclass(obj, Enum)) or inspect.isfunction(obj):
         entry["signature"] = _safe_signature(obj)
 
     if _is_pydantic_model(obj):

--- a/tests/scripts/regen_public_api.py
+++ b/tests/scripts/regen_public_api.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TESTS = ROOT / "tests"
+
+for path in (ROOT, TESTS):
+    path_text = str(path)
+    if path_text not in sys.path:
+        sys.path.insert(0, path_text)
+
+from public_api_snapshot import (  # noqa: E402
+    SNAPSHOT_PATH,
+    build_public_api_snapshot,
+    write_public_api_snapshot,
+)
+
+
+def main() -> None:
+    write_public_api_snapshot(build_public_api_snapshot(), SNAPSHOT_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_public_api_snapshot.py
+++ b/tests/test_public_api_snapshot.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from public_api_snapshot import (
+    build_public_api_snapshot,
+    load_public_api_snapshot,
+)
+
+
+def test_public_api_snapshot_matches_fixture() -> None:
+    expected = load_public_api_snapshot()
+    actual = build_public_api_snapshot()
+
+    assert actual == expected, (
+        "Public API snapshot changed. If the public API change is intentional, "
+        "run `python tests/scripts/regen_public_api.py` and commit the updated "
+        "`tests/fixtures/public_api.json`."
+    )


### PR DESCRIPTION
## Summary

Adds a public API snapshot guard for `chainweaver.__all__`, exported class/function signatures, and exported Pydantic model fields. Prepared with AI assistance and verified locally.

## Changes

- Add `tests/public_api_snapshot.py` and `tests/test_public_api_snapshot.py`.
- Add the initial deterministic fixture at `tests/fixtures/public_api.json`.
- Add `tests/scripts/regen_public_api.py` for intentional public API changes.
- Add the regeneration step to the review checklist.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`)
- [x] New tests added for new functionality

Additional validation:

- `python tests/scripts/regen_public_api.py` ran in 500.43 ms locally and produced a stable fixture hash on repeat regeneration.
- Smoke check confirmed the snapshot changes when a public symbol is removed, a public class signature changes, or a Pydantic model field changes.
- `git diff --cached --check`
- `git diff --cached | gitleaks detect --pipe --redact --verbose --no-color`

## Related Issues

Closes #140

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented
- [x] No secrets or credentials included

Limitations: this intentionally does not snapshot docstrings, matching the issue scope.