### PR TITLE
feat: README/landing-page conversion overhaul (#225, #227, #228, #229, #232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         run: python -m pytest tests/ -m property --no-cov --hypothesis-show-statistics -v
 
+      # Execute the "Open in Colab" quickstart notebook (issue #229) so the
+      # zero-install on-ramp can't silently rot. Run once on the canonical
+      # ubuntu / 3.12 lane (3.12 matches Colab's runtime); --no-cov because the
+      # notebook isn't part of the package coverage gate.
+      - name: Run notebooks (nbmake)
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: python -m pytest --nbmake notebooks/ --no-cov -v
+
   conformance:
     name: weaver-spec conformance (#91)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ and `FlowExecutor` *replaces* the per-step LLM round-trips with deterministic,
 schema-validated execution — no model in the loop. You compile the path the
 analyzer surfaces instead of hand-wiring it.
 
-**Governance for tool pipelines.** Typed I/O at every step, file-serializable
+**Governance for tool flows.** Typed I/O at every step, file-serializable
 flows, schema-drift detection, determinism *attestation*, property fuzzing, and
 structured audit traces — disciplined, auditable, portable deterministic
-pipelines.
+execution.
 
 > **Quantified and reproducible.** In the repo's
 > [benchmark report](benchmarks/results/latest.md), compiled flows show **0%

--- a/README.md
+++ b/README.md
@@ -1,21 +1,35 @@
 # ChainWeaver
 
-**Compile deterministic tool flows into LLM-free executable runs.**
+**Observe the tool paths your agent repeats. Compile them into typed, deterministic flows. Replace the LLM-in-the-loop with governed, auditable execution.**
 
 [![PyPI](https://img.shields.io/pypi/v/chainweaver)](https://pypi.org/project/chainweaver/)
 [![CI](https://github.com/dgenio/ChainWeaver/actions/workflows/ci.yml/badge.svg)](https://github.com/dgenio/ChainWeaver/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/pypi/pyversions/chainweaver)](https://pypi.org/project/chainweaver/)
 [![License](https://img.shields.io/github/license/dgenio/ChainWeaver)](LICENSE)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/ChainWeaver/blob/main/notebooks/quickstart.ipynb)
 
-```mermaid
-flowchart LR
-    subgraph before ["❌ Naive Agent Loop · N LLM calls"]
-        R1([Request]) --> L1[LLM] --> T1[Tool A] --> L2[LLM] --> T2[Tool B] --> L3[LLM] --> T3[Tool C]
-    end
-    subgraph after ["✅ ChainWeaver · 0 LLM calls"]
-        R2([Request]) --> E[FlowExecutor] --> U1[Tool A] --> U2[Tool B] --> U3[Tool C]
-    end
-```
+<p align="center">
+  <img src="docs/assets/quickstart.svg" alt="ChainWeaver quick start: pip install, run a flow, and see the LLM-free step log" width="760">
+</p>
+
+**The moat — observe → compile → replace.** Point ChainWeaver at the tool paths
+your agent already repeats. `ChainAnalyzer` maps every schema-compatible chain
+among your tools; you compile the ones worth keeping into typed `Flow` objects;
+and `FlowExecutor` *replaces* the per-step LLM round-trips with deterministic,
+schema-validated execution — no model in the loop. You compile the path the
+analyzer surfaces instead of hand-wiring it.
+
+**Governance for tool pipelines.** Typed I/O at every step, file-serializable
+flows, schema-drift detection, determinism *attestation*, property fuzzing, and
+structured audit traces — disciplined, auditable, portable deterministic
+pipelines.
+
+> **Quantified and reproducible.** In the repo's
+> [benchmark report](benchmarks/results/latest.md), compiled flows show **0%
+> data corruption** versus **61–96%** for naive LLM-in-the-loop chaining, and
+> avoid **~$0.06** of LLM spend per 10-step flow. Regenerate it yourself with
+> `python benchmarks/report.py`. Saving LLM calls is a *consequence* — not the
+> headline.
 
 ```python
 from chainweaver import Tool, Flow, FlowStep, FlowRegistry, FlowExecutor
@@ -221,14 +235,32 @@ on each minor release of any of the projects above.
 For the correctness argument behind the design, see
 [docs/data-integrity.md](docs/data-integrity.md).
 
-### Where ChainWeaver fits in the Weaver Stack
+### Part of the Weaver Stack
 
-ChainWeaver is the **deterministic multi-step tool execution** seam of
-the broader [Weaver Stack](https://github.com/dgenio/weaver-spec): the
-loose family of SDKs that share `weaver-spec`'s `SelectableItem`
-contract for capability routing.  In one line: the agent or the host's
-router decides *which* capability to invoke, and ChainWeaver runs the
-deterministic tool path *behind* that capability.
+ChainWeaver is the **deterministic multi-step tool execution** layer of the
+[Weaver Stack](https://github.com/dgenio/weaver-spec) — a family of small,
+composable SDKs that share `weaver-spec`'s `SelectableItem` routing contract.
+On the request path a router picks *which* capability to invoke, ChainWeaver
+runs the deterministic tool path *behind* it, and downstream layers gate and
+guard the call:
+
+```mermaid
+flowchart LR
+    req([Request]) --> ctx[contextweaver<br/>context assembly]
+    ctx --> cw[<b>ChainWeaver</b><br/>deterministic flow execution]
+    cw --> ak[agent-kernel<br/>capability gating]
+    ak --> af[agentfence<br/>runtime guardrails]
+    subgraph adjacent [Adjacent · use any subset]
+        vg[vibeguard]
+        lw[lessonweaver]
+        se[skdr-eval]
+    end
+```
+
+**Use standalone or together.** Each layer stands on its own — ChainWeaver has
+**no hard dependency** on any sibling and works fully standalone. The
+`chainweaver[weaver-stack]` extra is a placeholder that will pin the siblings
+once they ship on PyPI.
 
 | Layer | What it owns | Sibling project |
 |-------|--------------|-----------------|
@@ -242,9 +274,7 @@ ChainWeaver does **not** replace an agent framework.  It is meant to be
 called *from* one — see the [LangGraph
 recipe](docs/cookbook/langgraph-node.md) (issue #205) and the [OpenAI Agents
 SDK recipe](docs/cookbook/openai-agents-tool.md) (issue #206) for
-the canonical integration patterns.  None of the sibling packages above
-is a hard dependency; the `chainweaver[weaver-stack]` extra is a
-placeholder that will pin them when they ship on PyPI.
+the canonical integration patterns.
 
 For host-level expectations (when to invoke, how to store traces,
 side-effect tools, MCP parity), see the

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -34,7 +34,8 @@ python -m pytest tests/ -v
 
 | Workflow | Trigger | Steps |
 |----------|---------|-------|
-| `ci.yml` | Push/PR to `main` | Ruff lint + format + mypy `chainweaver/ tests/` (Python 3.10 on `ubuntu-latest` only); pytest across the OS × Python matrix `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12, 3.13}` |
+| `ci.yml` | Push/PR to `main` | Ruff lint + format + mypy `chainweaver/ tests/` (Python 3.10 on `ubuntu-latest` only); pytest across the OS × Python matrix `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12, 3.13}`; `nbmake` runs `notebooks/` on the `ubuntu-latest` / 3.12 lane (issue #229) |
+| `docs.yml` | Push/PR to `main` | `mkdocs build --strict` |
 | `publish.yml` | `v*` tags | Test → build → PyPI publish → GitHub Release |
 | `bench.yml` | Push/PR to `main` | Naive-vs-compiled benchmark on `ubuntu-22.04`; fails PRs whose median `total_duration_ms` regresses beyond 125 % of `gh-pages` baseline |
 

--- a/docs/assets/quickstart.cast
+++ b/docs/assets/quickstart.cast
@@ -1,0 +1,6 @@
+{"version": 2, "width": 92, "height": 26, "title": "ChainWeaver quick start", "env": {"TERM": "xterm-256color", "SHELL": "/bin/bash"}}
+[0.5, "o", "\u001b[1;32m$\u001b[0m pip install 'chainweaver[yaml]'\r\n"]
+[1.7, "o", "Successfully installed chainweaver-0.11.0\r\n\r\n"]
+[2.7, "o", "\u001b[1;32m$\u001b[0m python examples/simple_linear_flow.py\r\n"]
+[3.7, "o", "\r\nExecuting flow 'double_add_format' with input: {'number': 5}\r\n\r\n\r\n--- Execution Summary ---\r\nFlow      : double_add_format\r\nSuccess   : True\r\nOutput    : {'number': 5, 'value': 20, 'result': 'Final value: 20'}\r\n\r\n--- Step Log ---\r\n  [OK] Step 0 | double | inputs={'number': 5} \u2192 outputs={'value': 10}\r\n  [OK] Step 1 | add_ten | inputs={'value': 10} \u2192 outputs={'value': 20}\r\n  [OK] Step 2 | format_result | inputs={'value': 20} \u2192 outputs={'result': 'Final value: 20'}\r\n\r\n\u2713 Result verified: 'Final value: 20'\r\n"]
+[4.7, "o", "\r\n\u001b[2m# 3 tools, 0 LLM calls, fully reproducible.\u001b[0m\r\n"]

--- a/docs/assets/quickstart.svg
+++ b/docs/assets/quickstart.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="terminal" baseProfile="full" viewBox="0 0 783 523" width="783" version="1.1">
+    <defs>
+        <termtosvg:template_settings xmlns:termtosvg="https://github.com/nbedos/termtosvg">
+            <termtosvg:screen_geometry columns="92" rows="26"/>
+            <termtosvg:animation type="css"/>
+        </termtosvg:template_settings>
+        <style type="text/css" id="generated-style"><![CDATA[#screen {
+                font-family: 'DejaVu Sans Mono', monospace;
+                font-style: normal;
+                font-size: 14px;
+            }
+
+        text {
+            dominant-baseline: text-before-edge;
+            white-space: pre;
+        }
+    
+            :root {
+                --animation-duration: 5700ms;
+            }
+
+            @keyframes roll {
+                0.000%{transform:translateY(0px)}
+8.772%{transform:translateY(-476px)}
+29.825%{transform:translateY(-952px)}
+47.368%{transform:translateY(-1428px)}
+64.912%{transform:translateY(-1904px)}
+82.456%{transform:translateY(-2380px)}
+100.000%{transform:translateY(-2380px)}
+            }
+
+            #screen_view {
+                animation-duration: 5700ms;
+                animation-iteration-count:infinite;
+                animation-name:roll;
+                animation-timing-function: steps(1,end);
+                animation-fill-mode: forwards;
+            }
+        ]]></style>
+        <style type="text/css" id="user-style">
+            /* The colors defined below are the default 16 colors used for rendering text of the terminal. Adjust
+               them as needed.
+               gjm8 color theme (source: https://terminal.sexy/) */
+            .foreground {fill: #f8f8f2}
+            .background {fill: #272822}
+            .color0 {fill: #272822}
+            .color1 {fill: #f92672}
+            .color2 {fill: #a6e22e}
+            .color3 {fill: #f4bf75}
+            .color4 {fill: #66d9ef}
+            .color5 {fill: #ae81ff}
+            .color6 {fill: #a1efe4}
+            .color7 {fill: #f8f8f2}
+            .color8 {fill: #75715e}
+            .color9 {fill: #fd971f}
+            .color10 {fill: #383830}
+            .color11 {fill: #49483e}
+            .color12 {fill: #a59f85}
+            .color13 {fill: #f5f4f1}
+            .color14 {fill: #cc6633}
+            .color15 {fill: #f9f8f5}
+        </style>
+    </defs>
+    <rect id="terminalui" class="background" width="100%" height="100%" ry="4.5826941"/>
+    <circle cx="24" cy="23" r="7" class="color1"/>
+    <circle cx="44" cy="23" r="7" class="color3"/>
+    <circle cx="64" cy="23" r="7" class="color2"/>
+    <svg id="screen" width="736" height="442" x="23" y="50" viewBox="0 0 736 442" preserveAspectRatio="xMidYMin slice"><rect class="background" height="100%" width="100%" x="0" y="0"/><defs><g id="g1"><text x="0" textLength="8" class="background"> </text></g><g id="g2"><text x="0" textLength="8" font-weight="bold" class="color10">$</text><text x="8" textLength="256" class="foreground"> pip install 'chainweaver[yaml]'</text></g><g id="g3"><text x="0" textLength="328" class="foreground">Successfully installed chainweaver-0.11.0</text></g><g id="g4"><text x="0" textLength="8" font-weight="bold" class="color10">$</text><text x="8" textLength="304" class="foreground"> python examples/simple_linear_flow.py</text></g><g id="g5"><text x="0" textLength="480" class="foreground">Executing flow 'double_add_format' with input: {'number': 5}</text></g><g id="g6"><text x="0" textLength="200" class="foreground">--- Execution Summary ---</text></g><g id="g7"><text x="0" textLength="232" class="foreground">Flow      : double_add_format</text></g><g id="g8"><text x="0" textLength="128" class="foreground">Success   : True</text></g><g id="g9"><text x="0" textLength="536" class="foreground">Output    : {'number': 5, 'value': 20, 'result': 'Final value: 20'}</text></g><g id="g10"><text x="0" textLength="128" class="foreground">--- Step Log ---</text></g><g id="g11"><text x="0" textLength="552" class="foreground">  [OK] Step 0 | double | inputs={'number': 5} &#8594; outputs={'value': 10}</text></g><g id="g12"><text x="0" textLength="560" class="foreground">  [OK] Step 1 | add_ten | inputs={'value': 10} &#8594; outputs={'value': 20}</text></g><g id="g13"><text x="0" textLength="736" class="foreground">  [OK] Step 2 | format_result | inputs={'value': 20} &#8594; outputs={'result': 'Final value: 20'}</text></g><g id="g14"><text x="0" textLength="288" class="foreground">&#10003; Result verified: 'Final value: 20'</text></g><g id="g15"><text x="0" textLength="344" class="foreground"># 3 tools, 0 LLM calls, fully reproducible.</text></g></defs><g id="screen_view"><g><rect x="0" y="0" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="0"/></g><g><use xlink:href="#g2" y="476"/><rect x="0" y="493" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="493"/></g><g><use xlink:href="#g2" y="952"/><use xlink:href="#g3" y="969"/><rect x="0" y="1003" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="1003"/></g><g><use xlink:href="#g2" y="1428"/><use xlink:href="#g3" y="1445"/><use xlink:href="#g4" y="1479"/><rect x="0" y="1496" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="1496"/></g><g><use xlink:href="#g2" y="1904"/><use xlink:href="#g3" y="1921"/><use xlink:href="#g4" y="1955"/><use xlink:href="#g5" y="1989"/><use xlink:href="#g6" y="2040"/><use xlink:href="#g7" y="2057"/><use xlink:href="#g8" y="2074"/><use xlink:href="#g9" y="2091"/><use xlink:href="#g10" y="2125"/><use xlink:href="#g11" y="2142"/><use xlink:href="#g12" y="2159"/><use xlink:href="#g13" y="2176"/><use xlink:href="#g14" y="2210"/><rect x="0" y="2227" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="2227"/></g><g><use xlink:href="#g2" y="2380"/><use xlink:href="#g3" y="2397"/><use xlink:href="#g4" y="2431"/><use xlink:href="#g5" y="2465"/><use xlink:href="#g6" y="2516"/><use xlink:href="#g7" y="2533"/><use xlink:href="#g8" y="2550"/><use xlink:href="#g9" y="2567"/><use xlink:href="#g10" y="2601"/><use xlink:href="#g11" y="2618"/><use xlink:href="#g12" y="2635"/><use xlink:href="#g13" y="2652"/><use xlink:href="#g14" y="2686"/><use xlink:href="#g15" y="2720"/><rect x="0" y="2737" width="8" height="17" class="foreground"/><use xlink:href="#g1" y="2737"/></g></g></svg>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 worth keeping into typed `Flow` objects; and `FlowExecutor` runs them as a graph runner,
 not a reasoning engine — zero LLM calls, zero network I/O, zero randomness between steps,
 by design. Every step is Pydantic-validated, drift-detected, determinism-*attested*, and
-emits a structured audit trace, so the result is a disciplined, auditable pipeline rather
+emits a structured audit trace, so the result is a disciplined, auditable flow rather
 than an opaque sequence of calls. (Saving LLM calls is a *consequence* — see the
 [reproducible benchmark](https://github.com/dgenio/ChainWeaver/blob/main/benchmarks/results/latest.md).)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,14 @@
 # ChainWeaver
 
-**Deterministic orchestration layer for MCP-based agents.**
+**Observe the tool paths your agent repeats. Compile them into typed, deterministic flows. Replace the LLM-in-the-loop with governed, auditable execution.**
 
-ChainWeaver compiles multi-tool flows into executable sequences that run **without any
-LLM involvement between steps**. The executor is a graph runner, not a reasoning engine:
-zero LLM calls, zero network I/O, zero randomness — by design.
+`ChainAnalyzer` maps the schema-compatible chains among your tools; you compile the ones
+worth keeping into typed `Flow` objects; and `FlowExecutor` runs them as a graph runner,
+not a reasoning engine — zero LLM calls, zero network I/O, zero randomness between steps,
+by design. Every step is Pydantic-validated, drift-detected, determinism-*attested*, and
+emits a structured audit trace, so the result is a disciplined, auditable pipeline rather
+than an opaque sequence of calls. (Saving LLM calls is a *consequence* — see the
+[reproducible benchmark](https://github.com/dgenio/ChainWeaver/blob/main/benchmarks/results/latest.md).)
 
 ```mermaid
 flowchart LR

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5bf02d53",
+   "metadata": {},
+   "source": [
+    "# ChainWeaver — 60-second quick start\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/ChainWeaver/blob/main/notebooks/quickstart.ipynb)\n",
+    "\n",
+    "Zero install required — run this top-to-bottom in your browser. You will:\n",
+    "\n",
+    "1. Define tools with the `@tool` decorator.\n",
+    "2. Compile them into a typed `Flow` and execute it with **no LLM in the loop**.\n",
+    "3. Export the flow to OpenAI / Anthropic tool specs for your agent.\n",
+    "\n",
+    "ChainWeaver's executor is deterministic by design: zero LLM calls, zero network I/O, zero randomness between steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "530bfe79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install ChainWeaver if it isn't already available (no-op when running\n",
+    "# in an environment that already has it, e.g. CI's editable install).\n",
+    "try:\n",
+    "    import chainweaver  # noqa: F401\n",
+    "except ImportError:\n",
+    "    import subprocess\n",
+    "    import sys\n",
+    "\n",
+    "    subprocess.run(\n",
+    "        [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"chainweaver[yaml]\"],\n",
+    "        check=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e15361f",
+   "metadata": {},
+   "source": [
+    "## 1. Define tools with `@tool`\n",
+    "\n",
+    "The `@tool` decorator introspects type hints to build the Pydantic input schema; the return annotation is the output schema. Decorated tools are plain callables *and* `Tool` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "022c7f2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "\n",
+    "from chainweaver import tool\n",
+    "\n",
+    "\n",
+    "class ValueOutput(BaseModel):\n",
+    "    value: int\n",
+    "\n",
+    "\n",
+    "class FormattedOutput(BaseModel):\n",
+    "    result: str\n",
+    "\n",
+    "\n",
+    "@tool(description=\"Doubles a number.\")\n",
+    "def double(number: int) -> ValueOutput:\n",
+    "    return {\"value\": number * 2}\n",
+    "\n",
+    "\n",
+    "@tool(description=\"Adds 10 to a value.\")\n",
+    "def add_ten(value: int) -> ValueOutput:\n",
+    "    return {\"value\": value + 10}\n",
+    "\n",
+    "\n",
+    "@tool(description=\"Formats a value as a human-readable string.\")\n",
+    "def format_result(value: int) -> FormattedOutput:\n",
+    "    return {\"result\": f\"Final value: {value}\"}\n",
+    "\n",
+    "\n",
+    "double(number=5)  # decorated tools are directly callable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a40ce18",
+   "metadata": {},
+   "source": [
+    "## 2. Compile a flow and execute it — zero LLM calls\n",
+    "\n",
+    "Wire the tools into a `Flow`, register everything, and run it. Each step is Pydantic-validated; the `ExecutionResult` carries a structured, auditable step log."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3713f93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chainweaver import Flow, FlowExecutor, FlowRegistry, FlowStep\n",
+    "\n",
+    "flow = Flow(\n",
+    "    name=\"double_add_format\",\n",
+    "    version=\"0.1.0\",\n",
+    "    description=\"Doubles a number, adds 10, and formats the result.\",\n",
+    "    steps=[\n",
+    "        FlowStep(tool_name=\"double\", input_mapping={\"number\": \"number\"}),\n",
+    "        FlowStep(tool_name=\"add_ten\", input_mapping={\"value\": \"value\"}),\n",
+    "        FlowStep(tool_name=\"format_result\", input_mapping={\"value\": \"value\"}),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "registry = FlowRegistry()\n",
+    "registry.register_flow(flow)\n",
+    "\n",
+    "executor = FlowExecutor(registry=registry)\n",
+    "executor.register_tool(double)\n",
+    "executor.register_tool(add_ten)\n",
+    "executor.register_tool(format_result)\n",
+    "\n",
+    "result = executor.execute_flow(\"double_add_format\", {\"number\": 5})\n",
+    "\n",
+    "print(\"success     :\", result.success)\n",
+    "print(\"final_output:\", result.final_output)\n",
+    "print(\"\\nstep log:\")\n",
+    "for step in result.execution_log:\n",
+    "    print(f\"  step {step.step_index} {step.tool_name:<13} -> {step.outputs}\")\n",
+    "\n",
+    "assert result.success\n",
+    "assert result.final_output[\"result\"] == \"Final value: 20\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42a7f02a",
+   "metadata": {},
+   "source": [
+    "## 3. Export the flow to your agent framework\n",
+    "\n",
+    "The flow becomes a single tool your agent can call. ChainWeaver emits plain dict specs — it never imports the `openai` or `anthropic` SDKs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7142fdac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from chainweaver.export import flow_to_anthropic_tool, flow_to_openai_function\n",
+    "\n",
+    "openai_spec = flow_to_openai_function(flow, executor)\n",
+    "anthropic_spec = flow_to_anthropic_tool(flow, executor)\n",
+    "\n",
+    "print(\"OpenAI function spec:\")\n",
+    "print(json.dumps(openai_spec, indent=2))\n",
+    "print(\"\\nAnthropic tool spec:\")\n",
+    "print(json.dumps(anthropic_spec, indent=2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ keywords = [
     "tools",
     "pydantic",
     "flow",
+    "weaver-stack",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -117,6 +118,11 @@ dev = [
     "langgraph>=0.2",
     "openai-agents>=0.1",
     "mcp>=1.0,<2",
+    # Notebook execution gate (issue #229): nbmake runs notebooks/ in CI so the
+    # "Open in Colab" quickstart cannot silently rot; ipykernel is the kernel it
+    # executes against.
+    "nbmake>=1.5",
+    "ipykernel>=6.29",
 ]
 
 [project.urls]

--- a/scripts/gen_demo_cast.py
+++ b/scripts/gen_demo_cast.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate the README demo asciicast from a real ChainWeaver run (issue #228).
+
+Headless CI/sandbox environments have no TTY, so we cannot drive
+``termtosvg``'s live recorder.  Instead we *run the real quick-path command*,
+capture its real stdout, and assemble a deterministic asciinema v2 cast around
+it.  The cast is then rendered to an animated SVG that GitHub displays inline:
+
+    python scripts/gen_demo_cast.py            # writes docs/assets/quickstart.cast
+    termtosvg render docs/assets/quickstart.cast docs/assets/quickstart.svg \\
+        -m 1 -M 2200 -t window_frame
+
+Re-run both after the example output changes so the demo never goes stale.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_CAST = _REPO / "docs" / "assets" / "quickstart.cast"
+
+WIDTH, HEIGHT = 92, 26
+GREEN = "[1;32m"
+DIM = "[2m"
+RESET = "[0m"
+
+
+def _prompt(cmd: str) -> str:
+    return f"{GREEN}${RESET} {cmd}\r\n"
+
+
+def main() -> int:
+    # Capture the *real* output of the documented quick-path command.  The
+    # executor's INFO step logs go to stderr; we keep stdout (the structured
+    # ExecutionResult summary) so the demo shows the result, not log noise.
+    proc = subprocess.run(
+        [sys.executable, "examples/simple_linear_flow.py"],
+        cwd=_REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    real_output = proc.stdout.replace("\n", "\r\n")
+
+    header = {
+        "version": 2,
+        "width": WIDTH,
+        "height": HEIGHT,
+        "title": "ChainWeaver quick start",
+        "env": {"TERM": "xterm-256color", "SHELL": "/bin/bash"},
+    }
+
+    # (delay_seconds_before_event, text) — hand-tuned for a ~25s, readable cast.
+    script: list[tuple[float, str]] = [
+        (0.5, _prompt("pip install 'chainweaver[yaml]'")),
+        (1.2, "Successfully installed chainweaver-0.11.0\r\n\r\n"),
+        (1.0, _prompt("python examples/simple_linear_flow.py")),
+        (1.0, real_output),
+        (1.0, f"\r\n{DIM}# 3 tools, 0 LLM calls, fully reproducible.{RESET}\r\n"),
+        (1.5, ""),
+    ]
+
+    _CAST.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(header)]
+    clock = 0.0
+    for delay, text in script:
+        clock += delay
+        if text:
+            lines.append(json.dumps([round(clock, 3), "o", text]))
+    _CAST.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"wrote {_CAST.relative_to(_REPO)} ({len(lines) - 1} events)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_demo_cast.py
+++ b/scripts/gen_demo_cast.py
@@ -18,19 +18,70 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parents[1]
 _CAST = _REPO / "docs" / "assets" / "quickstart.cast"
 
+try:
+    # Show the real installed version so the simulated install line can't drift.
+    _CW_VERSION = version("chainweaver")
+except PackageNotFoundError:  # source checkout without installed metadata
+    _CW_VERSION = "0.0.0"
+
 WIDTH, HEIGHT = 92, 26
-GREEN = "[1;32m"
-DIM = "[2m"
-RESET = "[0m"
+GREEN = "\x1b[1;32m"
+DIM = "\x1b[2m"
+RESET = "\x1b[0m"
 
 
 def _prompt(cmd: str) -> str:
     return f"{GREEN}${RESET} {cmd}\r\n"
+
+
+def build_cast(real_output: str) -> str:
+    """Assemble a deterministic asciinema v2 cast around real example output.
+
+    Pure function (no I/O) so it can be unit-tested: given the captured stdout
+    of the example run, it returns the full cast text.
+
+    Args:
+        real_output: Captured stdout of the example, with ``\\n`` already
+            normalized to ``\\r\\n``.
+
+    Returns:
+        The asciinema v2 cast as a newline-terminated string: a JSON header
+        line followed by one ``[timestamp, "o", text]`` event per line.
+    """
+    header = {
+        "version": 2,
+        "width": WIDTH,
+        "height": HEIGHT,
+        "title": "ChainWeaver quick start",
+        "env": {"TERM": "xterm-256color", "SHELL": "/bin/bash"},
+    }
+
+    # (delay_seconds_before_event, text) — hand-tuned for a ~25s, readable cast.
+    script: list[tuple[float, str]] = [
+        (0.5, _prompt("pip install 'chainweaver[yaml]'")),
+        (1.2, f"Successfully installed chainweaver-{_CW_VERSION}\r\n\r\n"),
+        (1.0, _prompt("python examples/simple_linear_flow.py")),
+        (1.0, real_output),
+        (1.0, f"\r\n{DIM}# 3 tools, 0 LLM calls, fully reproducible.{RESET}\r\n"),
+        (1.5, ""),
+    ]
+
+    lines = [json.dumps(header)]
+    clock = 0.0
+    for delay, text in script:
+        clock += delay
+        if text:
+            lines.append(json.dumps([round(clock, 3), "o", text]))
+    # Emit a terminal no-op at the final timestamp so trailing pure-delay entries
+    # (e.g. the closing hold) still extend the recording and hold the last frame.
+    lines.append(json.dumps([round(clock, 3), "o", ""]))
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
@@ -46,33 +97,11 @@ def main() -> int:
     )
     real_output = proc.stdout.replace("\n", "\r\n")
 
-    header = {
-        "version": 2,
-        "width": WIDTH,
-        "height": HEIGHT,
-        "title": "ChainWeaver quick start",
-        "env": {"TERM": "xterm-256color", "SHELL": "/bin/bash"},
-    }
-
-    # (delay_seconds_before_event, text) — hand-tuned for a ~25s, readable cast.
-    script: list[tuple[float, str]] = [
-        (0.5, _prompt("pip install 'chainweaver[yaml]'")),
-        (1.2, "Successfully installed chainweaver-0.11.0\r\n\r\n"),
-        (1.0, _prompt("python examples/simple_linear_flow.py")),
-        (1.0, real_output),
-        (1.0, f"\r\n{DIM}# 3 tools, 0 LLM calls, fully reproducible.{RESET}\r\n"),
-        (1.5, ""),
-    ]
-
+    cast = build_cast(real_output)
     _CAST.parent.mkdir(parents=True, exist_ok=True)
-    lines = [json.dumps(header)]
-    clock = 0.0
-    for delay, text in script:
-        clock += delay
-        if text:
-            lines.append(json.dumps([round(clock, 3), "o", text]))
-    _CAST.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"wrote {_CAST.relative_to(_REPO)} ({len(lines) - 1} events)")
+    _CAST.write_text(cast, encoding="utf-8")
+    n_events = len(cast.splitlines()) - 1  # minus the header line
+    print(f"wrote {_CAST.relative_to(_REPO)} ({n_events} events)")
     return 0
 
 

--- a/tests/test_readme_assets.py
+++ b/tests/test_readme_assets.py
@@ -9,11 +9,23 @@ change) and check for stable anchors instead.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
+from types import ModuleType
 
 _REPO = Path(__file__).resolve().parents[1]
 _README = (_REPO / "README.md").read_text(encoding="utf-8")
+
+
+def _load_gen_demo_cast() -> ModuleType:
+    """Import scripts/gen_demo_cast.py (not a package) for direct testing."""
+    path = _REPO / "scripts" / "gen_demo_cast.py"
+    spec = importlib.util.spec_from_file_location("gen_demo_cast", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_demo_svg_committed_and_animated() -> None:
@@ -30,7 +42,9 @@ def test_demo_svg_committed_and_animated() -> None:
 def test_readme_embeds_demo_as_first_visual() -> None:
     """README embeds the demo SVG (#228) above the first prose section."""
     assert "docs/assets/quickstart.svg" in _README
-    assert _README.index("docs/assets/quickstart.svg") < _README.index("## See it in 30 seconds")
+    anchor = "## See it in 30 seconds"
+    assert anchor in _README, f"expected README section heading {anchor!r}"
+    assert _README.index("docs/assets/quickstart.svg") < _README.index(anchor)
 
 
 def test_readme_has_colab_badge_to_notebook() -> None:
@@ -81,3 +95,29 @@ def test_readme_no_longer_leads_with_demoted_hero() -> None:
     """The old 'save LLM calls' hero tagline is demoted, not the lead (#225)."""
     stale = "Compile deterministic tool flows into LLM-free executable runs."
     assert stale not in _README
+
+
+def test_gen_demo_cast_builds_valid_asciinema_v2() -> None:
+    """scripts/gen_demo_cast.py assembles a valid asciinema v2 cast (#228)."""
+    gen = _load_gen_demo_cast()
+    fake_output = "Executing flow 'double_add_format'\r\nFinal value: 20\r\n"
+    cast = gen.build_cast(fake_output)
+    lines = cast.splitlines()
+
+    # First line is the asciinema v2 header.
+    header = json.loads(lines[0])
+    assert header["version"] == 2
+    assert header["width"] > 0 and header["height"] > 0
+
+    # Remaining lines are [timestamp, "o", text] events with non-decreasing time.
+    events = [json.loads(line) for line in lines[1:]]
+    assert events, "cast has no events"
+    prev = 0.0
+    for timestamp, code, _text in events:
+        assert code == "o"
+        assert timestamp >= prev
+        prev = timestamp
+
+    # The real run output is embedded, and the recording ends on a terminal hold.
+    assert any("Final value" in text for _ts, _code, text in events)
+    assert events[-1][2] == "", "cast should end with a terminal hold event"

--- a/tests/test_readme_assets.py
+++ b/tests/test_readme_assets.py
@@ -1,0 +1,83 @@
+"""Guard the README landing-page assets against rot (issues #225, #227, #228, #229, #232).
+
+These are cheap structural checks — they assert the committed assets exist and
+that the README actually references them, so a future edit can't silently drop
+the demo cast, the Colab notebook, the benchmark headline, or the Weaver Stack
+diagram. They deliberately avoid asserting exact prose (which is expected to
+change) and check for stable anchors instead.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_README = (_REPO / "README.md").read_text(encoding="utf-8")
+
+
+def test_demo_svg_committed_and_animated() -> None:
+    """The demo cast (#228) is committed, animated, and shows real run output."""
+    svg = _REPO / "docs" / "assets" / "quickstart.svg"
+    assert svg.is_file(), "demo asset docs/assets/quickstart.svg is missing"
+    body = svg.read_text(encoding="utf-8")
+    assert "<svg" in body
+    assert "@keyframes" in body, "SVG should be animated (CSS keyframes)"
+    # Rendered from the real example output, not a hand-drawn mockup.
+    assert "double_add_format" in body and "Final value" in body
+
+
+def test_readme_embeds_demo_as_first_visual() -> None:
+    """README embeds the demo SVG (#228) above the first prose section."""
+    assert "docs/assets/quickstart.svg" in _README
+    assert _README.index("docs/assets/quickstart.svg") < _README.index("## See it in 30 seconds")
+
+
+def test_readme_has_colab_badge_to_notebook() -> None:
+    """README carries an Open-in-Colab badge pointing at the quickstart notebook (#229)."""
+    assert "Open in Colab" in _README
+    colab_url = (
+        "colab.research.google.com/github/dgenio/ChainWeaver/blob/main/notebooks/quickstart.ipynb"
+    )
+    assert colab_url in _README
+
+
+def test_quickstart_notebook_is_valid_and_self_installing() -> None:
+    """The Colab notebook (#229) is valid nbformat 4 and installs ChainWeaver when absent."""
+    nb_path = _REPO / "notebooks" / "quickstart.ipynb"
+    assert nb_path.is_file(), "notebooks/quickstart.ipynb is missing"
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    assert nb["nbformat"] == 4
+    sources = ["".join(c.get("source", [])) for c in nb["cells"]]
+    joined = "\n".join(sources)
+    # Defensive install so the notebook runs both in Colab and in CI's nbmake.
+    assert "pip" in joined and "chainweaver[yaml]" in joined
+    # Exercises the documented surface: @tool, execution, and export adapters.
+    assert "@tool" in joined
+    assert "execute_flow" in joined
+    assert "flow_to_openai_function" in joined
+
+
+def test_readme_headline_number_links_report() -> None:
+    """README hero surfaces a quantified, reproducible claim linked to the report (#227)."""
+    report = _REPO / "benchmarks" / "results" / "latest.md"
+    assert report.is_file(), "benchmark report artifact is missing"
+    assert "benchmarks/results/latest.md" in _README
+    assert "python benchmarks/report.py" in _README
+    # The defensible headline metric: zero data corruption vs naive chaining.
+    assert "0%" in _README
+
+
+def test_readme_has_standardized_weaver_stack_section() -> None:
+    """README has the standardized 'Part of the Weaver Stack' block + diagram (#232)."""
+    assert "## Part of the Weaver Stack" in _README or "### Part of the Weaver Stack" in _README
+    # The shared request-path diagram names every stage.
+    for node in ("contextweaver", "agent-kernel", "agentfence"):
+        assert node in _README, f"Weaver Stack diagram missing node: {node}"
+    assert "no hard dependency" in _README.lower()
+
+
+def test_readme_no_longer_leads_with_demoted_hero() -> None:
+    """The old 'save LLM calls' hero tagline is demoted, not the lead (#225)."""
+    stale = "Compile deterministic tool flows into LLM-free executable runs."
+    assert stale not in _README


### PR DESCRIPTION
## Summary

Overhauls the first-touch experience: it reframes the README + docs landing page around ChainWeaver's actual moat (observe → compile → replace + governance) and ships the missing zero-install on-ramps. All five issues edit the **same README hero region**, so doing them in one PR avoids five colliding edits and lets the new tagline, demo, headline number, Colab badge, and stack diagram be tuned as one coherent landing page.

## Changes

- **#225 (positioning)** — `README.md` and `docs/index.md` now lead with *"observe → compile → replace"* + governance; the old *"Compile deterministic tool flows into LLM-free executable runs"* hero and the top before/after mermaid (the strawman the issue calls out) are demoted, with "saving LLM calls" reframed as a *consequence*.
- **#227 (benchmark headline)** — the hero surfaces a quantified, reproducible claim (**0%** vs **61–96%** data corruption; **~$0.06** of LLM spend avoided per 10-step flow), linked to the committed report `benchmarks/results/latest.md` and reproducible with `python benchmarks/report.py`. (Numbers taken from the existing #207 artifact; no noisy regen committed.)
- **#228 (demo asset)** — `docs/assets/quickstart.svg`, an animated terminal SVG **rendered from a real `examples/simple_linear_flow.py` run**, is now the first visual in the README. `scripts/gen_demo_cast.py` is the headless, reproducible regenerator (captures real stdout → asciinema cast → `termtosvg render`); the cast is committed at `docs/assets/quickstart.cast`.
- **#229 (Colab notebook)** — `notebooks/quickstart.ipynb` (defensive self-install → `@tool` → execute → export adapters) + an "Open in Colab" badge in the README. Exercised in CI via `nbmake` (new dev deps `nbmake`, `ipykernel`) on the `ubuntu-latest` / 3.12 lane so it can't silently rot.
- **#232 (Weaver Stack)** — standardized **"Part of the Weaver Stack"** section with the shared request-path diagram (`contextweaver → ChainWeaver → agent-kernel → agentfence`; adjacent `vibeguard`, `lessonweaver`, `skdr-eval`), an explicit *standalone or together / no hard dependency* note, and a `weaver-stack` package keyword.
- Rot guard `tests/test_readme_assets.py`; `docs/agent-context/workflows.md` CI section updated for the new nbmake step.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`) — *All checks passed!* (also clean on `scripts/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`) — clean
- [x] Type checking passes (`python -m mypy chainweaver/`) — *Success: no issues found in 131 source files* (ran `chainweaver/ tests/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`) — **1196 passed**, coverage **91.46%** (gate 80%)
- [x] New tests added for new functionality — `tests/test_readme_assets.py` (7 passed)
- [x] Notebook executes (`pytest --nbmake notebooks/`) — 1 passed
- [x] Docs build (`mkdocs build --strict`) — exit 0

## Related Issues

Closes #225, closes #227, closes #228, closes #229, closes #232.

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented — N/A, no public API symbols added (docs/assets/CI only)
- [x] No secrets or credentials included

### Maintainer follow-up (cannot be done from a PR)
- **#232** also asks for the GitHub repo **topic** `weaver-stack`. Repo topics aren't settable via PR/MCP — please add it under **Settings → Topics**. The `weaver-stack` PyPI keyword is included here as the in-repo signal.
- **#228 / #227** numbers and the demo cast should be refreshed on a release cadence (`python scripts/gen_demo_cast.py && termtosvg render …`, `python benchmarks/report.py`).

### Notes / risks
- The demo SVG uses termtosvg's CSS-keyframe output, which animates inline on GitHub via `<img>`. If a reviewer prefers a GIF, the same `.cast` can be fed to `agg`.
- `#225`'s "observe → compile → replace" copy is scoped to **existing** capabilities (`ChainAnalyzer` schema discovery, governance/attestation) — it does **not** claim the not-yet-built runtime auto-suggest-from-trace (#78/#226).

---
_Generated by [Claude Code](https://claude.ai/code/session_012TidTFhhUSVFxxCU6hYzkR)_