### PR TITLE
docs, test: harden newcomer onboarding (#194, #202, #203, #208, #209, #212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,60 @@ result = executor.execute_flow("calc", {"number": 5})
 
 ---
 
+## See it in 30 seconds
+
+**The problem.** Your agent keeps doing the same path —
+`search → extract → validate → format` — but on every single turn it
+round-trips through the LLM between each tool call to "decide" what to
+do next.  That's four model calls to execute one deterministic
+operation.
+
+**Before — naive agent loop, 4 model-mediated decisions:**
+
+```
+turn 1   ─►  LLM("plan")    ─►  search(query)         ─► 12 results
+turn 2   ─►  LLM("next?")   ─►  extract(results)      ─► 8 facts
+turn 3   ─►  LLM("next?")   ─►  validate(facts)       ─► 7 facts
+turn 4   ─►  LLM("next?")   ─►  format(facts)         ─► answer
+                                                          ⏱  ~6 s, 4 LLM calls
+```
+
+**After — same path, compiled once into a named ChainWeaver flow:**
+
+```
+turn 1   ─►  LLM("plan")    ─►  search_summarize_flow(query)
+                                  └─ search ─► extract ─► validate ─► format
+                                                          ⏱  ~1 s, 1 LLM call
+```
+
+The agent still decides *which* flow to invoke (that part stays
+open-ended).  The four tool calls inside the flow no longer round-trip
+through the model — `FlowExecutor` runs them with strict Pydantic
+validation between every step and zero LLM involvement.
+
+**Copy-paste quick path:**
+
+```bash
+pip install 'chainweaver[yaml]'
+python examples/simple_linear_flow.py
+```
+
+```
+flow=double_add_format success=True
+final_output={'number': 5, 'value': 20, 'result': 'Final value: 20'}
+step 0 double          {'value': 10}
+step 1 add_ten         {'value': 20}
+step 2 format_result   {'result': 'Final value: 20'}
+```
+
+That's a real `ExecutionResult` — three tool calls, no LLM in the loop,
+fully reproducible from `examples/double_add_format.flow.yaml`.  Jump
+to the [Quick Start](#quick-start) for the Python version, or to the
+[Command-line interface](#command-line-interface) for the no-Python
+path.
+
+---
+
 ## Why ChainWeaver?
 
 When an LLM-powered agent routes tools together — `fetch_data → transform → store` — a
@@ -161,23 +215,68 @@ on each minor release of any of the projects above.
 For the correctness argument behind the design, see
 [docs/data-integrity.md](docs/data-integrity.md).
 
+### Where ChainWeaver fits in the Weaver Stack
+
+ChainWeaver is the **deterministic multi-step tool execution** seam of
+the broader [Weaver Stack](https://github.com/dgenio/weaver-spec): the
+loose family of SDKs that share `weaver-spec`'s `SelectableItem`
+contract for capability routing.  In one line: the agent or the host's
+router decides *which* capability to invoke, and ChainWeaver runs the
+deterministic tool path *behind* that capability.
+
+| Layer | What it owns | Sibling project |
+|-------|--------------|-----------------|
+| Routing / capability selection | "Which named operation handles this request?" | `weaver-spec` (#91, #107 — `SelectableItem` contract) |
+| Context assembly | "What facts and tool descriptions belong in the prompt?" | `contextweaver` (#106) |
+| Agent kernel | The model-mediated tool-use loop itself | `agent-kernel` (#89) |
+| **Deterministic flow execution** | "Run this exact tool sequence with strict schemas, no LLM between steps" | **ChainWeaver — this repo** |
+| Lessons & evaluation | Turning traces into reviewed operational guidance | `lessonweaver` (#210) |
+
+ChainWeaver does **not** replace an agent framework.  It is meant to be
+called *from* one — see the [LangGraph
+recipe](#command-line-interface) (issue #205) and the [OpenAI Agents
+SDK recipe](#command-line-interface) (issue #206) once they land for
+the canonical integration patterns.  None of the sibling packages above
+is a hard dependency; the `chainweaver[weaver-stack]` extra is a
+placeholder that will pin them when they ship on PyPI.
+
+For host-level expectations (when to invoke, how to store traces,
+side-effect tools, MCP parity), see the
+[Runtime responsibilities](docs/runtime-responsibilities.md) page.
+
 ---
 
 ## Installation
 
 ```bash
-pip install chainweaver
+pip install chainweaver                  # base install — no extras
+pip install 'chainweaver[yaml]'          # most common — needed for .flow.yaml files
+pip install 'chainweaver[yaml,otel,mcp]' # combine extras with commas
 ```
 
-Optional extras:
+The base install pulls only five runtime dependencies (`deepdiff`,
+`packaging`, `pydantic`, `tenacity`, `typer`) and has no transitive LLM
+SDK pinned.  Pick extras for the integrations you actually use:
 
-| Extra | Use when |
-|-------|----------|
-| `chainweaver[yaml]` | Reading / writing `.flow.yaml` files |
-| `chainweaver[otel]` | Emitting OpenTelemetry spans for every flow run |
-| `chainweaver[contrib]` | Importing the curated standard tool library (see [Standard tool library](#standard-tool-library)) |
-| `chainweaver[langchain]` | Bidirectional adapters between ChainWeaver and LangChain `BaseTool` |
-| `chainweaver[llamaindex]` | Bidirectional adapters between ChainWeaver and LlamaIndex `FunctionTool` |
+| Extra | Use when | Pulls in |
+|-------|----------|----------|
+| `chainweaver[yaml]` | Reading / writing `.flow.yaml` flow files (the CLI's `run`, `validate`, `check`, `doctor` commands need this) | `pyyaml` |
+| `chainweaver[otel]` | Emitting OpenTelemetry spans for every flow run | `opentelemetry-api` |
+| `chainweaver[mcp]` | Exposing flows over MCP via the `chainweaver.mcp` adapter | `mcp` |
+| `chainweaver[contrib]` | Importing the curated standard tool library (see [Standard tool library](#standard-tool-library)) | *(no extra deps today)* |
+| `chainweaver[langchain]` | Bidirectional adapters between ChainWeaver and LangChain `BaseTool` | `langchain-core` |
+| `chainweaver[llamaindex]` | Bidirectional adapters between ChainWeaver and LlamaIndex `FunctionTool` | `llama-index-core` |
+| `chainweaver[test]` | Hypothesis-based property tests for your own flows | `hypothesis`, `hypothesis-jsonschema` |
+| `chainweaver[docs]` | Building the docs site locally with mkdocs | `mkdocs`, `mkdocs-material`, `mkdocstrings` |
+| `chainweaver[dev]` | Contributing — pulls every test/lint/type dep and most integration deps | the union of the above |
+
+Package metadata (`pyproject.toml`) publishes URLs for the
+[documentation](https://chainweaver.readthedocs.io/), the
+[source](https://github.com/dgenio/ChainWeaver), the
+[changelog](https://github.com/dgenio/ChainWeaver/blob/main/CHANGELOG.md),
+and the
+[issue tracker](https://github.com/dgenio/ChainWeaver/issues), so `pip
+show chainweaver` and the PyPI sidebar point users to the right place.
 
 ---
 
@@ -185,6 +284,7 @@ Optional extras:
 
 ### Define tools, build a flow, and execute it
 
+<!-- smoke-test: run -->
 ```python
 from pydantic import BaseModel
 from chainweaver import Tool, Flow, FlowStep, FlowRegistry, FlowExecutor
@@ -294,6 +394,7 @@ scripts under `examples/cookbook/`.
 The `@tool` decorator eliminates boilerplate by introspecting type hints to
 auto-generate input schemas:
 
+<!-- smoke-test: run -->
 ```python
 from pydantic import BaseModel
 from chainweaver import tool, Flow, FlowStep, FlowRegistry, FlowExecutor
@@ -534,6 +635,14 @@ In practice:
 3. On subsequent invocations the executor runs the entire flow in a single
    call — no intermediate LLM calls required.
 
+ChainWeaver is **the library you embed**, not the runtime that owns
+your trace store, auth, side-effect policy, or MCP wiring.  Host
+authors should read
+[`docs/runtime-responsibilities.md`](docs/runtime-responsibilities.md)
+to see which responsibilities stay on their side of the seam (deciding
+when to invoke, persisting traces, redacting sensitive outputs,
+idempotency of side-effect tools, MCP authorisation).
+
 ---
 
 ## Error Handling
@@ -733,9 +842,11 @@ chainweaver validate flows/etl.flow.yaml
 chainweaver check flows/                  # whole-directory variant
 
 # Render a registered flow as ASCII or Graphviz DOT.
+# (See note below — `viz` reads from an in-memory registry, not a file.)
 chainweaver viz my_flow --format dot | dot -Tpng -o my_flow.png
 
 # Inspect a registered flow's structure (table or JSON).
+# (See note below — `inspect` reads from an in-memory registry, not a file.)
 chainweaver inspect my_flow --format json
 
 # Analyze ExecutionResult traces — bottlenecks, p50/p95/p99 across runs,
@@ -768,6 +879,30 @@ reporting subcommands also accept `--format json` for machine consumption
 and has no `--format` flag. All subcommands share the same exit-code
 contract (`0` success, `1` business-logic error, `2` file-not-found /
 argument error).
+
+**`inspect` and `viz` need a registry — they don't read from disk.**
+Unlike `run`/`validate`/`check`/`profile`/`diff`/`attest`/`suggest`/`doctor`
+(which load a flow file every time they run), `inspect` and `viz` operate on
+a process-scoped, in-memory registry that **you must install programmatically
+before invoking the CLI**.  Running `chainweaver inspect my_flow` against a
+fresh install will exit `1` with `No registry configured. Call
+chainweaver.cli.set_default_registry(...) before invoking the CLI.` —
+that's expected.  The fix is to wire a small entry script:
+
+```python
+# my_cli_entry.py
+from chainweaver import FlowRegistry
+from chainweaver.cli import main, set_default_registry
+from my_app import build_registry  # returns a populated FlowRegistry
+
+set_default_registry(build_registry())
+main()
+```
+
+See [`docs/cli.md` § Programmatic registration](docs/cli.md#programmatic-registration-inspect-viz)
+for the full pattern, including why the split exists (file-oriented
+commands stay zero-config, registry-oriented commands stay
+introspection-friendly).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ pip install 'chainweaver[yaml]'
 python examples/simple_linear_flow.py
 ```
 
+The summary below is a condensed view of the real
+`ExecutionResult` the script produces — the actual stdout also
+includes per-step timestamps and the executor's structured step
+log, but the values, the step order, and the final output are
+exactly what you get on disk:
+
 ```
 flow=double_add_format success=True
 final_output={'number': 5, 'value': 20, 'result': 'Final value: 20'}
@@ -88,8 +94,8 @@ step 1 add_ten         {'value': 20}
 step 2 format_result   {'result': 'Final value: 20'}
 ```
 
-That's a real `ExecutionResult` — three tool calls, no LLM in the loop,
-fully reproducible from `examples/double_add_format.flow.yaml`.  Jump
+Three tool calls, no LLM in the loop, fully reproducible from
+`examples/double_add_format.flow.yaml`.  Jump
 to the [Quick Start](#quick-start) for the Python version, or to the
 [Command-line interface](#command-line-interface) for the no-Python
 path.
@@ -226,7 +232,7 @@ deterministic tool path *behind* that capability.
 
 | Layer | What it owns | Sibling project |
 |-------|--------------|-----------------|
-| Routing / capability selection | "Which named operation handles this request?" | `weaver-spec` (#91, #107 — `SelectableItem` contract) |
+| Routing / capability selection | "Which named operation handles this request?" | `weaver-spec` (#91 — `SelectableItem` contract) |
 | Context assembly | "What facts and tool descriptions belong in the prompt?" | `contextweaver` (#106) |
 | Agent kernel | The model-mediated tool-use loop itself | `agent-kernel` (#89) |
 | **Deterministic flow execution** | "Run this exact tool sequence with strict schemas, no LLM between steps" | **ChainWeaver — this repo** |
@@ -268,6 +274,7 @@ SDK pinned.  Pick extras for the integrations you actually use:
 | `chainweaver[llamaindex]` | Bidirectional adapters between ChainWeaver and LlamaIndex `FunctionTool` | `llama-index-core` |
 | `chainweaver[test]` | Hypothesis-based property tests for your own flows | `hypothesis`, `hypothesis-jsonschema` |
 | `chainweaver[docs]` | Building the docs site locally with mkdocs | `mkdocs`, `mkdocs-material`, `mkdocstrings` |
+| `chainweaver[weaver-stack]` | Reserving the seam for the sibling Weaver Stack SDKs (`weaver-spec` #91, `contextweaver` #106, `agent-kernel` #89) | *(placeholder — no transitive dep today; will pin them once they ship on PyPI)* |
 | `chainweaver[dev]` | Contributing — pulls every test/lint/type dep and most integration deps | the union of the above |
 
 Package metadata (`pyproject.toml`) publishes URLs for the

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -164,7 +164,7 @@ ExecutionSnapshot.model_rebuild(_types_namespace=_forward_namespace)
 # applications can configure logging centrally without interference.
 logging.getLogger("chainweaver").addHandler(logging.NullHandler())
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 __all__ = [
     "AttestationInputError",

--- a/docs/runtime-responsibilities.md
+++ b/docs/runtime-responsibilities.md
@@ -50,11 +50,15 @@ What the host owns:
 - **Storage lifecycle.** Pick a backend (database, object store,
   append-only log).  Set a retention policy.  Encrypt at rest if the
   tool outputs include sensitive data.
-- **Redaction.** Use `chainweaver.RedactionPolicy` *before* persisting
-  if the inputs or outputs contain secrets, PII, or anything else you
-  don't want in your trace store.  ChainWeaver does not redact by
-  default — `StepRecord.inputs` and `StepRecord.outputs` are recorded
-  verbatim.
+- **Redaction.** `chainweaver.RedactionPolicy` is a dict-level masking
+  filter — it exposes `redact(data: dict) -> dict` and is intended for
+  logs and display.  ChainWeaver does **not** redact
+  `ExecutionResult` / `StepRecord` for you, and `RedactionPolicy` has
+  no `ExecutionResult`-shaped helper today.  If you want redacted
+  persistence, walk `result.execution_log` yourself and apply
+  `policy.redact()` to each step's `inputs` / `outputs` dict before
+  handing the record to your trace store.  `StepRecord.inputs` and
+  `StepRecord.outputs` are recorded verbatim by default.
 - **Index and search.** Decide whether traces are queried by
   `trace_id`, `flow_name`, `flow_version`, time range, or correlation
   ID.  ChainWeaver provides the fields; the host indexes them.
@@ -83,7 +87,7 @@ What the host owns:
   invoke more than once with the same inputs.  Use idempotency keys,
   conditional writes, or upserts as appropriate.
 - **Dry-run and preview modes.** Many hosts want a "show what this
-  flow would do" mode.  Implement it inside the tool (an `dry_run:
+  flow would do" mode.  Implement it inside the tool (a `dry_run:
   bool` field in the input schema) or by registering two variants and
   selecting at flow-build time.  ChainWeaver does not provide a
   framework-level dry-run flag.
@@ -107,8 +111,8 @@ deterministic in the way the host claims they are.
 
 Once a `Flow` is registered, the host should present it to the rest of
 its system as a **single named operation**, not as "a sequence of N
-tool calls".  This is the whole point of compiling tool chains into
-flows.
+tool calls".  This is the whole point of compiling sequences of tool
+calls into flows.
 
 What the host owns:
 
@@ -164,6 +168,8 @@ What the host owns when wearing an MCP-server hat:
 A representative host that owns all five responsibilities at once:
 
 ```python
+from dataclasses import replace
+
 from chainweaver import FlowExecutor, FlowRegistry, RedactionPolicy
 
 # 1. Decide when to invoke — host's routing logic.
@@ -179,8 +185,23 @@ def handle_request(intent: str, payload: dict, caller_id: str) -> dict:
     result = executor.execute_flow(flow.name, payload)
 
     # 3. Persist with redaction — host owns the trace store.
-    redacted = redactor.redact_execution_result(result)
-    trace_store.put(redacted, correlation_id=payload.get("request_id"))
+    #    `RedactionPolicy.redact()` is dict-only, so the host walks
+    #    `execution_log` and applies it per step before persisting.
+    redacted_steps = [
+        replace(
+            step,
+            inputs=redactor.redact(step.inputs),
+            outputs=redactor.redact(step.outputs),
+        )
+        for step in result.execution_log
+    ]
+    trace_store.put_trace(
+        trace_id=result.trace_id,
+        flow_name=flow.name,
+        flow_version=result.flow_version,
+        steps=redacted_steps,
+        correlation_id=payload.get("request_id"),
+    )
 
     # 4. Surface a single named operation back to the caller.
     return {
@@ -194,7 +215,7 @@ def handle_request(intent: str, payload: dict, caller_id: str) -> dict:
 registry = FlowRegistry()
 executor = FlowExecutor(registry=registry)
 redactor = RedactionPolicy(
-    redact_fields=("customer_email", "internal_notes"),
+    redact_keys=frozenset({"customer_email", "internal_notes"}),
 )
 ```
 

--- a/docs/runtime-responsibilities.md
+++ b/docs/runtime-responsibilities.md
@@ -1,0 +1,224 @@
+# Runtime Responsibilities for ChainWeaver Hosts
+
+ChainWeaver is a **library**, not a runtime.  `FlowExecutor` runs one flow
+when you call `execute_flow()` and returns.  Everything *around* that call
+— deciding *when* to run, *what to log*, *what to do with the result*,
+*how to handle side effects* — is the responsibility of the host
+application that embeds ChainWeaver.
+
+This page tells host authors which of those responsibilities ChainWeaver
+explicitly does **not** assume, and how to discharge them in practice.
+
+> **Audience.** Engineers wrapping ChainWeaver behind an HTTP service, an
+> MCP server, an agent loop, a CLI batch runner, or any other process
+> that imports `chainweaver` and calls `FlowExecutor.execute_flow()`.
+
+---
+
+## 1. Deciding when to invoke a flow
+
+ChainWeaver does **not** decide when a flow should run.  It does not
+listen for triggers, schedule itself, or watch external state.
+
+What the host owns:
+
+- Matching the agent's request (or queue message, or HTTP body) to a
+  registered `Flow` name.  `FlowRegistry.match_flow_by_intent()` is a
+  basic substring match — augment it or replace it with a real router
+  for production traffic.
+- Validating that the caller is allowed to run *this* flow.  ChainWeaver
+  does not authenticate or authorise — `executor.execute_flow()` runs
+  whatever you pass it.
+- Rate-limiting, queueing, and back-pressure.  ChainWeaver runs as fast
+  as its tools and will happily saturate downstream systems if you let
+  it.
+
+The reference path is: *host receives a request → host picks a flow
+name → host calls `execute_flow(name, initial_input)`*.  Everything
+before the arrow is host territory.
+
+---
+
+## 2. Treating stored execution traces
+
+`ExecutionResult` contains `execution_log: list[StepRecord]` with full
+inputs and outputs.  ChainWeaver does not persist these — the host
+decides where they go.
+
+What the host owns:
+
+- **Storage lifecycle.** Pick a backend (database, object store,
+  append-only log).  Set a retention policy.  Encrypt at rest if the
+  tool outputs include sensitive data.
+- **Redaction.** Use `chainweaver.RedactionPolicy` *before* persisting
+  if the inputs or outputs contain secrets, PII, or anything else you
+  don't want in your trace store.  ChainWeaver does not redact by
+  default — `StepRecord.inputs` and `StepRecord.outputs` are recorded
+  verbatim.
+- **Index and search.** Decide whether traces are queried by
+  `trace_id`, `flow_name`, `flow_version`, time range, or correlation
+  ID.  ChainWeaver provides the fields; the host indexes them.
+- **Replay correctness.** If the host promises "we can replay any past
+  run," it must guarantee that the same flow version and tool versions
+  are still loadable.  `Flow.tool_schema_hashes` and
+  `chainweaver doctor --check-drift` are the seams for that guarantee.
+
+The host's storage backend is what gives `ExecutionResult.trace_id` its
+durable meaning.  ChainWeaver only generates the UUID.
+
+---
+
+## 3. Describing tools with side effects
+
+`Tool` does not distinguish read-only tools from tools that mutate the
+world.  As far as `FlowExecutor` is concerned, every tool is a pure
+function from `inputs → outputs`.  In reality, your `send_email` tool
+sends email.
+
+What the host owns:
+
+- **Idempotency.** If a flow may be retried (by the executor's tool
+  retry policy, by your service's request-retry policy, or by a human
+  hitting "rerun"), the host's side-effect tools must be safe to
+  invoke more than once with the same inputs.  Use idempotency keys,
+  conditional writes, or upserts as appropriate.
+- **Dry-run and preview modes.** Many hosts want a "show what this
+  flow would do" mode.  Implement it inside the tool (an `dry_run:
+  bool` field in the input schema) or by registering two variants and
+  selecting at flow-build time.  ChainWeaver does not provide a
+  framework-level dry-run flag.
+- **Approval gates.** If a step must wait for human approval, encode
+  that as an upstream tool that blocks until approved — *outside* the
+  flow.  Do not embed approval logic in a ChainWeaver step; the
+  executor's wall-clock budget is the only knob it offers for waiting.
+- **Documentation.** Use the tool's `description` (which appears in
+  every introspection surface, including MCP listings) to declare
+  side-effect semantics so downstream agents and reviewers can audit
+  what a flow will actually do when invoked.
+
+This split — pure executor, host-described side effects — is what
+makes ChainWeaver's "no LLM between steps" guarantee meaningful at
+runtime: the executor is deterministic only if the *tools* are
+deterministic in the way the host claims they are.
+
+---
+
+## 4. Treating compiled flows as higher-level operations
+
+Once a `Flow` is registered, the host should present it to the rest of
+its system as a **single named operation**, not as "a sequence of N
+tool calls".  This is the whole point of compiling tool chains into
+flows.
+
+What the host owns:
+
+- **Naming and discovery.** A flow's `name` and `description` are what
+  agents, MCP clients, and human operators see.  Pick names that
+  describe *the deterministic operation*, not the implementation steps
+  inside.
+- **Versioning policy.** `Flow.version` is a SemVer string.  The host
+  decides what counts as a backwards-incompatible change to a flow:
+  changing the set of input fields, changing the output schema, or
+  swapping a tool that the host's downstream consumers depend on.
+- **Stable inputs and outputs.** Even if the internal steps change, the
+  flow's contract (its first-step input shape and its final-context
+  shape) is what the host's callers depend on.  Use the optional
+  `input_schema_ref` and `output_schema_ref` to lock that contract.
+- **Surfacing flows as tools.** If the host re-exposes flows to an
+  upstream agent (the canonical MCP integration), each flow should
+  appear as a single tool with a single schema-validated input and
+  output — not as N separate tools.
+
+---
+
+## 5. MCP examples must preserve the same expectations
+
+`chainweaver[mcp]` ships an MCP adapter (`chainweaver/mcp/`).  When a
+host exposes ChainWeaver flows over MCP, the same responsibilities apply
+as for any direct tool registration — the MCP transport is not a
+loophole.
+
+What the host owns when wearing an MCP-server hat:
+
+- **Authorisation per call.** Just because a tool is reachable over MCP
+  does not mean every connected client should be able to call every
+  flow.  Apply your auth model at the MCP server boundary.
+- **Side-effect parity.** A flow that sends email when called directly
+  must send email when called over MCP.  Do not silently switch tools
+  to a no-op variant for the MCP transport "for safety" — that breaks
+  the host's contract with its callers.  If you want a no-op variant
+  for testing, expose it as a separately named flow.
+- **Schema fidelity.** The MCP `inputSchema` should reflect the flow's
+  *actual* first-step input schema (or its `input_schema_ref` if set),
+  not a hand-written summary.  `flow_to_selectable_item` derives this
+  correctly; prefer it over hand-rolled MCP descriptors.
+- **Trace propagation.** If the MCP client passes a correlation ID,
+  forward it into the host's trace store entry for the resulting
+  `ExecutionResult`.  ChainWeaver does not parse MCP request metadata
+  on the host's behalf.
+
+---
+
+## Concrete example: a deterministic invoice-reminder host
+
+A representative host that owns all five responsibilities at once:
+
+```python
+from chainweaver import FlowExecutor, FlowRegistry, RedactionPolicy
+
+# 1. Decide when to invoke — host's routing logic.
+def handle_request(intent: str, payload: dict, caller_id: str) -> dict:
+    if not host_acl.allows(caller_id, intent):     # host owns auth
+        raise PermissionError(intent)
+
+    flow = registry.match_flow_by_intent(intent)
+    if flow is None:
+        return {"status": "no_flow_matched"}
+
+    # 2. Run the flow — ChainWeaver's deterministic step.
+    result = executor.execute_flow(flow.name, payload)
+
+    # 3. Persist with redaction — host owns the trace store.
+    redacted = redactor.redact_execution_result(result)
+    trace_store.put(redacted, correlation_id=payload.get("request_id"))
+
+    # 4. Surface a single named operation back to the caller.
+    return {
+        "operation": flow.name,
+        "version": result.flow_version,
+        "success": result.success,
+        "output": result.final_output,
+        "trace_id": result.trace_id,
+    }
+
+registry = FlowRegistry()
+executor = FlowExecutor(registry=registry)
+redactor = RedactionPolicy(
+    redact_fields=("customer_email", "internal_notes"),
+)
+```
+
+ChainWeaver provides the inner two lines (`execute_flow`,
+`RedactionPolicy`).  The host owns everything outside them.
+
+---
+
+## Scope of these guarantees
+
+This page is **practical guidance**, not a contract.  ChainWeaver does
+not enforce any of the responsibilities above at the framework level —
+that would defeat the "just a library" property that lets you embed it
+anywhere.  Treat this page as a checklist for host code review, not as
+a list of features ChainWeaver promises to provide.
+
+See also:
+
+- [`docs/cli.md`](cli.md) — `chainweaver doctor --check-drift`, the
+  seam for catching tool-schema drift that breaks replayability.
+- [`docs/data-integrity.md`](data-integrity.md) — the correctness
+  argument for why ChainWeaver's executor is the deterministic part.
+- [`docs/security.md`](security.md) — the security model for the
+  library proper (input validation, no `eval`, redaction primitives).
+- [`AGENTS.md`](https://github.com/dgenio/ChainWeaver/blob/main/AGENTS.md)
+  — the canonical contributor map, including the executor's three
+  hard invariants.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Is this for me?:
       - When ChainWeaver fits: boundaries.md
       - Data integrity guarantees: data-integrity.md
+      - Runtime responsibilities for hosts: runtime-responsibilities.md
       - vs LangChain, Prefect, Dagster, Temporal, LangGraph: comparisons.md
   - Cookbook:
       - Overview: cookbook/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ keywords = [
     "tools",
     "pydantic",
     "flow",
-    "pipeline",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,18 @@ description = "Deterministic orchestration layer for MCP-based agents."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
-keywords = ["mcp", "agents", "orchestration", "deterministic", "workflow"]
+keywords = [
+    "mcp",
+    "agents",
+    "orchestration",
+    "deterministic",
+    "workflow",
+    "llm",
+    "tools",
+    "pydantic",
+    "flow",
+    "pipeline",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -99,6 +110,10 @@ dev = [
 
 [project.urls]
 "Homepage" = "https://github.com/dgenio/ChainWeaver"
+"Documentation" = "https://chainweaver.readthedocs.io/"
+"Source" = "https://github.com/dgenio/ChainWeaver"
+"Changelog" = "https://github.com/dgenio/ChainWeaver/blob/main/CHANGELOG.md"
+"Issues" = "https://github.com/dgenio/ChainWeaver/issues"
 "Bug Tracker" = "https://github.com/dgenio/ChainWeaver/issues"
 
 [tool.pytest.ini_options]

--- a/tests/test_metadata_consistency.py
+++ b/tests/test_metadata_consistency.py
@@ -1,0 +1,116 @@
+"""Package metadata anti-drift (#203, #209).
+
+These tests fail when the three version sources fall out of sync:
+
+- ``pyproject.toml`` ``[project]`` ``version``
+- ``chainweaver.__version__`` at runtime
+- the latest released heading in ``CHANGELOG.md`` (``## [x.y.z] - YYYY-MM-DD``)
+
+Historical drift example: ``pyproject.toml`` was bumped to 0.10.0 in the
+release commit but ``chainweaver/__init__.py`` still reported 0.9.0 to
+``pip show`` consumers and to anyone introspecting ``chainweaver.__version__``.
+This file catches that class of bug at CI time, before the next release.
+
+The tests also check that ``pyproject.toml`` declares the project URLs the
+PyPI sidebar and ``pip show chainweaver`` expose to users.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import chainweaver
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+
+
+def _pyproject_table() -> dict[str, Any]:
+    """Load ``pyproject.toml`` via stdlib ``tomllib`` (3.11+) or a regex fallback.
+
+    ChainWeaver supports Python >=3.10 (see ``pyproject.toml``).  ``tomllib``
+    ships with the stdlib from 3.11.  Rather than add ``tomli`` to the dev
+    deps for the single 3.10 leg, we fall back to a minimal regex parser
+    that only handles the keys we read here.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        with _PYPROJECT.open("rb") as handle:
+            return tomllib.load(handle)
+    # Fallback: read just the keys we need.
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    table: dict[str, Any] = {"project": {}, "urls": {}}
+    version_match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if version_match:
+        table["project"]["version"] = version_match.group(1)
+    urls_block = re.search(
+        r"^\[project\.urls\]\n(.*?)(?=^\[|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if urls_block:
+        for line in urls_block.group(1).splitlines():
+            entry = re.match(r'\s*"([^"]+)"\s*=\s*"([^"]+)"', line)
+            if entry:
+                table["urls"][entry.group(1)] = entry.group(2)
+    table["project"]["urls"] = table["urls"]
+    return table
+
+
+def _pyproject_version() -> str:
+    return cast(str, _pyproject_table()["project"]["version"])
+
+
+def _latest_changelog_version() -> str:
+    """Return the most recent released version heading from ``CHANGELOG.md``.
+
+    Skips the ``## [Unreleased]`` heading.  Expects ``## [x.y.z] - YYYY-MM-DD``.
+    """
+    text = _CHANGELOG.read_text(encoding="utf-8")
+    for match in re.finditer(r"^## \[(.+?)\]", text, re.MULTILINE):
+        version = match.group(1).strip()
+        if version.lower() != "unreleased":
+            return version
+    pytest.fail(f"No released version heading found in {_CHANGELOG}")
+
+
+def test_pyproject_version_matches_runtime_version() -> None:
+    """``pyproject.toml`` and ``chainweaver.__version__`` must agree."""
+    assert _pyproject_version() == chainweaver.__version__, (
+        f"version drift: pyproject.toml={_pyproject_version()!r} "
+        f"but chainweaver.__version__={chainweaver.__version__!r}"
+    )
+
+
+def test_changelog_top_release_matches_runtime_version() -> None:
+    """The latest released ``## [x.y.z]`` heading must match the package version."""
+    top = _latest_changelog_version()
+    assert top == chainweaver.__version__, (
+        f"CHANGELOG.md top release heading is {top!r}, "
+        f"chainweaver.__version__ is {chainweaver.__version__!r}. "
+        "Bump the changelog or the package version so they agree."
+    )
+
+
+def test_pyproject_publishes_user_navigation_urls() -> None:
+    """``pyproject.toml`` must expose the URLs the PyPI sidebar surfaces."""
+    urls = _pyproject_table()["project"]["urls"]
+    required = {"Homepage", "Documentation", "Source", "Changelog", "Issues"}
+    missing = required - urls.keys()
+    assert not missing, (
+        f"pyproject.toml [project.urls] is missing required entries: {sorted(missing)}. "
+        f"Present: {sorted(urls.keys())}."
+    )
+    # Sanity-check that the URLs are absolute https — relative paths would
+    # render as broken links on PyPI.
+    for label, value in urls.items():
+        assert value.startswith("https://"), (
+            f"[project.urls] {label!r} must be an absolute https:// URL, got {value!r}"
+        )

--- a/tests/test_readme_smoke.py
+++ b/tests/test_readme_smoke.py
@@ -1,0 +1,200 @@
+"""README anti-drift smoke tests (#203).
+
+These tests catch the class of bug that issues #190, #195, #196, and the
+historical onboarding-doc drift fell into: a copy-paste example in the
+README quietly stops working when the underlying API changes, but nothing
+in CI fails because nothing in CI tries to run README snippets.
+
+The contract:
+
+- Any fenced ``python`` block preceded *immediately* by the HTML comment
+  ``<!-- smoke-test: run -->`` is extracted, written to a temp file, and
+  executed in a fresh subprocess.  It must exit cleanly (``returncode == 0``)
+  with no traceback on stderr.
+- Blocks **without** that marker are illustrative-only and the test skips
+  them.  This is the allowlist that #203 calls for — opt-in by marker, not
+  opt-out by allowlist file.
+- The "bundled examples" mentioned by the README (``python examples/...``)
+  must exist on disk so the README never points at a script that has been
+  deleted or renamed.
+- CLI smoke: ``chainweaver --help`` and ``chainweaver validate <example>``
+  both work straight out of a fresh checkout, with no programmatic registry
+  setup, so a newcomer pasting the first CLI lines from the README does not
+  hit a broken command.
+
+Add ``<!-- smoke-test: run -->`` above a README ``python`` block to opt
+that block into CI execution.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_README = _REPO_ROOT / "README.md"
+_EXAMPLE_FLOW = _REPO_ROOT / "examples" / "double_add_format.flow.yaml"
+
+# Match an HTML marker on its own line, optional blank line, then a fenced
+# ``python`` block.  The block body is captured greedily up to the closing
+# fence on its own line.
+_RUNNABLE_BLOCK = re.compile(
+    r"<!--\s*smoke-test:\s*run\s*-->\s*\n+```python\n(?P<body>.*?)\n```",
+    re.DOTALL,
+)
+
+# README CLI section advertises these bundled example scripts.  Each must
+# exist or the README points at a stale path.  Sourced from `## Quick Start`
+# and the "## Command-line interface" sections.
+_BUNDLED_EXAMPLES = (
+    "examples/simple_linear_flow.py",
+    "examples/etl_flow.py",
+    "examples/mcp_search_flow.py",
+    "examples/naive_vs_compiled.py",
+    "examples/coding_agent_pr_review.py",
+    "examples/coding_agent_changelog.py",
+    "examples/coding_agent_debug_log.py",
+    "examples/decorator_tool.py",
+    "examples/double_add_format.flow.yaml",
+)
+
+
+def _extracted_runnable_blocks() -> list[str]:
+    text = _README.read_text(encoding="utf-8")
+    return [match.group("body") for match in _RUNNABLE_BLOCK.finditer(text)]
+
+
+def test_at_least_one_readme_block_is_marked_runnable() -> None:
+    """Guard against silently removing every smoke marker from the README."""
+    blocks = _extracted_runnable_blocks()
+    assert blocks, (
+        "No `<!-- smoke-test: run -->` markers found in README.md. "
+        "At least the Quick Start block must opt in to smoke execution."
+    )
+
+
+@pytest.mark.parametrize(
+    "block_body",
+    _extracted_runnable_blocks(),
+    ids=lambda body: body.splitlines()[0][:60] if body else "<empty>",
+)
+def test_readme_runnable_block_executes(
+    block_body: str,
+    tmp_path: Path,
+) -> None:
+    """Each ``<!-- smoke-test: run -->`` block must run cleanly."""
+    script = tmp_path / "readme_block.py"
+    script.write_text(block_body, encoding="utf-8")
+
+    # Inherit the parent environment so an editable install of `chainweaver`
+    # is importable, but force the repo root onto PYTHONPATH as well: README
+    # snippets must work whether the user installed via `pip install -e .` or
+    # is just running `python script.py` from a fresh checkout.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        f"{_REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(_REPO_ROOT)
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+
+    if completed.returncode != 0:
+        output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+        pytest.fail(f"README runnable block failed (returncode={completed.returncode}):\n{output}")
+
+
+@pytest.mark.parametrize("relpath", _BUNDLED_EXAMPLES)
+def test_readme_bundled_example_exists(relpath: str) -> None:
+    """README references to bundled examples must point at real files."""
+    assert (_REPO_ROOT / relpath).is_file(), (
+        f"README references {relpath!r} but the file does not exist. "
+        "Update the README or restore the example."
+    )
+
+
+def test_cli_help_runs_without_a_registry() -> None:
+    """``chainweaver --help`` must work on a fresh install — no registry needed."""
+    completed = subprocess.run(
+        [sys.executable, "-m", "chainweaver.cli", "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    out = completed.stdout + completed.stderr
+    # Every command the CLI advertises must appear in --help output.  Catches
+    # the "README/docs say there are N commands, --help only shows N-1" bug
+    # class historically tracked by issue #190.
+    for name in (
+        "inspect",
+        "viz",
+        "validate",
+        "check",
+        "run",
+        "profile",
+        "diff",
+        "attest",
+        "suggest",
+        "dump-schema",
+        "doctor",
+    ):
+        assert name in out, f"`chainweaver --help` is missing the {name!r} command"
+
+
+def test_cli_validate_runs_against_bundled_yaml_example() -> None:
+    """``chainweaver validate examples/double_add_format.flow.yaml`` works on a fresh install."""
+    assert _EXAMPLE_FLOW.is_file(), f"missing shipped example flow: {_EXAMPLE_FLOW}"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "chainweaver.cli",
+            "validate",
+            str(_EXAMPLE_FLOW),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"`chainweaver validate {_EXAMPLE_FLOW.relative_to(_REPO_ROOT)}` "
+        f"failed:\n{completed.stdout}\n{completed.stderr}"
+    )
+
+
+def test_readme_yaml_extra_is_mentioned_near_yaml_examples() -> None:
+    """README must tell users to install ``chainweaver[yaml]`` before promising YAML examples."""
+    text = _README.read_text(encoding="utf-8")
+    # First YAML reference (any ``.flow.yaml`` token in fenced code or prose)
+    yaml_token = ".flow.yaml"
+    first_yaml = text.find(yaml_token)
+    extra_token = "chainweaver[yaml]"
+    first_extra = text.find(extra_token)
+    assert first_yaml != -1, "README has no .flow.yaml reference at all (unexpected)."
+    assert first_extra != -1, (
+        f"README mentions {yaml_token!r} but never explains the "
+        f"`pip install '{extra_token}'` requirement."
+    )
+    assert first_extra < first_yaml + 6000, (
+        "The first mention of `chainweaver[yaml]` is too far from the first "
+        "`.flow.yaml` reference; a newcomer reading top-down hits the YAML "
+        "example before the install instruction."
+    )

--- a/tests/test_readme_smoke.py
+++ b/tests/test_readme_smoke.py
@@ -116,6 +116,15 @@ def test_readme_runnable_block_executes(
         output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
         pytest.fail(f"README runnable block failed (returncode={completed.returncode}):\n{output}")
 
+    # The contract in this module's docstring promises "no traceback on stderr".
+    # A script can still print a traceback (e.g. ``traceback.print_exc()``) and
+    # exit 0, so check stderr directly — otherwise the docstring lies.
+    if "Traceback (most recent call last):" in completed.stderr:
+        pytest.fail(
+            "README runnable block exited 0 but printed a traceback to stderr; "
+            "the smoke contract requires clean stderr:\n" + completed.stderr
+        )
+
 
 @pytest.mark.parametrize("relpath", _BUNDLED_EXAMPLES)
 def test_readme_bundled_example_exists(relpath: str) -> None:

--- a/tests/test_runtime_responsibilities_doc.py
+++ b/tests/test_runtime_responsibilities_doc.py
@@ -1,0 +1,70 @@
+"""Anti-drift guards for ``docs/runtime-responsibilities.md`` (#208).
+
+These tests fail when:
+
+- the page goes missing from ``docs/`` (e.g. someone moves it without
+  updating the references);
+- a top-level section the issue's acceptance criteria call for disappears;
+- the README stops linking to it from the MCP integration section
+  (#208 acceptance criterion: "README links to it from the architecture
+  or MCP section");
+- ``mkdocs.yml`` stops including it in the published nav.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOC = _REPO_ROOT / "docs" / "runtime-responsibilities.md"
+_README = _REPO_ROOT / "README.md"
+_MKDOCS = _REPO_ROOT / "mkdocs.yml"
+
+# Section H2 headings the page must keep — these map 1:1 to the
+# responsibilities #208 enumerates in its acceptance criteria.
+_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "1. Deciding when to invoke a flow",
+    "2. Treating stored execution traces",
+    "3. Describing tools with side effects",
+    "4. Treating compiled flows as higher-level operations",
+    "5. MCP examples must preserve the same expectations",
+)
+
+
+def test_runtime_responsibilities_page_exists() -> None:
+    assert _DOC.is_file(), f"missing docs page: {_DOC}"
+
+
+def test_runtime_responsibilities_page_has_required_sections() -> None:
+    text = _DOC.read_text(encoding="utf-8")
+    missing = [heading for heading in _REQUIRED_SECTIONS if f"## {heading}" not in text]
+    assert not missing, (
+        f"docs/runtime-responsibilities.md is missing required H2 sections: {missing}"
+    )
+
+
+def test_runtime_responsibilities_page_includes_concrete_example() -> None:
+    """Acceptance criterion: the page includes one concrete example."""
+    text = _DOC.read_text(encoding="utf-8")
+    # The example uses ``handle_request`` as its entry point — a stable marker.
+    assert "```python" in text, "page must include at least one Python code block"
+    assert "handle_request" in text, (
+        "the concrete example (host's `handle_request`) is missing from the page"
+    )
+
+
+def test_readme_links_to_runtime_responsibilities_page() -> None:
+    """Acceptance criterion: README links to it from architecture or MCP section."""
+    text = _README.read_text(encoding="utf-8")
+    assert "docs/runtime-responsibilities.md" in text, (
+        "README.md must link to docs/runtime-responsibilities.md "
+        "(currently missing — see issue #208 acceptance criteria)."
+    )
+
+
+def test_mkdocs_includes_runtime_responsibilities_in_nav() -> None:
+    text = _MKDOCS.read_text(encoding="utf-8")
+    assert "runtime-responsibilities.md" in text, (
+        "mkdocs.yml nav does not reference runtime-responsibilities.md — "
+        "the page would build but not show up in the hosted site nav."
+    )


### PR DESCRIPTION
## Summary

Six tightly-coupled documentation and metadata fixes that share the README, `pyproject.toml`, and `docs/` surface — bundled so the new smoke tests (#203) can guard the doc fixes (#194, #202, #209, #212) from regressing the moment they land, and so the new runtime-responsibilities page (#208) is anchored into both the README and the mkdocs nav.

Pure docs + tests + package metadata. No runtime code changes. The single touched non-test source file is `chainweaver/__init__.py`, where `__version__` is bumped from `"0.9.0"` → `"0.10.0"` to match the release commit in `pyproject.toml` — the kind of drift the new metadata-consistency test catches.

## Changes

| File | Issue | Change |
|------|-------|--------|
| `pyproject.toml` | #209 | `[project.urls]` adds `Documentation`, `Source`, `Changelog`, `Issues` so PyPI sidebar / `pip show` link users to the right place; `keywords` expanded. |
| `chainweaver/__init__.py` | #209 | `__version__` bumped to `"0.10.0"` to match `pyproject.toml` (now caught by `tests/test_metadata_consistency.py`). |
| `README.md` | #194, #202, #208, #209, #212 | New top-of-file "See it in 30 seconds" before/after narrative (#202); expanded Installation extras table (#209); "Where ChainWeaver fits in the Weaver Stack" subsection (#212); link to the new runtime-responsibilities page from the MCP Integration section (#208); paragraph + entry-script snippet explaining `set_default_registry` next to the `inspect`/`viz` CLI examples (#194). Two existing Python blocks marked with `<!-- smoke-test: run -->` so they get exercised by the new smoke test. |
| `docs/runtime-responsibilities.md` *(new)* | #208 | 5 sections (when to invoke, trace persistence/redaction, side-effect tools, flows as named operations, MCP parity) + concrete `handle_request` example. |
| `mkdocs.yml` | #208 | Wires the new page into nav under "Is this for me?". |
| `tests/test_readme_smoke.py` *(new)* | #203 | Extracts opt-in `<!-- smoke-test: run -->` Python blocks and runs each in a fresh subprocess (with the repo on `PYTHONPATH`); asserts `chainweaver --help` lists every registered command; asserts `chainweaver validate examples/double_add_format.flow.yaml` exits clean from a fresh checkout; asserts all bundled examples the README points to exist; asserts the `chainweaver[yaml]` install note appears near the first `.flow.yaml` mention. |
| `tests/test_metadata_consistency.py` *(new)* | #203, #209 | Asserts `pyproject.toml` version ↔ `chainweaver.__version__` ↔ latest released `## [x.y.z]` heading in CHANGELOG.md agree, and that `[project.urls]` exposes the required user-navigation URLs. Uses stdlib `tomllib` on 3.11+ with a regex fallback for 3.10. |
| `tests/test_runtime_responsibilities_doc.py` *(new)* | #208 | Anti-drift: the page exists, has the 5 required H2 sections, includes a concrete `handle_request` example, the README links to it, and `mkdocs.yml` includes it in nav. |

## Why

All six issues describe distinct first-30-seconds-of-the-repo failure modes that the maintainer-triage process kept reopening (#190 / #192 / #193 / #195 / #196 / #197 closed earlier today were the *concrete instances*; #194 and the rest in this PR are the *next batch plus the systemic guard*). Shipping the README polish (#194 / #202 / #209 / #212) alongside the smoke tests (#203) means the *class* of drift becomes a CI failure mode from day one rather than something that has to be re-discovered by the next contributor.

The runtime-responsibilities page (#208) is the only sizable new doc; it lands here because the README's MCP-integration section now links to it, so the two issues' acceptance criteria are jointly satisfied without orphaning either page.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`) — *All checks passed*
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`) — *152 files OK*
- [x] Type checking passes (`python -m mypy chainweaver/`) — *125 files, 0 issues*
- [x] All existing tests pass (`python -m pytest tests/ -v`) — *1107 passed*
- [x] New tests added for new functionality — *23 new tests in 3 new test modules*

Reproducible verification:

```text
$ python -m ruff check chainweaver/ tests/ examples/
All checks passed!

$ python -m ruff format --check chainweaver/ tests/ examples/
152 files already formatted

$ python -m mypy chainweaver/ tests/
Success: no issues found in 125 source files

$ python -m pytest tests/ -q --no-cov
........................................................................ [97%]
........................................................................ [100%]
1107 passed in 10.08s
```

Targeted run of the new suites:

```text
$ python -m pytest tests/test_readme_smoke.py tests/test_metadata_consistency.py tests/test_runtime_responsibilities_doc.py --no-cov -v
...
23 passed in 1.30s
```

## Related Issues

Closes #194 — README `inspect` example assumes a programmatically-registered registry.
Closes #202 — Rewrite README landing path around a concrete before/after use case.
Closes #203 — Add README and docs snippet smoke tests to prevent onboarding drift.
Closes #208 — Add runtime responsibilities page.
Closes #209 — Improve package metadata and install docs.
Closes #212 — docs: link ChainWeaver into the Weaver Stack ecosystem map.

Follows directly from the triage in #214's predecessor sweep (six already-fixed issues closed today: #190, #192, #193, #195, #196, #197).

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`) — anti-drift tests mirror `tests/test_cli_docs.py`'s pattern; smoke-test subprocess plumbing mirrors `tests/test_cookbook_examples.py`'s pattern; commit message follows the repo's `docs, test: …` conventional style.
- [x] Public API changes are documented — none; this PR is docs + tests + package metadata only. `__version__` bump is metadata, not API.
- [x] No secrets or credentials included.

## Scope notes (Mode B)

User explicitly authorized Mode B + "one PR for all" + "I don't care about retro compatibility" + "new dependencies if worthy". I did not add any new runtime dependency (the test deps `pytest` / `pyyaml` are already in `[dev]`). Mode B latitude used **only** for: (a) bundling all six issues in one PR per the user's explicit request; (b) fixing the `__init__.py` ↔ `pyproject.toml` version drift discovered while writing the metadata consistency test, which is in #209's explicit scope ("Ensure package version metadata remains consistent with `chainweaver.__version__`"); (c) wiring the new docs page into both the README and the mkdocs nav rather than leaving it floating.

## Tradeoffs / risks

- **Smoke-test opt-in marker** (#203). I chose opt-in (`<!-- smoke-test: run -->`) over opt-out (allowlist file) because the README has many illustrative Python blocks (16 today) and the asymmetry is asymmetric: missing one illustrative block from the allowlist breaks CI for innocent reasons, while missing one runnable block from the marker just fails to catch a future regression in *that block*. Marking two blocks today (Quick Start and `@tool` decorator); follow-ups can mark more.
- **Subprocess PYTHONPATH plumbing.** The smoke test forces `PYTHONPATH=<repo_root>` into the subprocess so README blocks work from a fresh checkout *and* from an editable install. This matches what a newcomer running `python -c "$(cat block.py)"` from the repo root would experience.
- **`tomllib` vs `tomli` for 3.10.** Repo supports Python `>=3.10` but `tomllib` lands in stdlib at 3.11. Rather than add `tomli` to `[dev]` for the single 3.10 leg, I added a small regex fallback in `_pyproject_table()` that handles the keys the test reads. If 3.10 ever drops from the matrix, the fallback becomes dead code and is one delete away.
- **`agent-context/` doc-drift.** The README and the new page do not duplicate `docs/agent-context/` content; that boundary stays intact (`agent-context/` remains `not_in_nav` per the existing mkdocs convention).
- **Weaver Stack URL** (#212). The sibling-projects table cross-references issue numbers (#91 / #106 / #89 / #210), not external URLs, because the sibling repos' canonical URLs are still being shaped. When `weaver-spec` publishes the ecosystem map, the placeholder link in the same subsection can be promoted to a real URL in a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0189GJUxjviz1r1KmrJpM7Pc)_