### PR TITLE
feat: add property-based fuzzing harness, trace minimization, and CLI (#220, #221, #222, #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Property-based fuzzing harness for flows** (#220): a new `chainweaver.fuzz`
+  module exposing `FlowFuzzer`, `FlowProperty`, `FaultConfig`, `FuzzCase`,
+  `FuzzFailure`, `FuzzReport`, and `BUILTIN_PROPERTIES`. The fuzzer generates or
+  mutates initial inputs from a flow's `input_schema` (or a supplied base
+  input), optionally injects malformed tool outputs via a seeded fault hook,
+  executes the flow, and records any property violation as a replayable
+  `ExecutionResult`. All randomness is seeded (`random.Random(seed)`) so runs
+  are reproducible; the executor stays randomness-free.
+- **Trace minimization** (#221): `minimize_failure(...)` delta-debugs a failing
+  input down to the smallest reproducer that still violates a property,
+  re-verifying every reduction via `FlowExecutor.execute_flow`.
+- **`chainweaver fuzz` CLI command** (#222): runs property-based tests against a
+  `.flow.{yaml,yml,json}` file with `--property` (built-in name or `module:attr`
+  path), `--runs`, `--seed`, `--input`/`--input-file`, `--output-fault-prob`,
+  `--minimize`, and `--save-failures`. Exits non-zero on a violation; saves
+  redacted, replayable failure traces. Documented in `docs/cli.md`.
+- **Trace-redaction helpers** (#217): `RedactionPolicy.redact_step_record` and
+  `RedactionPolicy.redact_execution_result` return redacted copies of a
+  `StepRecord` / `ExecutionResult` (used by `chainweaver fuzz --save-failures`
+  to keep persisted artifacts secret-safe by default).
+- New `FuzzConfigError` (a `ChainWeaverError`) for misconfigured fuzzing runs.
+
 ## [0.11.0] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   input), optionally injects malformed tool outputs via a seeded fault hook,
   executes the flow, and records any property violation as a replayable
   `ExecutionResult`. All randomness is seeded (`random.Random(seed)`) so runs
-  are reproducible; the executor stays randomness-free.
+  are reproducible; the executor stays randomness-free. Fault injection now runs
+  under a clone that preserves the executor's full configuration (middleware,
+  caches, cost profile, redaction policy, decision callback) via the new
+  `FlowExecutor.with_replaced_tools(...)`, and the schema-driven value generator
+  is shared as the supported `chainweaver.attest.generate_value`.
 - **Trace minimization** (#221): `minimize_failure(...)` delta-debugs a failing
   input down to the smallest reproducer that still violates a property,
   re-verifying every reduction via `FlowExecutor.execute_flow`.
@@ -25,7 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.flow.{yaml,yml,json}` file with `--property` (built-in name or `module:attr`
   path), `--runs`, `--seed`, `--input`/`--input-file`, `--output-fault-prob`,
   `--minimize`, and `--save-failures`. Exits non-zero on a violation; saves
-  redacted, replayable failure traces. Documented in `docs/cli.md`.
+  redacted, replayable failure traces. `--redact` (the default) also redacts
+  the failing/minimized inputs printed to stdout so secrets do not leak into CI
+  logs; duplicate `--property` names are rejected up front; and saved-failure
+  filenames are sanitized for cross-platform safety. Documented in
+  `docs/cli.md`.
 - **Trace-redaction helpers** (#217): `RedactionPolicy.redact_step_record` and
   `RedactionPolicy.redact_execution_result` return redacted copies of a
   `StepRecord` / `ExecutionResult` (used by `chainweaver fuzz --save-failures`

--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ All errors are typed and traceable:
 | `PluginDiscoveryError` | Strict-mode plugin discovery (`discover_tools(strict=True)` / `discover_flows(strict=True)`) hits a misbehaving entry-point loader |
 | `ContribError` | A `chainweaver.contrib.tools` tool hits a contract violation (missing JSON-pointer key, wrong predicate shape, assertion mismatch) |
 | `FixtureStaleError` | A `record_then_replay` replay invocation cannot be matched to a recording (missing/stale fixture) |
+| `FuzzConfigError` | A property-based fuzzing run is misconfigured (no properties, `runs < 1`, a flow with no `input_schema` and no base input, or an unsupported input-field type) |
 
 All exceptions inherit from `ChainWeaverError`.
 
@@ -877,6 +878,11 @@ chainweaver suggest flows/etl.flow.yaml --tools my_pkg.tools --trace trace_a.jso
 
 # Check saved flows for tool schema drift against the live registry.
 chainweaver doctor flows/ --check-drift --tools my_pkg.tools
+
+# Property-based fuzzing: generate cases, check invariants, save/minimize failures.
+chainweaver fuzz flows/etl.flow.yaml --tools my_pkg.tools \
+  --property my_pkg.props:no_unauthorized_action --runs 1000 --seed 42 \
+  --minimize --save-failures failures/
 ```
 
 `run` is the fastest path from a fresh install to seeing a flow execute:

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -123,6 +123,17 @@ from chainweaver.flow import (
     RetryPolicy,
     validate_dag_topology,
 )
+from chainweaver.fuzz import (
+    BUILTIN_PROPERTIES,
+    FaultConfig,
+    FlowFuzzer,
+    FlowProperty,
+    FuzzCase,
+    FuzzConfigError,
+    FuzzFailure,
+    FuzzReport,
+    minimize_failure,
+)
 from chainweaver.log_utils import RedactionPolicy
 from chainweaver.middleware import (
     BaseMiddleware,
@@ -167,6 +178,7 @@ logging.getLogger("chainweaver").addHandler(logging.NullHandler())
 __version__ = "0.11.0"
 
 __all__ = [
+    "BUILTIN_PROPERTIES",
     "AttestationInputError",
     "AttestationReport",
     "BaseDecisionCallback",
@@ -197,6 +209,7 @@ __all__ = [
     "ExecutionPlan",
     "ExecutionResult",
     "ExecutionSnapshot",
+    "FaultConfig",
     "FileCheckpointer",
     "FileStepCache",
     "FileStore",
@@ -210,13 +223,19 @@ __all__ = [
     "FlowExecutionError",
     "FlowExecutor",
     "FlowExecutorMiddleware",
+    "FlowFuzzer",
     "FlowNotFoundError",
+    "FlowProperty",
     "FlowRegistry",
     "FlowSerializationError",
     "FlowStartContext",
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
+    "FuzzCase",
+    "FuzzConfigError",
+    "FuzzFailure",
+    "FuzzReport",
     "InMemoryCheckpointer",
     "InMemoryStepCache",
     "InMemoryStore",
@@ -273,6 +292,7 @@ __all__ = [
     "flow_to_mermaid",
     "flow_to_yaml",
     "merge_safety",
+    "minimize_failure",
     "result_to_mermaid",
     "schema_fingerprint",
     "suggest_optimizations",

--- a/chainweaver/attest.py
+++ b/chainweaver/attest.py
@@ -63,7 +63,9 @@ from chainweaver.flow import DAGFlow, Flow
 __all__ = [
     "AttestationInputError",
     "AttestationReport",
+    "UnsupportedAnnotation",
     "attest_flow",
+    "generate_value",
 ]
 
 
@@ -89,15 +91,19 @@ class AttestationInputError(ChainWeaverError):
 # ---------------------------------------------------------------------------
 
 
-class _UnsupportedAnnotation(Exception):
-    """Internal: raised when _generate_value cannot handle an annotation."""
+class UnsupportedAnnotation(Exception):
+    """Raised when :func:`generate_value` cannot handle an annotation.
+
+    Part of the supported schema-value generation utility shared by the
+    attestation and fuzzing harnesses (issue #220 review follow-up).
+    """
 
     def __init__(self, annotation_repr: str) -> None:
         self.annotation_repr = annotation_repr
         super().__init__(annotation_repr)
 
 
-def _generate_value(annotation: object, rng: random.Random, *, depth: int = 0) -> Any:
+def generate_value(annotation: object, rng: random.Random, *, depth: int = 0) -> Any:
     """Generate one example value matching *annotation*.
 
     The generator covers the common subset of Pydantic field types:
@@ -110,7 +116,7 @@ def _generate_value(annotation: object, rng: random.Random, *, depth: int = 0) -
     - ``dict`` / ``dict[K, V]`` → small dict
     - ``Literal[a, b, c]`` → uniform choice
     - ``Optional[X]`` / ``X | None`` → 25% chance of ``None``, else X
-    - ``BaseModel`` subclass → recurse via ``_generate_value`` per field
+    - ``BaseModel`` subclass → recurse via ``generate_value`` per field
     """
     if depth > 4:
         # Bound recursion conservatively for self-referential schemas.
@@ -134,14 +140,14 @@ def _generate_value(annotation: object, rng: random.Random, *, depth: int = 0) -
     if origin is list or annotation is list:
         item_type = args[0] if args else int
         length = rng.randint(0, 3)
-        return [_generate_value(item_type, rng, depth=depth + 1) for _ in range(length)]
+        return [generate_value(item_type, rng, depth=depth + 1) for _ in range(length)]
     if origin is dict or annotation is dict:
         # Use a small {str: int} dict by default; honour annotation args
         # when provided.
         key_type = args[0] if args else str
         val_type = args[1] if len(args) > 1 else int
         return {
-            _generate_value(key_type, rng, depth=depth + 1): _generate_value(
+            generate_value(key_type, rng, depth=depth + 1): generate_value(
                 val_type, rng, depth=depth + 1
             )
             for _ in range(rng.randint(0, 2))
@@ -152,14 +158,14 @@ def _generate_value(annotation: object, rng: random.Random, *, depth: int = 0) -
         non_none = [a for a in args if a is not type(None)]
         if type(None) in args and rng.random() < 0.25:
             return None
-        return _generate_value(non_none[0] if non_none else args[0], rng, depth=depth + 1)
+        return generate_value(non_none[0] if non_none else args[0], rng, depth=depth + 1)
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
         return {
-            name: _generate_value(info.annotation, rng, depth=depth + 1)
+            name: generate_value(info.annotation, rng, depth=depth + 1)
             for name, info in annotation.model_fields.items()
         }
 
-    raise _UnsupportedAnnotation(repr(annotation))
+    raise UnsupportedAnnotation(repr(annotation))
 
 
 def _generate_inputs(
@@ -181,10 +187,10 @@ def _generate_inputs(
         payload: dict[str, Any] = {}
         for name, info in schema.model_fields.items():
             try:
-                payload[name] = _generate_value(info.annotation, rng)
+                payload[name] = generate_value(info.annotation, rng)
             except RecursionError as exc:
                 raise AttestationInputError(name, repr(info.annotation)) from exc
-            except _UnsupportedAnnotation as exc:
+            except UnsupportedAnnotation as exc:
                 raise AttestationInputError(name, exc.annotation_repr) from exc
         # Validate by constructing the model; .model_dump() normalizes.
         try:

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -75,8 +75,10 @@ from __future__ import annotations
 
 import importlib
 import json
+import re
 import statistics
 import sys
+from collections import Counter
 from enum import Enum
 from pathlib import Path
 from types import ModuleType
@@ -1862,7 +1864,10 @@ _FUZZ_MINIMIZE_OPTION = typer.Option(
 _FUZZ_REDACT_OPTION = typer.Option(
     True,
     "--redact/--no-redact",
-    help="Redact saved failure traces with the default RedactionPolicy (issue #217).",
+    help=(
+        "Redact saved failure traces and emitted failing/minimized inputs with "
+        "the default RedactionPolicy (issue #217). Use --no-redact for raw values."
+    ),
 )
 
 
@@ -1919,7 +1924,32 @@ def _resolve_fuzz_properties(specs: list[str]) -> list[FlowProperty]:
                 err=True,
             )
             raise typer.Exit(code=1)
+
+    # Reject duplicate property names up front.  Downstream the CLI builds
+    # ``{p.name: p for p in props}``, which would silently drop duplicates and
+    # could run minimization/checking against the wrong implementation.
+    counts = Counter(p.name for p in resolved)
+    duplicates = sorted(name for name, count in counts.items() if count > 1)
+    if duplicates:
+        typer.echo(
+            f"chainweaver: duplicate property name(s): {', '.join(duplicates)}. "
+            "Each --property must resolve to a unique name.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     return resolved
+
+
+def _sanitize_path_component(component: str) -> str:
+    """Make *component* safe to use as a single filesystem path segment.
+
+    Property names can contain ``:`` (from ``module:attr`` specs) and flow
+    names could contain ``/`` or ``\\``; these are invalid on Windows and can
+    alter path semantics elsewhere.  Replace any character outside
+    ``[A-Za-z0-9._-]`` with ``_`` and never return an empty string.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", component)
+    return cleaned or "_"
 
 
 @app.command("fuzz")
@@ -2019,19 +2049,29 @@ def fuzz_command(
         saved_path: str | None = None
         if save_failures is not None:
             out_trace = policy.redact_execution_result(trace) if redact else trace
-            filename = f"{flow.name}.{failure.property_name}.case{failure.case_index}.json"
+            filename = (
+                f"{_sanitize_path_component(flow.name)}."
+                f"{_sanitize_path_component(failure.property_name)}."
+                f"case{failure.case_index}.json"
+            )
             path = save_failures / filename
             path.write_text(out_trace.model_dump_json(indent=2) + "\n", encoding="utf-8")
             saved_path = str(path)
 
+        # Honor --redact for emitted inputs too: raw failing/minimized inputs
+        # in stdout/stderr can leak secrets into CI logs even when saved
+        # traces are redacted (issue #217 review follow-up).
+        emitted_initial = policy.redact(failure.initial_input) if redact else failure.initial_input
         record: dict[str, Any] = {
             "property": failure.property_name,
             "case_index": failure.case_index,
-            "initial_input": failure.initial_input,
+            "initial_input": emitted_initial,
             "check_error": failure.check_error,
         }
         if minimized_input is not None:
-            record["minimized_input"] = minimized_input
+            record["minimized_input"] = (
+                policy.redact(minimized_input) if redact else minimized_input
+            )
         if saved_path is not None:
             record["saved"] = saved_path
         failure_records.append(record)

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -33,6 +33,9 @@ Available commands
 - ``chainweaver doctor <path>`` — diagnostic command; ``--check-drift``
   reports missing tools and tool-schema fingerprint drift for one or
   more saved flow files (issue #175).
+- ``chainweaver fuzz <file>`` — property-based fuzzing: generate / mutate
+  inputs (optionally injecting malformed tool outputs), check invariants,
+  and save / minimize failing traces (issues #220, #221, #222).
 - ``chainweaver dump-schema`` — emit the JSON Schema for
   ``.flow.json`` / ``.flow.yaml`` files derived from the live Pydantic
   models; supports ``--check`` for CI drift detection (issue #135).
@@ -97,6 +100,7 @@ from chainweaver.viz import _render_step_bar_chart, flow_to_ascii, flow_to_dot
 
 if TYPE_CHECKING:
     from chainweaver.attest import AttestationReport
+    from chainweaver.fuzz import FlowProperty, FuzzReport
 
 app = typer.Typer(
     name="chainweaver",
@@ -1800,6 +1804,278 @@ def doctor_command(
 
     if load_errors or drift_count:
         raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# fuzz command (issues #220, #221, #222)
+# ---------------------------------------------------------------------------
+
+
+_FUZZ_PROPERTY_OPTION = typer.Option(
+    [],
+    "--property",
+    "-p",
+    help=(
+        "Property to check: a built-in name (e.g. 'flow_succeeds', "
+        "'final_output_present') or a 'module:attr' path to a FlowProperty or "
+        "a callable taking an ExecutionResult. Repeatable. "
+        "Defaults to 'flow_succeeds'."
+    ),
+)
+_FUZZ_RUNS_OPTION = typer.Option(
+    100,
+    "--runs",
+    "-n",
+    help="Number of fuzz cases to generate (>= 1).",
+)
+_FUZZ_SEED_OPTION = typer.Option(
+    0,
+    "--seed",
+    help="Deterministic RNG seed; re-running with it reproduces the same cases.",
+)
+_FUZZ_INPUT_OPTION = typer.Option(
+    None,
+    "--input",
+    "-i",
+    help="JSON object used as the base input to mutate (instead of generating from the schema).",
+)
+_FUZZ_INPUT_FILE_OPTION = typer.Option(
+    None,
+    "--input-file",
+    help="Path to a JSON object used as the base input to mutate.",
+)
+_FUZZ_SAVE_OPTION = typer.Option(
+    None,
+    "--save-failures",
+    help="Directory to write failing ExecutionResult traces to (created if absent).",
+)
+_FUZZ_FAULT_PROB_OPTION = typer.Option(
+    0.0,
+    "--output-fault-prob",
+    help="Probability in [0,1] of injecting a malformed tool output per call (0 disables).",
+)
+_FUZZ_MINIMIZE_OPTION = typer.Option(
+    False,
+    "--minimize/--no-minimize",
+    help="Shrink each failing input to a minimal reproducer (issue #221).",
+)
+_FUZZ_REDACT_OPTION = typer.Option(
+    True,
+    "--redact/--no-redact",
+    help="Redact saved failure traces with the default RedactionPolicy (issue #217).",
+)
+
+
+def _resolve_fuzz_properties(specs: list[str]) -> list[FlowProperty]:
+    """Resolve ``--property`` specs to :class:`FlowProperty` objects.
+
+    Each spec is either a built-in property name or a ``module:attr`` path to a
+    :class:`FlowProperty` or a ``Callable[[ExecutionResult], bool]``.  An empty
+    list defaults to ``["flow_succeeds"]``.  Exits 1 on a malformed spec and 2
+    when a referenced module is not importable (mirrors the CLI exit contract).
+    """
+    from chainweaver.fuzz import BUILTIN_PROPERTIES, FlowProperty
+
+    if not specs:
+        return [BUILTIN_PROPERTIES["flow_succeeds"]]
+
+    resolved: list[FlowProperty] = []
+    for spec in specs:
+        if spec in BUILTIN_PROPERTIES:
+            resolved.append(BUILTIN_PROPERTIES[spec])
+            continue
+        if ":" not in spec:
+            builtins = ", ".join(sorted(BUILTIN_PROPERTIES))
+            typer.echo(
+                f"chainweaver: unknown property '{spec}'. "
+                f"Use a built-in ({builtins}) or a 'module:attr' path.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        module_name, _, attr = spec.partition(":")
+        try:
+            module = importlib.import_module(module_name)
+        except (ImportError, ModuleNotFoundError) as exc:
+            typer.echo(
+                f"chainweaver: property module not importable: {module_name}: {exc}",
+                err=True,
+            )
+            raise typer.Exit(code=2) from exc
+        try:
+            obj = getattr(module, attr)
+        except AttributeError as exc:
+            typer.echo(
+                f"chainweaver: '{attr}' not found in module '{module_name}'.",
+                err=True,
+            )
+            raise typer.Exit(code=1) from exc
+        if isinstance(obj, FlowProperty):
+            resolved.append(obj)
+        elif callable(obj):
+            resolved.append(FlowProperty(name=f"{module_name}:{attr}", check=obj))
+        else:
+            typer.echo(
+                f"chainweaver: '{spec}' is neither a FlowProperty nor a callable.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+    return resolved
+
+
+@app.command("fuzz")
+def fuzz_command(
+    flow_file: Path = _RUN_FILE_ARG,
+    tools: list[str] = _RUN_TOOLS_OPTION,
+    properties: list[str] = _FUZZ_PROPERTY_OPTION,
+    runs: int = _FUZZ_RUNS_OPTION,
+    seed: int = _FUZZ_SEED_OPTION,
+    input_arg: str | None = _FUZZ_INPUT_OPTION,
+    input_file: Path | None = _FUZZ_INPUT_FILE_OPTION,
+    save_failures: Path | None = _FUZZ_SAVE_OPTION,
+    output_fault_prob: float = _FUZZ_FAULT_PROB_OPTION,
+    minimize: bool = _FUZZ_MINIMIZE_OPTION,
+    redact: bool = _FUZZ_REDACT_OPTION,
+    output_format: OutputFormat = _FORMAT_OPTION,
+) -> None:
+    """Property-based fuzzing for a flow file (issues #220, #221, #222).
+
+    Generates ``--runs`` cases (from the flow's ``input_schema`` or by mutating
+    a ``--input`` base), executes the flow, and checks each ``--property``
+    against the result.  Failing cases can be shrunk (``--minimize``) and saved
+    as replayable, optionally-redacted traces (``--save-failures``).
+
+    Exit codes:
+
+    - ``0`` — no property was violated.
+    - ``1`` — one or more violations found, or a CLI-level error (bad
+      arguments, malformed flow/input, unknown property).
+    - ``2`` — flow file, tools module, or property module not found / not
+      importable.
+    """
+    from chainweaver.fuzz import FaultConfig, FlowFuzzer, FuzzConfigError, minimize_failure
+    from chainweaver.log_utils import RedactionPolicy
+
+    if runs < 1:
+        typer.echo("chainweaver: --runs must be >= 1.", err=True)
+        raise typer.Exit(code=1)
+    if not 0.0 <= output_fault_prob <= 1.0:
+        typer.echo("chainweaver: --output-fault-prob must be in [0.0, 1.0].", err=True)
+        raise typer.Exit(code=1)
+
+    _require_existing_file(flow_file)
+    try:
+        flow = _load_flow_file(flow_file)
+    except FlowSerializationError as exc:
+        typer.echo(f"chainweaver: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    base_input: dict[str, Any] | None = None
+    if input_arg is not None or input_file is not None:
+        base_input = _parse_initial_input(input_arg=input_arg, input_file=input_file)
+
+    props = _resolve_fuzz_properties(properties)
+
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    executor = FlowExecutor(registry=registry)
+    seen_tool_names: set[str] = set()
+    for module_name in tools:
+        for tool_obj in _import_tools_from(module_name):
+            if tool_obj.name in seen_tool_names:
+                continue
+            executor.register_tool(tool_obj)
+            seen_tool_names.add(tool_obj.name)
+
+    fuzzer = FlowFuzzer(
+        executor=executor,
+        flow=flow,
+        properties=props,
+        fault_config=FaultConfig(output_fault_probability=output_fault_prob),
+    )
+    try:
+        report = fuzzer.run(runs=runs, seed=seed, base_input=base_input)
+    except FuzzConfigError as exc:
+        typer.echo(f"chainweaver: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+    except ChainWeaverError as exc:
+        typer.echo(f"chainweaver: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    props_by_name = {p.name: p for p in props}
+    policy = RedactionPolicy()
+    if save_failures is not None and report.failures:
+        save_failures.mkdir(parents=True, exist_ok=True)
+
+    failure_records: list[dict[str, Any]] = []
+    for failure in report.failures:
+        minimized_input: dict[str, Any] | None = None
+        trace = failure.result
+        if minimize:
+            minimized_input = minimize_failure(
+                executor, flow, failure.initial_input, props_by_name[failure.property_name]
+            )
+            trace = executor.execute_flow(flow.name, minimized_input)
+
+        saved_path: str | None = None
+        if save_failures is not None:
+            out_trace = policy.redact_execution_result(trace) if redact else trace
+            filename = f"{flow.name}.{failure.property_name}.case{failure.case_index}.json"
+            path = save_failures / filename
+            path.write_text(out_trace.model_dump_json(indent=2) + "\n", encoding="utf-8")
+            saved_path = str(path)
+
+        record: dict[str, Any] = {
+            "property": failure.property_name,
+            "case_index": failure.case_index,
+            "initial_input": failure.initial_input,
+            "check_error": failure.check_error,
+        }
+        if minimized_input is not None:
+            record["minimized_input"] = minimized_input
+        if saved_path is not None:
+            record["saved"] = saved_path
+        failure_records.append(record)
+
+    summary: dict[str, Any] = {
+        "flow": report.flow_name,
+        "runs": report.runs,
+        "seed": report.seed,
+        "properties": report.property_names,
+        "failures": report.num_failures,
+        "failure_cases": failure_records,
+    }
+
+    if output_format is OutputFormat.JSON:
+        _emit_json(summary)
+    else:
+        typer.echo(_fuzz_report_to_table(report, failure_records))
+
+    if not report.passed:
+        raise typer.Exit(code=1)
+
+
+def _fuzz_report_to_table(report: FuzzReport, failure_records: list[dict[str, Any]]) -> str:
+    """Render a human-readable summary of a fuzzing run."""
+    lines = [
+        f"flow: {report.flow_name}",
+        f"runs: {report.runs} | seed: {report.seed} | "
+        f"properties: {', '.join(report.property_names)}",
+        f"failures: {report.num_failures}",
+    ]
+    for record in failure_records:
+        lines.append(
+            f"  - property '{record['property']}' violated by case "
+            f"{record['case_index']}: input={record['initial_input']!r}"
+        )
+        if record.get("check_error"):
+            lines.append(f"      check raised: {record['check_error']}")
+        if "minimized_input" in record:
+            lines.append(f"      minimized: {record['minimized_input']!r}")
+        if "saved" in record:
+            lines.append(f"      saved: {record['saved']}")
+    if report.passed:
+        lines.append("no property violations found")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/chainweaver/executor.py
+++ b/chainweaver/executor.py
@@ -19,7 +19,7 @@ import queue
 import threading
 import time
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from enum import Enum
 from graphlib import TopologicalSorter
@@ -709,6 +709,41 @@ class FlowExecutor:
         compatibility reports, or attestation artifacts.
         """
         return dict(self._tools)
+
+    def with_replaced_tools(self, tools: Iterable[Tool]) -> FlowExecutor:
+        """Return a new executor sharing this one's configuration and registry.
+
+        The clone preserves every executor-level setting (cost profile,
+        redaction policy, trace recorder, middleware, step cache, checkpointer,
+        ``delete_on_success`` flag, and decision callback) but starts with an
+        empty tool set populated from *tools*.  Plugin discovery is not re-run,
+        because the caller passes the already-resolved tools explicitly.
+
+        This is used by the fuzzing harness to run a flow under the same
+        executor configuration with fault-injecting tool wrappers, so behavior
+        does not diverge depending on whether fault injection is enabled
+        (issue #220 review follow-up).
+
+        Args:
+            tools: Tools to register on the cloned executor.
+
+        Returns:
+            A new :class:`FlowExecutor` with matching configuration.
+        """
+        clone = FlowExecutor(
+            registry=self._registry,
+            cost_profile=self._cost_profile,
+            redaction_policy=self._redaction_policy,
+            trace_recorder=self._trace_recorder,
+            middleware=list(self._middleware),
+            step_cache=self._step_cache,
+            checkpointer=self._checkpointer,
+            delete_on_success=self._delete_on_success,
+            decision_callback=self._decision_callback,
+        )
+        for tool in tools:
+            clone.register_tool(tool)
+        return clone
 
     def get_drift_report(self) -> list[DriftInfo]:
         """Compare registered tools' current schema hashes against each flow's snapshot.

--- a/chainweaver/fuzz.py
+++ b/chainweaver/fuzz.py
@@ -354,9 +354,15 @@ class FlowFuzzer:
 
     Args:
         executor: A :class:`~chainweaver.executor.FlowExecutor` with the flow's
-            tools registered.  When fault injection is active a *fresh* executor
-            is built per case (sharing this one's registry) so the caller's
-            executor is never mutated.
+            tools registered.  When fault injection is active, a per-case
+            executor is created via
+            :meth:`~chainweaver.executor.FlowExecutor.with_replaced_tools`,
+            preserving this executor's full configuration (middleware,
+            step_cache, cost_profile, redaction_policy, decision_callback) while
+            swapping in fault-wrapped tools, so the caller's executor is never
+            mutated.  Note: if a ``step_cache`` is configured, cached tool
+            outputs may be returned instead of re-running the fault-wrapped
+            tool, which can mask per-case faults for repeated inputs.
         flow: The flow to fuzz.  Its ``input_schema`` drives input generation
             when no ``base_input`` is supplied to :meth:`run`.
         properties: Invariants to check against every result (at least one).

--- a/chainweaver/fuzz.py
+++ b/chainweaver/fuzz.py
@@ -41,7 +41,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from chainweaver.attest import _generate_value, _UnsupportedAnnotation
+from chainweaver.attest import UnsupportedAnnotation, generate_value
 from chainweaver.exceptions import ChainWeaverError
 from chainweaver.executor import ExecutionResult, FlowExecutor
 from chainweaver.flow import DAGFlow, Flow
@@ -461,8 +461,8 @@ class FlowFuzzer:
         payload: dict[str, Any] = {}
         for name, info in schema.model_fields.items():
             try:
-                payload[name] = _generate_value(info.annotation, rng)
-            except _UnsupportedAnnotation as exc:
+                payload[name] = generate_value(info.annotation, rng)
+            except UnsupportedAnnotation as exc:
                 raise FuzzConfigError(
                     f"cannot generate inputs for field '{name}' "
                     f"({exc.annotation_repr}); supply base_input"
@@ -473,9 +473,15 @@ class FlowFuzzer:
         if self.fault_config.active or self.fault_hook is not None:
             run_rng = random.Random(seed * 1_000_003 + case.index)
             hook = self.fault_hook or self._default_fault_hook()
-            run_executor = FlowExecutor(registry=self.executor.registry)
-            for tool in self.executor.registered_tools.values():
-                run_executor.register_tool(_wrap_tool_with_fault(tool, hook, run_rng))
+            # Preserve the executor's full configuration (middleware, caches,
+            # cost profile, redaction policy, decision callback, …) so fault
+            # injection does not silently change behavior versus the no-fault
+            # path (issue #220 review follow-up).
+            wrapped_tools = (
+                _wrap_tool_with_fault(tool, hook, run_rng)
+                for tool in self.executor.registered_tools.values()
+            )
+            run_executor = self.executor.with_replaced_tools(wrapped_tools)
             return run_executor.execute_flow(self.flow.name, case.initial_input)
         return self.executor.execute_flow(self.flow.name, case.initial_input)
 

--- a/chainweaver/fuzz.py
+++ b/chainweaver/fuzz.py
@@ -1,0 +1,598 @@
+"""Property-based fuzzing harness for ChainWeaver flows (issues #220, #221, #222).
+
+ChainWeaver already has strong *reproduction* primitives — deterministic
+execution, structured :class:`~chainweaver.executor.ExecutionResult` traces,
+replay, diff, profiling, and observed-determinism attestation.  Those answer
+"given a failure, can we reproduce and understand it?".
+
+This module adds the missing *discovery* layer: generate unusual inputs and
+runtime conditions, check explicit properties, and persist any violation as a
+replayable trace.  It answers "how do we find weird failures before users do?".
+
+Three capabilities are provided:
+
+- :class:`FlowFuzzer` — generates / mutates initial inputs from the flow's
+  ``input_schema`` (optionally injecting malformed tool outputs via a seeded
+  fault hook), executes the flow, and evaluates :class:`FlowProperty`
+  invariants against every :class:`~chainweaver.executor.ExecutionResult`
+  (issue #220).
+- :func:`minimize_failure` — delta-debugging that shrinks a failing input to
+  the smallest reproducer that still violates a property (issue #221).
+- The :class:`FlowProperty` abstraction plus :data:`BUILTIN_PROPERTIES`, which
+  the ``chainweaver fuzz`` CLI command consumes (issue #222).
+
+Determinism contract
+---------------------
+All randomness lives here in private ``random.Random(seed)`` instances — the
+executor itself remains randomness-free (see
+``docs/agent-context/invariants.md``).  Re-running a :class:`FlowFuzzer` with
+the same flow, tools, ``seed``, and ``runs`` yields the same cases and the
+same failures.  :func:`minimize_failure` is fully deterministic (no RNG): it
+iterates keys in sorted order.
+"""
+
+from __future__ import annotations
+
+import copy
+import random
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from chainweaver.attest import _generate_value, _UnsupportedAnnotation
+from chainweaver.exceptions import ChainWeaverError
+from chainweaver.executor import ExecutionResult, FlowExecutor
+from chainweaver.flow import DAGFlow, Flow
+from chainweaver.tools import Tool
+
+__all__ = [
+    "BUILTIN_PROPERTIES",
+    "FaultConfig",
+    "FlowFuzzer",
+    "FlowProperty",
+    "FuzzCase",
+    "FuzzConfigError",
+    "FuzzFailure",
+    "FuzzReport",
+    "minimize_failure",
+]
+
+
+class FuzzConfigError(ChainWeaverError):
+    """Raised when a fuzzing run cannot be configured.
+
+    Examples: no properties supplied, ``runs < 1``, a flow without an
+    ``input_schema`` and no ``base_input`` to mutate, or an input field whose
+    annotation the seeded generator cannot synthesize.
+    """
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
+# ---------------------------------------------------------------------------
+# Property abstraction
+# ---------------------------------------------------------------------------
+
+PropertyCheck = Callable[[ExecutionResult], bool]
+"""A predicate over an execution result.  Returns ``True`` when the invariant
+holds.  A property is *violated* when the check returns a falsy value **or**
+raises an exception."""
+
+
+@dataclass(frozen=True)
+class FlowProperty:
+    """A named invariant evaluated against an :class:`ExecutionResult`.
+
+    Attributes:
+        name: Short identifier used in reports and saved-artifact filenames.
+        check: Predicate returning ``True`` when the invariant holds.
+        description: Optional human-readable explanation.
+    """
+
+    name: str
+    check: PropertyCheck
+    description: str = ""
+
+    def holds(self, result: ExecutionResult) -> bool:
+        """Return ``True`` when the invariant holds for *result*."""
+        return bool(self.check(result))
+
+
+def _flow_succeeds(result: ExecutionResult) -> bool:
+    """Built-in property: every step completed without error."""
+    return result.success
+
+
+def _final_output_present(result: ExecutionResult) -> bool:
+    """Built-in property: the flow produced a non-``None`` final output."""
+    return result.final_output is not None
+
+
+BUILTIN_PROPERTIES: dict[str, FlowProperty] = {
+    "flow_succeeds": FlowProperty(
+        "flow_succeeds",
+        _flow_succeeds,
+        "Every step completes without a recorded error (result.success is True).",
+    ),
+    "final_output_present": FlowProperty(
+        "final_output_present",
+        _final_output_present,
+        "The flow produces a non-None final output.",
+    ),
+}
+"""Generic, opinionated properties usable by name from the CLI (``--property
+flow_succeeds``).  They assert robustness against *all* generated inputs, so a
+tool that legitimately rejects some inputs will surface as a violation — that
+is intentional: it tells you which inputs the flow does not yet handle."""
+
+
+# ---------------------------------------------------------------------------
+# Fault injection (seeded tool-output mutation)
+# ---------------------------------------------------------------------------
+
+FaultHook = Callable[[str, dict[str, Any], random.Random], dict[str, Any]]
+"""Hook invoked after each tool returns: ``(tool_name, outputs, rng)`` -> new
+outputs.  Must be deterministic given the same *rng* state."""
+
+
+@dataclass(frozen=True)
+class FaultConfig:
+    """Configuration for seeded tool-output fault injection (issue #220).
+
+    Attributes:
+        output_fault_probability: Per-tool-call probability in ``[0.0, 1.0]``
+            that a tool's output dict is mutated (a key dropped, a scalar
+            type-corrupted, etc.) *before* output-schema validation.  ``0.0``
+            (the default) disables injection.
+    """
+
+    output_fault_probability: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.output_fault_probability <= 1.0:
+            raise FuzzConfigError("output_fault_probability must be in [0.0, 1.0]")
+
+    @property
+    def active(self) -> bool:
+        """Whether this config injects any faults."""
+        return self.output_fault_probability > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Mutation primitives (shared by input generation and fault injection)
+# ---------------------------------------------------------------------------
+
+_ADVERSARIAL_STRINGS: tuple[str, ...] = (
+    "",
+    " ",
+    "0",
+    "-1",
+    "null",
+    "💥",
+    "../../etc/passwd",
+    "A" * 1024,
+)
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _corrupt_scalar(value: Any, rng: random.Random) -> Any:
+    """Return a JSON-safe, type-corrupted version of a scalar *value*."""
+    if isinstance(value, bool):
+        return rng.choice([not value, "yes", 0])
+    if isinstance(value, int):
+        return rng.choice([str(value), -value, value * 1000 + 1, None])
+    if isinstance(value, float):
+        return rng.choice([str(value), -value, None])
+    if isinstance(value, str):
+        return rng.choice([*_ADVERSARIAL_STRINGS, value + "!", value.upper()])
+    # ``None`` and anything else collapse to a short adversarial string.
+    return rng.choice(_ADVERSARIAL_STRINGS)
+
+
+def _mutate_mapping(payload: dict[str, Any], rng: random.Random) -> dict[str, Any]:
+    """Return a deep-copied *payload* with exactly one seeded mutation applied.
+
+    Mutations are JSON-safe so the result round-trips through
+    :meth:`ExecutionResult.model_dump_json`.  An empty mapping is returned
+    unchanged (there is nothing to mutate).
+    """
+    mutated = copy.deepcopy(payload)
+    if not mutated:
+        return mutated
+
+    key = rng.choice(sorted(mutated.keys()))
+    strategy = rng.choice(["drop", "corrupt", "extra", "deep"])
+
+    if strategy == "drop":
+        del mutated[key]
+    elif strategy == "extra":
+        mutated[f"__fuzz_{rng.randint(0, 9999)}"] = rng.choice(_ADVERSARIAL_STRINGS)
+    elif strategy == "deep":
+        value = mutated[key]
+        if isinstance(value, dict):
+            mutated[key] = _mutate_mapping(value, rng)
+        elif isinstance(value, list) and value:
+            idx = rng.randrange(len(value))
+            new_list = list(value)
+            item = new_list[idx]
+            new_list[idx] = _corrupt_scalar(item, rng) if _is_scalar(item) else None
+            mutated[key] = new_list
+        else:
+            mutated[key] = _corrupt_scalar(value, rng) if _is_scalar(value) else None
+    else:  # "corrupt"
+        value = mutated[key]
+        mutated[key] = _corrupt_scalar(value, rng) if _is_scalar(value) else None
+
+    return mutated
+
+
+def _wrap_tool_with_fault(tool: Tool, hook: FaultHook, rng: random.Random) -> Tool:
+    """Return a copy of *tool* whose ``fn`` passes its output through *hook*.
+
+    Mirrors :meth:`chainweaver.testing.runner.FlowTestRunner._wrap_for_logging`:
+    schemas, guards, ``schema_version``, and ``cacheable`` are preserved so the
+    tool's ``schema_hash`` is unchanged and the executor treats it identically.
+    Both sync and async ``fn`` shapes are supported (#80).
+    """
+    original_fn = tool.fn
+    name = tool.name
+
+    fn: Callable[[Any], dict[str, Any] | Awaitable[dict[str, Any]]]
+    if tool.is_async:
+
+        async def _faulty_fn_async(validated_input: BaseModel) -> dict[str, Any]:
+            outputs = await cast("Awaitable[dict[str, Any]]", original_fn(validated_input))
+            return hook(name, dict(outputs), rng)
+
+        fn = _faulty_fn_async
+    else:
+
+        def _faulty_fn(validated_input: BaseModel) -> dict[str, Any]:
+            outputs = cast("dict[str, Any]", original_fn(validated_input))
+            return hook(name, dict(outputs), rng)
+
+        fn = _faulty_fn
+
+    return Tool(
+        name=tool.name,
+        description=tool.description,
+        input_schema=tool.input_schema,
+        output_schema=tool.output_schema,
+        fn=fn,
+        timeout_seconds=tool.timeout_seconds,
+        max_output_size=tool.max_output_size,
+        schema_version=tool.schema_version,
+        cacheable=tool.cacheable,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result models
+# ---------------------------------------------------------------------------
+
+
+class FuzzCase(BaseModel):
+    """One generated fuzzing case.
+
+    Attributes:
+        index: Zero-based position in the run (``0`` is the pristine
+            generated/base input; later cases may carry mutations).
+        initial_input: The initial context passed to ``execute_flow``.
+    """
+
+    index: int
+    initial_input: dict[str, Any]
+
+
+class FuzzFailure(BaseModel):
+    """A single property violation discovered during a fuzzing run.
+
+    Attributes:
+        property_name: Name of the violated :class:`FlowProperty`.
+        case_index: Index of the :class:`FuzzCase` that triggered it.
+        initial_input: The input that triggered the violation (replay it via
+            ``executor.execute_flow(flow_name, initial_input)``).
+        result: The full :class:`ExecutionResult` trace for the case.
+        check_error: Set when the property check itself *raised* (the message
+            of that exception); ``None`` when the check simply returned falsy.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    property_name: str
+    case_index: int
+    initial_input: dict[str, Any]
+    result: ExecutionResult
+    check_error: str | None = None
+
+
+class FuzzReport(BaseModel):
+    """Summary of a :meth:`FlowFuzzer.run` invocation.
+
+    Attributes:
+        flow_name: Name of the fuzzed flow.
+        runs: Number of cases generated.
+        seed: The RNG seed used (re-running with it is reproducible).
+        property_names: Names of the properties that were checked.
+        failures: Every :class:`FuzzFailure` discovered, in case order.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    flow_name: str
+    runs: int
+    seed: int
+    property_names: list[str] = Field(default_factory=list)
+    failures: list[FuzzFailure] = Field(default_factory=list)
+
+    @property
+    def num_failures(self) -> int:
+        """Number of property violations discovered."""
+        return len(self.failures)
+
+    @property
+    def passed(self) -> bool:
+        """``True`` when no property was violated."""
+        return not self.failures
+
+
+# ---------------------------------------------------------------------------
+# Fuzzer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FlowFuzzer:
+    """Generate cases, execute a flow, and check properties (issue #220).
+
+    Args:
+        executor: A :class:`~chainweaver.executor.FlowExecutor` with the flow's
+            tools registered.  When fault injection is active a *fresh* executor
+            is built per case (sharing this one's registry) so the caller's
+            executor is never mutated.
+        flow: The flow to fuzz.  Its ``input_schema`` drives input generation
+            when no ``base_input`` is supplied to :meth:`run`.
+        properties: Invariants to check against every result (at least one).
+        fault_config: Optional tool-output fault-injection configuration.
+        fault_hook: Optional custom fault hook overriding the default derived
+            from ``fault_config``.  Only consulted when fault injection is
+            active (``fault_config.active`` or a hook is supplied).
+    """
+
+    executor: FlowExecutor
+    flow: Flow | DAGFlow
+    properties: list[FlowProperty]
+    fault_config: FaultConfig = field(default_factory=FaultConfig)
+    fault_hook: FaultHook | None = None
+
+    def __post_init__(self) -> None:
+        if not self.properties:
+            raise FuzzConfigError("at least one property is required")
+
+    def run(
+        self,
+        *,
+        runs: int,
+        seed: int,
+        base_input: dict[str, Any] | None = None,
+    ) -> FuzzReport:
+        """Generate *runs* cases seeded by *seed* and return a :class:`FuzzReport`.
+
+        Args:
+            runs: Number of cases to generate (``>= 1``).
+            seed: Deterministic RNG seed.
+            base_input: Optional input to mutate.  When ``None`` the inputs are
+                generated from the flow's ``input_schema``.
+
+        Raises:
+            FuzzConfigError: For ``runs < 1``, a missing/ungeneratable
+                ``input_schema`` with no ``base_input``, etc.
+        """
+        if runs < 1:
+            raise FuzzConfigError("runs must be >= 1")
+
+        cases = self._build_cases(runs=runs, seed=seed, base_input=base_input)
+        failures: list[FuzzFailure] = []
+        for case in cases:
+            result = self._execute(case, seed=seed)
+            for prop in self.properties:
+                violated, check_error = self._evaluate(prop, result)
+                if violated:
+                    failures.append(
+                        FuzzFailure(
+                            property_name=prop.name,
+                            case_index=case.index,
+                            initial_input=case.initial_input,
+                            result=result,
+                            check_error=check_error,
+                        )
+                    )
+
+        return FuzzReport(
+            flow_name=self.flow.name,
+            runs=runs,
+            seed=seed,
+            property_names=[p.name for p in self.properties],
+            failures=failures,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _build_cases(
+        self,
+        *,
+        runs: int,
+        seed: int,
+        base_input: dict[str, Any] | None,
+    ) -> list[FuzzCase]:
+        rng = random.Random(seed)
+        schema = None if base_input is not None else self._resolve_input_schema()
+        cases: list[FuzzCase] = []
+        for i in range(runs):
+            if base_input is not None:
+                payload = copy.deepcopy(base_input)
+                if i > 0:
+                    payload = _mutate_mapping(payload, rng)
+            else:
+                assert schema is not None
+                payload = self._generate_from_schema(schema, rng)
+                if i > 0 and rng.random() < 0.5:
+                    payload = _mutate_mapping(payload, rng)
+            cases.append(FuzzCase(index=i, initial_input=payload))
+        return cases
+
+    def _resolve_input_schema(self) -> type[BaseModel]:
+        schema = self.flow.input_schema
+        if schema is None:
+            raise FuzzConfigError(
+                f"flow '{self.flow.name}' has no input_schema; supply base_input to fuzz it"
+            )
+        return schema
+
+    @staticmethod
+    def _generate_from_schema(schema: type[BaseModel], rng: random.Random) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        for name, info in schema.model_fields.items():
+            try:
+                payload[name] = _generate_value(info.annotation, rng)
+            except _UnsupportedAnnotation as exc:
+                raise FuzzConfigError(
+                    f"cannot generate inputs for field '{name}' "
+                    f"({exc.annotation_repr}); supply base_input"
+                ) from exc
+        return payload
+
+    def _execute(self, case: FuzzCase, *, seed: int) -> ExecutionResult:
+        if self.fault_config.active or self.fault_hook is not None:
+            run_rng = random.Random(seed * 1_000_003 + case.index)
+            hook = self.fault_hook or self._default_fault_hook()
+            run_executor = FlowExecutor(registry=self.executor.registry)
+            for tool in self.executor.registered_tools.values():
+                run_executor.register_tool(_wrap_tool_with_fault(tool, hook, run_rng))
+            return run_executor.execute_flow(self.flow.name, case.initial_input)
+        return self.executor.execute_flow(self.flow.name, case.initial_input)
+
+    def _default_fault_hook(self) -> FaultHook:
+        prob = self.fault_config.output_fault_probability
+
+        def hook(tool_name: str, outputs: dict[str, Any], rng: random.Random) -> dict[str, Any]:
+            if rng.random() >= prob:
+                return outputs
+            return _mutate_mapping(outputs, rng)
+
+        return hook
+
+    @staticmethod
+    def _evaluate(prop: FlowProperty, result: ExecutionResult) -> tuple[bool, str | None]:
+        """Return ``(violated, check_error)`` for *prop* against *result*."""
+        try:
+            holds = prop.holds(result)
+        except Exception as exc:  # a raising property check is itself a violation
+            return True, f"{type(exc).__name__}: {exc}"
+        return (not holds), None
+
+
+# ---------------------------------------------------------------------------
+# Minimization / shrinking (issue #221)
+# ---------------------------------------------------------------------------
+
+
+def _simpler_values(value: Any) -> list[Any]:
+    """Candidate simpler replacements for *value*, in order of preference."""
+    if isinstance(value, bool):
+        return [] if value is False else [False]
+    if isinstance(value, int):
+        return [] if value == 0 else [0]
+    if isinstance(value, float):
+        return [] if value == 0.0 else [0.0]
+    if isinstance(value, str):
+        return [] if value == "" else [""]
+    if isinstance(value, list):
+        return [] if value == [] else [[]]
+    if isinstance(value, dict):
+        return [] if value == {} else [{}]
+    return []
+
+
+def minimize_failure(
+    executor: FlowExecutor,
+    flow: Flow | DAGFlow,
+    failing_input: dict[str, Any],
+    prop: FlowProperty,
+    *,
+    max_rounds: int = 50,
+) -> dict[str, Any]:
+    """Shrink *failing_input* to the smallest input that still violates *prop*.
+
+    A delta-debugging pass that repeatedly (1) removes input keys and (2)
+    simplifies scalar/collection values, keeping a reduction only when the
+    flow still violates the property.  Re-execution uses the public
+    :meth:`FlowExecutor.execute_flow`, so the result is deterministic and the
+    minimized input is a genuine, replayable reproducer.
+
+    Note:
+        Minimization replays against *executor* without fault injection, so it
+        targets *input-driven* failures.  A failure that only reproduces under
+        tool-output fault injection may not shrink (it may not even reproduce);
+        the original failing input/trace remains the authoritative artifact in
+        that case.
+
+    Args:
+        executor: Executor with the flow's tools registered.
+        flow: The flow to replay.
+        failing_input: An input known to violate *prop*.
+        prop: The property whose violation must be preserved.
+        max_rounds: Safety bound on reduction passes (a fixpoint usually ends
+            the loop well before this).
+
+    Returns:
+        The minimized input dict.
+
+    Raises:
+        FuzzConfigError: When *failing_input* does not actually violate *prop*.
+    """
+
+    def violates(candidate: dict[str, Any]) -> bool:
+        result = executor.execute_flow(flow.name, candidate)
+        try:
+            return not prop.holds(result)
+        except Exception:
+            return True
+
+    if not violates(failing_input):
+        raise FuzzConfigError(
+            f"failing_input does not violate property '{prop.name}'; nothing to minimize"
+        )
+
+    current = copy.deepcopy(failing_input)
+    for _ in range(max_rounds):
+        changed = False
+
+        # 1. Try removing each key.
+        for key in sorted(current.keys()):
+            candidate = {k: v for k, v in current.items() if k != key}
+            if violates(candidate):
+                current = candidate
+                changed = True
+
+        # 2. Try simplifying each remaining value.
+        for key in sorted(current.keys()):
+            for simpler in _simpler_values(current[key]):
+                candidate = dict(current)
+                candidate[key] = simpler
+                if violates(candidate):
+                    current = candidate
+                    changed = True
+                    break
+
+        if not changed:
+            break
+
+    return current

--- a/chainweaver/log_utils.py
+++ b/chainweaver/log_utils.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from chainweaver.executor import ExecutionResult, StepRecord
 
 DEFAULT_REDACT_KEYS: frozenset[str] = frozenset(
     {"password", "token", "api_key", "apikey", "secret", "authorization"}
@@ -55,6 +58,41 @@ class RedactionPolicy(BaseModel):
         result = self._apply(data)
         assert isinstance(result, dict)
         return result
+
+    def redact_step_record(self, step: StepRecord) -> StepRecord:
+        """Return a copy of *step* with redacted ``inputs`` and ``outputs`` (issue #217).
+
+        Hosts that persist :class:`~chainweaver.executor.StepRecord` instances
+        (e.g. saving a failing fuzz trace) can mask sensitive values without
+        walking the trace themselves.
+
+        ``StepRecord`` is a Pydantic model — its error is carried as the
+        ``error_type`` / ``error_message`` strings, not as a live exception —
+        so this uses :meth:`pydantic.BaseModel.model_copy` with an ``update``
+        rather than ``dataclasses.replace``.  Non-redacted fields (timestamps,
+        durations, retry metadata) are preserved unchanged.
+        """
+        update: dict[str, Any] = {"inputs": self.redact(step.inputs)}
+        if step.outputs is not None:
+            update["outputs"] = self.redact(step.outputs)
+        return step.model_copy(update=update)
+
+    def redact_execution_result(self, result: ExecutionResult) -> ExecutionResult:
+        """Return a copy of *result* with its trace redacted (issue #217).
+
+        Redacts every :class:`~chainweaver.executor.StepRecord` in
+        ``execution_log`` (via :meth:`redact_step_record`) as well as the
+        top-level ``initial_input`` and ``final_output`` so the returned trace
+        is safe to persist in full.  All other fields (``trace_id``,
+        timestamps, ``cost_report``, …) are preserved unchanged.
+        """
+        update: dict[str, Any] = {
+            "execution_log": [self.redact_step_record(s) for s in result.execution_log],
+            "initial_input": self.redact(result.initial_input),
+        }
+        if result.final_output is not None:
+            update["final_output"] = self.redact(result.final_output)
+        return result.model_copy(update=update)
 
     # ------------------------------------------------------------------
     # Internal recursive helpers

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -479,6 +479,72 @@ chainweaver dump-schema --check --output schemas/flow.schema.json   # CI: fails 
 
 ---
 
+### `fuzz`
+
+Property-based fuzzing for a flow file (issues #220, #221, #222). Generates `--runs` cases — either from the flow's `input_schema` or by mutating a `--input` base — executes the flow, and checks each `--property` (a generic invariant over the `ExecutionResult`) against the result. Optionally injects malformed tool outputs (`--output-fault-prob`), shrinks failing inputs to a minimal reproducer (`--minimize`, issue #221), and saves failing traces as replayable JSON, redacted by default (`--save-failures` / `--redact`, issue #217).
+
+A run is **reproducible**: re-running with the same `--seed`, `--runs`, flow, and tools yields the same cases and failures.
+
+```
+chainweaver fuzz <file> [--tools MODULE...] [--property NAME|module:attr ...] [--runs N] [--seed S] \
+                        [--input JSON | --input-file PATH] [--output-fault-prob P] \
+                        [--minimize] [--save-failures DIR] [--redact/--no-redact] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tools` / `-t` | (empty) | Python module path that exposes `Tool` instances at top level. Repeatable. |
+| `--property` / `-p` | `flow_succeeds` | A built-in property name (`flow_succeeds`, `final_output_present`) or a `module:attr` path to a `FlowProperty` or a `Callable[[ExecutionResult], bool]`. Repeatable. |
+| `--runs` / `-n` | `100` | Number of cases to generate (`>= 1`). |
+| `--seed` | `0` | Deterministic RNG seed. |
+| `--input` / `-i` | (off) | JSON object used as the base input to mutate instead of generating from the schema. |
+| `--input-file` | (off) | Path to a JSON object used as the base input. |
+| `--output-fault-prob` | `0.0` | Probability in `[0,1]` of corrupting a tool's output per call (`0` disables). |
+| `--minimize` / `--no-minimize` | `--no-minimize` | Shrink each failing input to a minimal reproducer. |
+| `--save-failures` | (off) | Directory to write failing `ExecutionResult` traces to (created if absent). |
+| `--redact` / `--no-redact` | `--redact` | Redact saved traces with the default `RedactionPolicy`. |
+| `--format` / `-f` | `table` | Output format: human-readable table or structured JSON. |
+
+**Exit codes**: `0` = no property violated, `1` = one or more violations found or a CLI-level error (bad arguments, malformed flow/input, unknown property), `2` = flow file, tools module, or property module not found / not importable.
+
+**JSON output shape** (when `--format json`):
+
+```json
+{
+  "flow": "my_flow",
+  "runs": 1000,
+  "seed": 42,
+  "properties": ["flow_succeeds"],
+  "failures": 1,
+  "failure_cases": [
+    {
+      "property": "flow_succeeds",
+      "case_index": 17,
+      "initial_input": {"number": 5, "junk": "x"},
+      "check_error": null,
+      "minimized_input": {"junk": "x"},
+      "saved": "failures/my_flow.flow_succeeds.case17.json"
+    }
+  ]
+}
+```
+
+`minimized_input` is present only with `--minimize`; `saved` only with `--save-failures`. `check_error` is set when a property check itself raised (treated as a violation).
+
+**Example (CI integration)**:
+
+```bash
+chainweaver fuzz flows/my_flow.flow.yaml \
+  --tools my_pkg.tools \
+  --property my_pkg.props:no_unauthorized_action \
+  --runs 1000 --seed 42 \
+  --minimize --save-failures failures/
+# exits non-zero when a property is violated, failing the CI job;
+# minimized, redacted reproducers land in failures/ as build artifacts.
+```
+
+---
+
 ## Programmatic registration (`inspect`, `viz`)
 
 `inspect` and `viz` read from a process-scoped registry installed via `cli.set_default_registry`:
@@ -492,4 +558,4 @@ cli.set_default_registry(registry)
 cli.main(["inspect", "my_flow"])
 ```
 
-`validate`, `check`, `run`, `profile`, `diff`, `attest`, `suggest`, and `doctor` read directly from disk and do not consult the default registry. `dump-schema` takes no flow input.
+`validate`, `check`, `run`, `profile`, `diff`, `attest`, `suggest`, `doctor`, and `fuzz` read directly from disk and do not consult the default registry. `dump-schema` takes no flow input.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -481,7 +481,7 @@ chainweaver dump-schema --check --output schemas/flow.schema.json   # CI: fails 
 
 ### `fuzz`
 
-Property-based fuzzing for a flow file (issues #220, #221, #222). Generates `--runs` cases — either from the flow's `input_schema` or by mutating a `--input` base — executes the flow, and checks each `--property` (a generic invariant over the `ExecutionResult`) against the result. Optionally injects malformed tool outputs (`--output-fault-prob`), shrinks failing inputs to a minimal reproducer (`--minimize`, issue #221), and saves failing traces as replayable JSON, redacted by default (`--save-failures` / `--redact`, issue #217).
+Property-based fuzzing for a flow file (issues #220, #221, #222). Generates `--runs` cases — either from the flow's `input_schema` or by mutating a `--input` base — executes the flow, and checks each `--property` (a generic invariant over the `ExecutionResult`) against the result. Optionally injects malformed tool outputs (`--output-fault-prob`), shrinks failing inputs to a minimal reproducer (`--minimize`, issue #221), and saves failing traces as replayable JSON, redacted by default (`--save-failures` / `--redact`, issue #217). With `--redact` (the default) the failing and minimized inputs printed in the summary/table are redacted too, so secrets do not leak into CI logs; pass `--no-redact` for raw values. Each `--property` must resolve to a unique name.
 
 A run is **reproducible**: re-running with the same `--seed`, `--runs`, flow, and tools yields the same cases and failures.
 
@@ -502,7 +502,7 @@ chainweaver fuzz <file> [--tools MODULE...] [--property NAME|module:attr ...] [-
 | `--output-fault-prob` | `0.0` | Probability in `[0,1]` of corrupting a tool's output per call (`0` disables). |
 | `--minimize` / `--no-minimize` | `--no-minimize` | Shrink each failing input to a minimal reproducer. |
 | `--save-failures` | (off) | Directory to write failing `ExecutionResult` traces to (created if absent). |
-| `--redact` / `--no-redact` | `--redact` | Redact saved traces with the default `RedactionPolicy`. |
+| `--redact` / `--no-redact` | `--redact` | Redact saved traces **and emitted failing/minimized inputs** with the default `RedactionPolicy`. Use `--no-redact` for raw values. |
 | `--format` / `-f` | `table` | Output format: human-readable table or structured JSON. |
 
 **Exit codes**: `0` = no property violated, `1` = one or more violations found or a CLI-level error (bad arguments, malformed flow/input, unknown property), `2` = flow file, tools module, or property module not found / not importable.

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -2,6 +2,7 @@
   "__all__": [
     "AttestationInputError",
     "AttestationReport",
+    "BUILTIN_PROPERTIES",
     "BaseDecisionCallback",
     "BaseMiddleware",
     "ChainAnalyzer",
@@ -30,6 +31,7 @@
     "ExecutionPlan",
     "ExecutionResult",
     "ExecutionSnapshot",
+    "FaultConfig",
     "FileCheckpointer",
     "FileStepCache",
     "FileStore",
@@ -43,13 +45,19 @@
     "FlowExecutionError",
     "FlowExecutor",
     "FlowExecutorMiddleware",
+    "FlowFuzzer",
     "FlowNotFoundError",
+    "FlowProperty",
     "FlowRegistry",
     "FlowSerializationError",
     "FlowStartContext",
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
+    "FuzzCase",
+    "FuzzConfigError",
+    "FuzzFailure",
+    "FuzzReport",
     "InMemoryCheckpointer",
     "InMemoryStepCache",
     "InMemoryStore",
@@ -106,6 +114,7 @@
     "flow_to_mermaid",
     "flow_to_yaml",
     "merge_safety",
+    "minimize_failure",
     "result_to_mermaid",
     "schema_fingerprint",
     "suggest_optimizations",
@@ -144,6 +153,11 @@
       },
       "module": "chainweaver.attest",
       "qualname": "AttestationReport"
+    },
+    "BUILTIN_PROPERTIES": {
+      "kind": "dict",
+      "module": null,
+      "qualname": null
     },
     "BaseDecisionCallback": {
       "kind": "class",
@@ -388,6 +402,12 @@
       "module": "chainweaver.checkpoint",
       "qualname": "ExecutionSnapshot"
     },
+    "FaultConfig": {
+      "kind": "class",
+      "module": "chainweaver.fuzz",
+      "qualname": "FaultConfig",
+      "signature": "(output_fault_probability: float = 0.0) -> None"
+    },
     "FileCheckpointer": {
       "kind": "class",
       "module": "chainweaver.checkpoint",
@@ -496,11 +516,23 @@
       "qualname": "FlowExecutorMiddleware",
       "signature": "(*args, **kwargs)"
     },
+    "FlowFuzzer": {
+      "kind": "class",
+      "module": "chainweaver.fuzz",
+      "qualname": "FlowFuzzer",
+      "signature": "(executor: FlowExecutor, flow: Flow | DAGFlow, properties: list[FlowProperty], fault_config: FaultConfig = <factory>, fault_hook: FaultHook | None = None) -> None"
+    },
     "FlowNotFoundError": {
       "kind": "class",
       "module": "chainweaver.exceptions",
       "qualname": "FlowNotFoundError",
       "signature": "(flow_name: str, *, version: str | None = None) -> None"
+    },
+    "FlowProperty": {
+      "kind": "class",
+      "module": "chainweaver.fuzz",
+      "qualname": "FlowProperty",
+      "signature": "(name: str, check: PropertyCheck, description: str = '') -> None"
     },
     "FlowRegistry": {
       "kind": "class",
@@ -551,6 +583,45 @@
       },
       "module": "chainweaver.flow",
       "qualname": "FlowStep"
+    },
+    "FuzzCase": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "index": "int",
+        "initial_input": "dict[str, Any]"
+      },
+      "module": "chainweaver.fuzz",
+      "qualname": "FuzzCase"
+    },
+    "FuzzConfigError": {
+      "kind": "class",
+      "module": "chainweaver.fuzz",
+      "qualname": "FuzzConfigError",
+      "signature": "(detail: str) -> None"
+    },
+    "FuzzFailure": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "case_index": "int",
+        "check_error": "str | NoneType",
+        "initial_input": "dict[str, Any]",
+        "property_name": "str",
+        "result": "chainweaver.executor.ExecutionResult"
+      },
+      "module": "chainweaver.fuzz",
+      "qualname": "FuzzFailure"
+    },
+    "FuzzReport": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "failures": "list[chainweaver.fuzz.FuzzFailure]",
+        "flow_name": "str",
+        "property_names": "list[str]",
+        "runs": "int",
+        "seed": "int"
+      },
+      "module": "chainweaver.fuzz",
+      "qualname": "FuzzReport"
     },
     "InMemoryCheckpointer": {
       "kind": "class",
@@ -969,6 +1040,12 @@
       "module": "chainweaver.contracts",
       "qualname": "merge_safety",
       "signature": "(contracts: Iterable[ToolSafetyContract], *, default: ToolSafetyContract | None = None) -> ToolSafetyContract"
+    },
+    "minimize_failure": {
+      "kind": "function",
+      "module": "chainweaver.fuzz",
+      "qualname": "minimize_failure",
+      "signature": "(executor: FlowExecutor, flow: Flow | DAGFlow, failing_input: dict[str, Any], prop: FlowProperty, *, max_rounds: int = 50) -> dict[str, Any]"
     },
     "result_to_mermaid": {
       "kind": "function",

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -1,0 +1,358 @@
+"""CLI tests for ``chainweaver fuzz`` (issue #222, with #217/#221 integration)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from chainweaver import Flow, FlowStep, cli
+
+
+def _write_flow(path: Path, module_name: str) -> None:
+    flow = Flow(
+        name="cli_fuzz",
+        version="0.1.0",
+        description="Echoes a token.",
+        steps=[FlowStep(tool_name="emit", input_mapping={"token": "token"})],
+        input_schema_ref=f"{module_name}:TokenIn",
+    )
+    path.write_text(flow.to_yaml(), encoding="utf-8")
+
+
+def _write_module(dir_path: Path) -> str:
+    module_name = f"fuzzmod_{dir_path.stem.replace('.', '_')}"
+    (dir_path / f"{module_name}.py").write_text(
+        "from __future__ import annotations\n"
+        "from typing import Any\n"
+        "from pydantic import BaseModel\n"
+        "from chainweaver import Tool, FlowProperty\n"
+        "\n"
+        "class TokenIn(BaseModel):\n"
+        "    token: str\n"
+        "\n"
+        "class TokenOut(BaseModel):\n"
+        "    token: str\n"
+        "    length: int\n"
+        "\n"
+        "def _fn(inp: TokenIn) -> dict[str, Any]:\n"
+        "    return {'token': inp.token, 'length': len(inp.token)}\n"
+        "\n"
+        "emit = Tool(\n"
+        "    name='emit', description='Echoes.',\n"
+        "    input_schema=TokenIn, output_schema=TokenOut, fn=_fn,\n"
+        ")\n"
+        "\n"
+        "always_false = FlowProperty('always_false', lambda r: False, 'Never holds.')\n"
+        "\n"
+        "NOT_CALLABLE = 42\n",
+        encoding="utf-8",
+    )
+    return module_name
+
+
+@pytest.fixture()
+def _env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for key in list(sys.modules):
+        if key.startswith("fuzzmod_"):
+            sys.modules.pop(key, None)
+    module = _write_module(tmp_path)
+    flow_path = tmp_path / "f.flow.yaml"
+    _write_flow(flow_path, module)
+    return flow_path, module
+
+
+class TestFuzzHappyPath:
+    def test_no_violations_exits_zero(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "1",
+                "--format",
+                "json",
+            ]
+        )
+        out = json.loads(capsys.readouterr().out)
+        assert code == 0
+        assert out["failures"] == 0
+        assert out["flow"] == "cli_fuzz"
+        assert out["properties"] == ["flow_succeeds"]
+
+    def test_table_output_runs(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "1",
+            ]
+        )
+        assert code == 0
+        assert "no property violations found" in capsys.readouterr().out
+
+
+class TestFuzzViolations:
+    def test_always_false_property_exits_one(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "4",
+                "--format",
+                "json",
+            ]
+        )
+        out = json.loads(capsys.readouterr().out)
+        assert code == 1
+        assert out["failures"] == 4
+        # The FlowProperty's own ``name`` is reported, not the import spec.
+        assert out["properties"] == ["always_false"]
+
+    def test_builtin_property_by_name(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                "final_output_present",
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "1",
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 0
+        assert json.loads(capsys.readouterr().out)["properties"] == ["final_output_present"]
+
+    def test_deterministic_summary(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        args = [
+            "fuzz",
+            str(flow_path),
+            "--tools",
+            module,
+            "--property",
+            f"{module}:always_false",
+            "--runs",
+            "10",
+            "--seed",
+            "5",
+            "--format",
+            "json",
+        ]
+        cli.main(args)
+        first = capsys.readouterr().out
+        cli.main(args)
+        second = capsys.readouterr().out
+        assert first == second
+
+
+class TestFuzzSaveAndRedact:
+    def test_save_failures_redacts_by_default(
+        self, _env: tuple[Path, str], tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        out_dir = tmp_path / "failures"
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "topsecret"}',
+                "--runs",
+                "1",
+                "--save-failures",
+                str(out_dir),
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 1
+        saved = list(out_dir.glob("*.json"))
+        assert len(saved) == 1
+        text = saved[0].read_text(encoding="utf-8")
+        # "token" is a default-redacted key, so the secret must not leak.
+        assert "topsecret" not in text
+        assert "***REDACTED***" in text
+        # The summary references the saved path.
+        record = json.loads(capsys.readouterr().out)["failure_cases"][0]
+        assert record["saved"] == str(saved[0])
+
+    def test_no_redact_keeps_raw_values(self, _env: tuple[Path, str], tmp_path: Path) -> None:
+        flow_path, module = _env
+        out_dir = tmp_path / "raw"
+        cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "topsecret"}',
+                "--runs",
+                "1",
+                "--save-failures",
+                str(out_dir),
+                "--no-redact",
+            ]
+        )
+        saved = list(out_dir.glob("*.json"))
+        assert "topsecret" in saved[0].read_text(encoding="utf-8")
+
+    def test_minimize_emits_minimized_input(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "abc", "junk": "x"}',
+                "--runs",
+                "1",
+                "--minimize",
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 1
+        record = json.loads(capsys.readouterr().out)["failure_cases"][0]
+        assert "minimized_input" in record
+        # An always-false property lets the input shrink to nothing.
+        assert len(record["minimized_input"]) <= len(record["initial_input"])
+
+
+class TestFuzzErrors:
+    def test_missing_flow_file_returns_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert cli.main(["fuzz", str(tmp_path / "nope.flow.yaml")]) == 2
+
+    def test_runs_must_be_positive(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(["fuzz", str(flow_path), "--tools", module, "--runs", "0"])
+        assert code == 1
+        assert "--runs must be >= 1" in capsys.readouterr().err
+
+    def test_invalid_fault_probability(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(["fuzz", str(flow_path), "--tools", module, "--output-fault-prob", "2.0"])
+        assert code == 1
+        assert "output-fault-prob" in capsys.readouterr().err
+
+    def test_unknown_property_returns_one(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(["fuzz", str(flow_path), "--tools", module, "--property", "nope"])
+        assert code == 1
+        assert "unknown property" in capsys.readouterr().err
+
+    def test_property_module_not_importable_returns_two(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            ["fuzz", str(flow_path), "--tools", module, "--property", "no_such_module:prop"]
+        )
+        assert code == 2
+
+    def test_non_callable_property_returns_one(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            ["fuzz", str(flow_path), "--tools", module, "--property", f"{module}:NOT_CALLABLE"]
+        )
+        assert code == 1
+        assert "neither a FlowProperty nor a callable" in capsys.readouterr().err
+
+    def test_missing_property_attr_returns_one(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            ["fuzz", str(flow_path), "--tools", module, "--property", f"{module}:ghost"]
+        )
+        assert code == 1
+        assert "not found in module" in capsys.readouterr().err
+
+    def test_output_fault_injection_via_cli(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "20",
+                "--output-fault-prob",
+                "1.0",
+                "--seed",
+                "1",
+                "--format",
+                "json",
+            ]
+        )
+        # Corrupting every tool output makes the doubling/echo flow fail
+        # output validation, so flow_succeeds is violated at least once.
+        assert code == 1
+        assert json.loads(capsys.readouterr().out)["failures"] > 0

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -47,6 +47,9 @@ def _write_module(dir_path: Path) -> str:
         "\n"
         "always_false = FlowProperty('always_false', lambda r: False, 'Never holds.')\n"
         "\n"
+        "def always_false_fn(r: Any) -> bool:\n"
+        "    return False\n"
+        "\n"
         "NOT_CALLABLE = 42\n",
         encoding="utf-8",
     )
@@ -270,6 +273,91 @@ class TestFuzzSaveAndRedact:
         # An always-false property lets the input shrink to nothing.
         assert len(record["minimized_input"]) <= len(record["initial_input"])
 
+    def test_emitted_inputs_redacted_by_default(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "topsecret"}',
+                "--runs",
+                "1",
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 1
+        out = capsys.readouterr().out
+        # Even without --save-failures, raw inputs printed to stdout must not
+        # leak secrets into CI logs (issue #217 review follow-up).
+        assert "topsecret" not in out
+        record = json.loads(out)["failure_cases"][0]
+        assert record["initial_input"]["token"] == "***REDACTED***"
+
+    def test_emitted_inputs_raw_with_no_redact(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false",
+                "--input",
+                '{"token": "topsecret"}',
+                "--runs",
+                "1",
+                "--no-redact",
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 1
+        record = json.loads(capsys.readouterr().out)["failure_cases"][0]
+        assert record["initial_input"]["token"] == "topsecret"
+
+    def test_saved_filename_is_sanitized(
+        self, _env: tuple[Path, str], tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        out_dir = tmp_path / "sanitized"
+        # A callable property spec yields the name "module:always_false_fn",
+        # whose ':' is invalid in a Windows filename (issue #217 review
+        # follow-up).  It must be sanitized before building the path.
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                f"{module}:always_false_fn",
+                "--input",
+                '{"token": "abc"}',
+                "--runs",
+                "1",
+                "--save-failures",
+                str(out_dir),
+                "--format",
+                "json",
+            ]
+        )
+        assert code == 1
+        saved = list(out_dir.glob("*.json"))
+        assert len(saved) == 1
+        assert ":" not in saved[0].name
+        assert f"{module}_always_false_fn" in saved[0].name
+
 
 class TestFuzzErrors:
     def test_missing_flow_file_returns_two(
@@ -329,6 +417,29 @@ class TestFuzzErrors:
         )
         assert code == 1
         assert "not found in module" in capsys.readouterr().err
+
+    def test_duplicate_property_names_returns_one(
+        self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        flow_path, module = _env
+        # The same property twice would silently collapse in props_by_name and
+        # could run minimization against the wrong impl (#222 review follow-up).
+        code = cli.main(
+            [
+                "fuzz",
+                str(flow_path),
+                "--tools",
+                module,
+                "--property",
+                "flow_succeeds",
+                "--property",
+                "flow_succeeds",
+                "--input",
+                '{"token": "abc"}',
+            ]
+        )
+        assert code == 1
+        assert "duplicate property name" in capsys.readouterr().err
 
     def test_output_fault_injection_via_cli(
         self, _env: tuple[Path, str], capsys: pytest.CaptureFixture[str]

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,250 @@
+"""Tests for the property-based fuzzing harness (issues #220, #221)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from helpers import NumberInput, ValueOutput, _double_fn
+
+from chainweaver import (
+    BUILTIN_PROPERTIES,
+    ExecutionResult,
+    FaultConfig,
+    Flow,
+    FlowExecutor,
+    FlowFuzzer,
+    FlowProperty,
+    FlowRegistry,
+    FlowStep,
+    FuzzConfigError,
+    Tool,
+    minimize_failure,
+)
+
+
+def _build() -> tuple[FlowExecutor, Flow]:
+    """A single-step doubling flow with an input_schema, plus its executor."""
+    flow = Flow(
+        name="fuzz_double",
+        version="0.1.0",
+        description="Doubles a number.",
+        steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
+        input_schema_ref=Flow.schema_ref_from(NumberInput),
+    )
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    executor = FlowExecutor(registry=registry)
+    executor.register_tool(
+        Tool(
+            name="double",
+            description="Doubles.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_double_fn,
+        )
+    )
+    return executor, flow
+
+
+_ALWAYS_FALSE = FlowProperty("always_false", lambda _r: False, "Never holds.")
+
+
+class TestFlowFuzzerBasics:
+    def test_requires_at_least_one_property(self) -> None:
+        executor, flow = _build()
+        with pytest.raises(FuzzConfigError):
+            FlowFuzzer(executor=executor, flow=flow, properties=[])
+
+    def test_runs_must_be_positive(self) -> None:
+        executor, flow = _build()
+        fuzzer = FlowFuzzer(
+            executor=executor, flow=flow, properties=[BUILTIN_PROPERTIES["flow_succeeds"]]
+        )
+        with pytest.raises(FuzzConfigError):
+            fuzzer.run(runs=0, seed=1)
+
+    def test_schema_generation_when_no_base_input(self) -> None:
+        executor, flow = _build()
+        fuzzer = FlowFuzzer(
+            executor=executor, flow=flow, properties=[BUILTIN_PROPERTIES["flow_succeeds"]]
+        )
+        report = fuzzer.run(runs=20, seed=7)
+        assert report.runs == 20
+        assert report.property_names == ["flow_succeeds"]
+        # Case 0 is the pristine, schema-valid generated input — it always runs
+        # cleanly.  Later cases may be mutated (e.g. the required ``number`` key
+        # dropped), and such adversarial inputs legitimately surface as failures.
+        assert 0 not in {f.case_index for f in report.failures}
+
+    def test_schema_generation_is_deterministic(self) -> None:
+        executor, flow = _build()
+        prop = [BUILTIN_PROPERTIES["flow_succeeds"]]
+        a = FlowFuzzer(executor=executor, flow=flow, properties=prop).run(runs=20, seed=7)
+        b = FlowFuzzer(executor=executor, flow=flow, properties=prop).run(runs=20, seed=7)
+        assert [f.initial_input for f in a.failures] == [f.initial_input for f in b.failures]
+
+    def test_missing_schema_without_base_input_errors(self) -> None:
+        # A flow with no input_schema_ref cannot generate inputs.
+        flow = Flow(
+            name="no_schema",
+            description="No schema.",
+            steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
+        )
+        registry = FlowRegistry()
+        registry.register_flow(flow)
+        executor = FlowExecutor(registry=registry)
+        executor.register_tool(
+            Tool(
+                name="double",
+                description="Doubles.",
+                input_schema=NumberInput,
+                output_schema=ValueOutput,
+                fn=_double_fn,
+            )
+        )
+        fuzzer = FlowFuzzer(
+            executor=executor, flow=flow, properties=[BUILTIN_PROPERTIES["flow_succeeds"]]
+        )
+        with pytest.raises(FuzzConfigError):
+            fuzzer.run(runs=5, seed=1)
+
+
+class TestViolationDetection:
+    def test_always_false_property_fails_every_case(self) -> None:
+        executor, flow = _build()
+        fuzzer = FlowFuzzer(executor=executor, flow=flow, properties=[_ALWAYS_FALSE])
+        report = fuzzer.run(runs=8, seed=1, base_input={"number": 3})
+        assert report.num_failures == 8
+        assert not report.passed
+        assert all(f.property_name == "always_false" for f in report.failures)
+        assert {f.case_index for f in report.failures} == set(range(8))
+
+    def test_raising_property_is_recorded_as_violation(self) -> None:
+        executor, flow = _build()
+
+        def _boom(_r: ExecutionResult) -> bool:
+            raise RuntimeError("kaboom")
+
+        prop = FlowProperty("boom", _boom)
+        fuzzer = FlowFuzzer(executor=executor, flow=flow, properties=[prop])
+        report = fuzzer.run(runs=3, seed=1, base_input={"number": 1})
+        assert report.num_failures == 3
+        assert report.failures[0].check_error is not None
+        assert "RuntimeError: kaboom" in report.failures[0].check_error
+
+    def test_failure_carries_replayable_trace(self) -> None:
+        executor, flow = _build()
+        fuzzer = FlowFuzzer(executor=executor, flow=flow, properties=[_ALWAYS_FALSE])
+        report = fuzzer.run(runs=1, seed=1, base_input={"number": 21})
+        failure = report.failures[0]
+        assert isinstance(failure.result, ExecutionResult)
+        # The carried input replays to the same successful doubling result.
+        replayed = executor.execute_flow(flow.name, failure.initial_input)
+        assert replayed.success
+        assert replayed.final_output is not None
+        assert replayed.final_output["value"] == 42
+
+
+class TestDeterminism:
+    def test_same_seed_same_failures(self) -> None:
+        executor, flow = _build()
+        prop = [BUILTIN_PROPERTIES["flow_succeeds"]]
+        a = FlowFuzzer(executor=executor, flow=flow, properties=prop).run(runs=40, seed=99)
+        b = FlowFuzzer(executor=executor, flow=flow, properties=prop).run(runs=40, seed=99)
+        assert [f.initial_input for f in a.failures] == [f.initial_input for f in b.failures]
+        assert a.num_failures == b.num_failures
+
+    def test_base_input_mutation_is_seeded(self) -> None:
+        executor, flow = _build()
+        fuzzer = FlowFuzzer(executor=executor, flow=flow, properties=[_ALWAYS_FALSE])
+        a = fuzzer.run(runs=10, seed=5, base_input={"number": 2})
+        b = fuzzer.run(runs=10, seed=5, base_input={"number": 2})
+        assert [f.initial_input for f in a.failures] == [f.initial_input for f in b.failures]
+        # Case 0 is the pristine base input; later cases may be mutated.
+        assert a.failures[0].initial_input == {"number": 2}
+
+
+class TestFaultInjection:
+    def test_custom_fault_hook_breaks_every_run(self) -> None:
+        executor, flow = _build()
+
+        def _drop_all(_name: str, _outputs: dict[str, Any], _rng: Any) -> dict[str, Any]:
+            return {}  # empty output -> required 'value' missing -> step fails
+
+        fuzzer = FlowFuzzer(
+            executor=executor,
+            flow=flow,
+            properties=[BUILTIN_PROPERTIES["flow_succeeds"]],
+            fault_hook=_drop_all,
+        )
+        report = fuzzer.run(runs=6, seed=1, base_input={"number": 4})
+        assert report.num_failures == 6
+
+    def test_fault_injection_does_not_mutate_caller_executor(self) -> None:
+        executor, flow = _build()
+
+        def _drop_all(_name: str, _outputs: dict[str, Any], _rng: Any) -> dict[str, Any]:
+            return {}
+
+        FlowFuzzer(
+            executor=executor,
+            flow=flow,
+            properties=[BUILTIN_PROPERTIES["flow_succeeds"]],
+            fault_hook=_drop_all,
+        ).run(runs=3, seed=1, base_input={"number": 4})
+        # The caller's executor still runs the real (un-faulted) tool.
+        clean = executor.execute_flow(flow.name, {"number": 4})
+        assert clean.success
+        assert clean.final_output is not None
+        assert clean.final_output["value"] == 8
+
+    def test_fault_config_probability_is_reproducible(self) -> None:
+        executor, flow = _build()
+        prop = [BUILTIN_PROPERTIES["flow_succeeds"]]
+        config = FaultConfig(output_fault_probability=1.0)
+        assert config.active
+        a = FlowFuzzer(executor=executor, flow=flow, properties=prop, fault_config=config).run(
+            runs=30, seed=3, base_input={"number": 4}
+        )
+        b = FlowFuzzer(executor=executor, flow=flow, properties=prop, fault_config=config).run(
+            runs=30, seed=3, base_input={"number": 4}
+        )
+        assert a.num_failures == b.num_failures
+        assert a.num_failures > 0
+
+    def test_invalid_fault_probability_rejected(self) -> None:
+        with pytest.raises(FuzzConfigError):
+            FaultConfig(output_fault_probability=1.5)
+
+
+class TestMinimize:
+    def test_shrinks_to_minimal_reproducer(self) -> None:
+        executor, flow = _build()
+        # Violated whenever the input carries a key other than "number".
+        prop = FlowProperty(
+            "only_number",
+            lambda r: set(r.initial_input.keys()) <= {"number"},
+        )
+        failing = {"number": 7, "junk": "leak", "extra": 99}
+        minimized = minimize_failure(executor, flow, failing, prop)
+        # Still violates, and is strictly smaller than the noisy original.
+        assert set(minimized.keys()) - {"number"}
+        assert len(minimized) < len(failing)
+        replayed = executor.execute_flow(flow.name, minimized)
+        assert set(replayed.initial_input.keys()) - {"number"}
+
+    def test_minimize_rejects_non_violating_input(self) -> None:
+        executor, flow = _build()
+        prop = BUILTIN_PROPERTIES["flow_succeeds"]
+        with pytest.raises(FuzzConfigError):
+            # A valid input succeeds, so there is nothing to minimize.
+            minimize_failure(executor, flow, {"number": 1}, prop)
+
+
+class TestBuiltinProperties:
+    def test_final_output_present_holds_on_success(self) -> None:
+        executor, flow = _build()
+        result = executor.execute_flow(flow.name, {"number": 2})
+        assert BUILTIN_PROPERTIES["final_output_present"].holds(result)
+        assert BUILTIN_PROPERTIES["flow_succeeds"].holds(result)

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -21,6 +21,32 @@ from chainweaver import (
     Tool,
     minimize_failure,
 )
+from chainweaver import attest as attest_module
+from chainweaver.middleware import (
+    FlowEndContext,
+    FlowStartContext,
+    StepEndContext,
+    StepStartContext,
+)
+
+
+class _RecordingMiddleware:
+    """Records every middleware hook invocation, mirroring test_middleware.py."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any]] = []
+
+    def on_flow_start(self, ctx: FlowStartContext) -> None:
+        self.events.append(("flow_start", ctx))
+
+    def on_step_start(self, ctx: StepStartContext) -> None:
+        self.events.append(("step_start", ctx))
+
+    def on_step_end(self, ctx: StepEndContext) -> None:
+        self.events.append(("step_end", ctx))
+
+    def on_flow_end(self, ctx: FlowEndContext) -> None:
+        self.events.append(("flow_end", ctx))
 
 
 def _build() -> tuple[FlowExecutor, Flow]:
@@ -248,3 +274,58 @@ class TestBuiltinProperties:
         result = executor.execute_flow(flow.name, {"number": 2})
         assert BUILTIN_PROPERTIES["final_output_present"].holds(result)
         assert BUILTIN_PROPERTIES["flow_succeeds"].holds(result)
+
+
+class TestExecutorConfigPreservation:
+    """Fault injection must not silently drop executor configuration (#220 review)."""
+
+    def test_middleware_preserved_under_fault_injection(self) -> None:
+        executor, flow = _build()
+        rec = _RecordingMiddleware()
+        executor.add_middleware(rec)
+        fuzzer = FlowFuzzer(
+            executor=executor,
+            flow=flow,
+            properties=[BUILTIN_PROPERTIES["flow_succeeds"]],
+            fault_config=FaultConfig(output_fault_probability=1.0),
+        )
+        fuzzer.run(runs=3, seed=1)
+        # The per-case executor built for fault injection must reuse the
+        # configured middleware, so its hooks fire.  Before the fix it built a
+        # bare FlowExecutor and recorded nothing.
+        kinds = {kind for kind, _ in rec.events}
+        assert "flow_start" in kinds
+        assert "flow_end" in kinds
+
+    def test_with_replaced_tools_preserves_config_and_swaps_tools(self) -> None:
+        executor, flow = _build()
+        rec = _RecordingMiddleware()
+        executor.add_middleware(rec)
+
+        def _tripled(inp: NumberInput) -> dict[str, Any]:
+            return {"value": inp.number * 3}
+
+        replacement = Tool(
+            name="double",  # same name, different behavior
+            description="Actually triples.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_tripled,
+        )
+        clone = executor.with_replaced_tools([replacement])
+        result = clone.execute_flow(flow.name, {"number": 4})
+        assert result.final_output is not None
+        assert result.final_output["value"] == 12  # swapped tool ran
+        assert any(kind == "flow_end" for kind, _ in rec.events)  # config preserved
+
+
+class TestSharedSchemaGenerator:
+    """The schema-value generator is a supported public API (#220 review)."""
+
+    def test_generator_helpers_are_public(self) -> None:
+        from chainweaver.attest import UnsupportedAnnotation, generate_value
+
+        assert "generate_value" in attest_module.__all__
+        assert "UnsupportedAnnotation" in attest_module.__all__
+        assert callable(generate_value)
+        assert issubclass(UnsupportedAnnotation, Exception)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -213,3 +213,100 @@ class TestExecutorIntegration:
         start_message = start_messages[0]
         assert "s3cret" not in start_message
         assert "***REDACTED***" in start_message
+
+
+# ---------------------------------------------------------------------------
+# Trace-redaction helpers (issue #217)
+# ---------------------------------------------------------------------------
+
+
+def _run_secret_flow() -> Any:
+    """Run a single-step flow whose trace carries a sensitive ``token``."""
+
+    class _In(BaseModel):
+        token: str
+
+    class _Out(BaseModel):
+        token: str
+        ok: bool
+
+    def _echo(inp: _In) -> dict[str, Any]:
+        return {"token": inp.token, "ok": True}
+
+    flow = Flow(
+        name="secret_flow",
+        version="0.1.0",
+        description="Echoes a token.",
+        steps=[FlowStep(tool_name="echo")],
+    )
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    ex = FlowExecutor(registry=registry)
+    ex.register_tool(
+        Tool(
+            name="echo",
+            description="Echoes.",
+            input_schema=_In,
+            output_schema=_Out,
+            fn=_echo,
+        )
+    )
+    return ex.execute_flow("secret_flow", {"token": "s3cret"})
+
+
+class TestRedactStepRecord:
+    def test_masks_inputs_and_outputs(self) -> None:
+        result = _run_secret_flow()
+        policy = RedactionPolicy()
+        step = result.execution_log[0]
+        redacted = policy.redact_step_record(step)
+        assert redacted.inputs["token"] == policy.redact_replacement
+        assert redacted.outputs is not None
+        assert redacted.outputs["token"] == policy.redact_replacement
+        assert redacted.outputs["ok"] is True
+
+    def test_returns_a_copy_and_preserves_metadata(self) -> None:
+        result = _run_secret_flow()
+        policy = RedactionPolicy()
+        step = result.execution_log[0]
+        redacted = policy.redact_step_record(step)
+        # Original is untouched (audit-grade contract).
+        assert step.inputs["token"] == "s3cret"
+        # Non-redacted metadata is preserved unchanged.
+        assert redacted.tool_name == step.tool_name
+        assert redacted.step_index == step.step_index
+        assert redacted.started_at == step.started_at
+        assert redacted.success == step.success
+
+    def test_none_outputs_preserved(self) -> None:
+        policy = RedactionPolicy()
+        result = _run_secret_flow()
+        step = result.execution_log[0].model_copy(update={"outputs": None})
+        redacted = policy.redact_step_record(step)
+        assert redacted.outputs is None
+        assert redacted.inputs["token"] == policy.redact_replacement
+
+
+class TestRedactExecutionResult:
+    def test_redacts_log_initial_and_final(self) -> None:
+        result = _run_secret_flow()
+        policy = RedactionPolicy()
+        redacted = policy.redact_execution_result(result)
+        assert redacted.initial_input["token"] == policy.redact_replacement
+        assert redacted.final_output is not None
+        assert redacted.final_output["token"] == policy.redact_replacement
+        assert redacted.execution_log[0].outputs is not None
+        assert redacted.execution_log[0].outputs["token"] == policy.redact_replacement
+        # Original trace is unmodified.
+        assert result.initial_input["token"] == "s3cret"
+
+    def test_preserves_trace_id_and_serializes(self) -> None:
+        result = _run_secret_flow()
+        policy = RedactionPolicy()
+        redacted = policy.redact_execution_result(result)
+        assert redacted.trace_id == result.trace_id
+        assert redacted.success == result.success
+        # The redacted trace still round-trips through JSON.
+        dumped = redacted.model_dump_json()
+        assert "s3cret" not in dumped
+        assert policy.redact_replacement in dumped


### PR DESCRIPTION
Add an active failure-discovery layer that complements ChainWeaver's existing
replay/diff/attest reproduction primitives.

- chainweaver/fuzz.py (#220): FlowFuzzer generates/mutates inputs from a flow's
  input_schema (or a base input), optionally injects malformed tool outputs via
  a seeded fault hook, executes the flow, and records FlowProperty violations as
  replayable ExecutionResult traces. All randomness is seeded so runs are
  reproducible; the executor stays randomness-free. Ships FlowProperty,
  FaultConfig, FuzzCase/FuzzFailure/FuzzReport, BUILTIN_PROPERTIES, and
  FuzzConfigError.
- minimize_failure (#221): delta-debugs a failing input to the smallest
  reproducer that still violates a property, re-verifying each reduction.
- chainweaver fuzz CLI (#222): --property (builtin or module:attr), --runs,
  --seed, --input/--input-file, --output-fault-prob, --minimize, --save-failures
  (redacted by default), --format. Non-zero exit on violation. Documented in
  docs/cli.md.
- RedactionPolicy.redact_step_record / redact_execution_result (#217): return
  redacted copies of StepRecord / ExecutionResult, used by the save-failures
  path. Implemented with Pydantic model_copy (the models are BaseModel with
  string-only error fields, not dataclasses carrying live exceptions).

Tests cover detection, seed determinism, fault injection, minimization,
redaction round-trips, and the full CLI exit-code contract. All four validation
commands pass; project coverage 91%.

https://claude.ai/code/session_01KQy8CtFEATMZ8rZmkepQ1Y