### PR TITLE
feat: offline LLM-assisted flow compiler and description optimizer (#28, #100)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ chainweaver/
 ├── builder.py         FlowBuilder: fluent API for constructing Flow objects
 ├── compat.py          schema_fingerprint() + check_flow_compatibility() + CompatibilityIssue
 ├── compiler.py        compile_flow(): static schema flow validation (CompilationResult)
+├── compiler_llm.py    Offline build-time LLM flow compiler: LLMProposal + llm_propose_flows() + write_proposals() (#28); banned from executor.py
+├── optimizer.py       Offline build-time tool-description optimizer: OptimizationStrategy + ToolDescriptionProposal + optimize_tool_descriptions()/optimize_new_tool_description() (#100); banned from executor.py
+├── _offline_llm.py    Private shared internals for the offline LLM proposers: LLMFn type + parse_llm_yaml() + render_tool_catalogue() (#28, #100)
 ├── contracts.py       ToolSafetyContract + SideEffectLevel/StabilityLevel/DeterminismLevel enums + merge_safety() + evaluate_predicate() — determinism + safety vocabulary (#19, #125, #9, #8)
 ├── decorators.py      @tool decorator for zero-boilerplate tool definition
 ├── tools.py           Tool class: named callable with Pydantic I/O schemas + schema_hash + safety contract (#19); Tool.from_flow() wraps a Flow as a Tool (#24) with derived safety (#125)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reached only through a provider-agnostic `llm_fn(prompt) -> completion`
   callable — **offline, at build time, never in the executor**. Proposals are
   returned as reviewable data (and optionally written as PR-ready `.flow.yaml`
-  files plus a `PROPOSALS.md`); they are never auto-registered.
+  files plus a `PROPOSALS.md`); they are never auto-registered. Proposed flow
+  names are validated as safe filenames before `write_proposals()` writes them,
+  so a malformed completion cannot escape the target directory (path traversal).
 - **Offline tool-description optimizer** (#100): a new `chainweaver.optimizer`
   module exposing `OptimizationStrategy`, `ToolDescriptionProposal`,
   `optimize_tool_descriptions()`, and `optimize_new_tool_description()`. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Offline LLM-assisted flow compiler** (#28): a new `chainweaver.compiler_llm`
+  module exposing `LLMProposal`, `llm_propose_flows()`, and `write_proposals()`.
+  It proposes deterministic `Flow` definitions from tool metadata using an LLM
+  reached only through a provider-agnostic `llm_fn(prompt) -> completion`
+  callable — **offline, at build time, never in the executor**. Proposals are
+  returned as reviewable data (and optionally written as PR-ready `.flow.yaml`
+  files plus a `PROPOSALS.md`); they are never auto-registered.
+- **Offline tool-description optimizer** (#100): a new `chainweaver.optimizer`
+  module exposing `OptimizationStrategy`, `ToolDescriptionProposal`,
+  `optimize_tool_descriptions()`, and `optimize_new_tool_description()`. It
+  rewrites tool descriptions for ecosystem-wide discriminability (or
+  conciseness / structure) via the same offline `llm_fn` seam, returning
+  proposals with an approximate `token_delta` for human review.
+  Both modules share a private `chainweaver._offline_llm` helper and a new
+  typed `OfflineLLMError`; a guard test keeps `executor.py` free of any LLM
+  import (core invariant #1). YAML parsing uses the existing `chainweaver[yaml]`
+  extra, so the base install is unaffected.
 - **Official Python 3.14 support** (#215): `pyproject.toml` classifiers and the
   CI test matrix now cover Python 3.10–3.14 inclusive.
 - **Library-grade dependency hygiene** (#236): a `floor-deps` CI job installs

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -58,6 +58,7 @@ from chainweaver.compiler import (
     CompilationWarning,
     compile_flow,
 )
+from chainweaver.compiler_llm import LLMProposal, llm_propose_flows, write_proposals
 from chainweaver.contracts import (
     DeterminismLevel,
     SideEffectLevel,
@@ -104,6 +105,7 @@ from chainweaver.exceptions import (
     MCPError,
     MCPSchemaConversionError,
     MCPToolInvocationError,
+    OfflineLLMError,
     PluginDiscoveryError,
     PredicateSyntaxError,
     SchemaValidationError,
@@ -154,6 +156,12 @@ from chainweaver.middleware import (
     StepStartContext,
 )
 from chainweaver.observation import ObservedStep, ObservedTrace, TraceRecorder
+from chainweaver.optimizer import (
+    OptimizationStrategy,
+    ToolDescriptionProposal,
+    optimize_new_tool_description,
+    optimize_tool_descriptions,
+)
 from chainweaver.plugins import discover_flows, discover_tools
 from chainweaver.registry import FlowRegistry
 from chainweaver.schemas import flow_schema_json
@@ -257,11 +265,14 @@ __all__ = [
     "InputMappingError",
     "InvalidFlowVersionError",
     "KernelInvocationError",
+    "LLMProposal",
     "MCPError",
     "MCPSchemaConversionError",
     "MCPToolInvocationError",
     "ObservedStep",
     "ObservedTrace",
+    "OfflineLLMError",
+    "OptimizationStrategy",
     "PluginDiscoveryError",
     "PredicateSyntaxError",
     "PriceSnap",
@@ -284,6 +295,7 @@ __all__ = [
     "Tool",
     "ToolChain",
     "ToolDefinitionError",
+    "ToolDescriptionProposal",
     "ToolNotFoundError",
     "ToolOutputSizeError",
     "ToolSafetyContract",
@@ -307,12 +319,16 @@ __all__ = [
     "flow_to_json",
     "flow_to_mermaid",
     "flow_to_yaml",
+    "llm_propose_flows",
     "lookup_price",
     "merge_safety",
     "minimize_failure",
+    "optimize_new_tool_description",
+    "optimize_tool_descriptions",
     "result_to_mermaid",
     "schema_fingerprint",
     "suggest_optimizations",
     "tool",
     "validate_dag_topology",
+    "write_proposals",
 ]

--- a/chainweaver/_offline_llm.py
+++ b/chainweaver/_offline_llm.py
@@ -1,0 +1,122 @@
+"""Shared internals for ChainWeaver's offline, build-time LLM proposers.
+
+This module hosts the abstractions common to
+:mod:`chainweaver.compiler_llm` (issue #28, which proposes *flows*) and
+:mod:`chainweaver.optimizer` (issue #100, which proposes *tool-description
+rewrites*): the provider-agnostic :data:`LLMFn` callable type, a tolerant
+YAML payload parser, and a compact tool-catalogue renderer for prompts.
+
+**Build-time only.**  Like the two modules that import it, this module MUST
+NOT be imported by :mod:`chainweaver.executor` — the executor stays free of
+any LLM coupling (AGENTS.md core invariant #1: *no LLM calls in
+``executor.py``*).  ``tests/test_offline_llm_guardrail.py`` enforces this
+statically by parsing ``executor.py``'s import graph.
+
+The single LLM seam is :data:`LLMFn` — ChainWeaver never imports an LLM SDK,
+so it carries zero dependency on any provider.  Parsing YAML requires
+``pyyaml`` (the ``chainweaver[yaml]`` extra); the base install is unaffected
+because nothing imports this module at import time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from pydantic import BaseModel
+
+from chainweaver.exceptions import OfflineLLMError
+from chainweaver.tools import Tool
+
+LLMFn = Callable[[str], str]
+"""A provider-agnostic LLM call: a prompt string in, a completion string out.
+
+Callers adapt the model of their choice (a local Llama, GPT, Claude, an
+offline stub, ...) to this signature.  ChainWeaver never inspects the model
+or imports a provider SDK — the completion is plain text the proposer then
+parses as YAML.
+"""
+
+
+def parse_llm_yaml(raw: str) -> Any:
+    """Parse an LLM completion as YAML, tolerating a Markdown code fence.
+
+    Many models wrap structured output in a ```` ```yaml … ``` ```` fence.
+    A single leading fence line (```` ``` ```` or ```` ```yaml ````) and a
+    matching trailing fence line are stripped before the text is handed to
+    ``yaml.safe_load``.
+
+    Args:
+        raw: The raw completion string returned by an :data:`LLMFn`.
+
+    Returns:
+        The parsed YAML document (typically a ``list`` or ``dict``).
+
+    Raises:
+        OfflineLLMError: When ``pyyaml`` is unavailable, the completion is
+            blank, or the text is not valid YAML.
+    """
+    yaml = _require_yaml()
+    text = _strip_code_fence(raw)
+    if not text.strip():
+        raise OfflineLLMError("LLM returned an empty completion; expected YAML.")
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise OfflineLLMError(f"LLM completion is not valid YAML: {exc}") from exc
+
+
+def render_tool_catalogue(tools: Iterable[Tool]) -> str:
+    """Render a compact, prompt-ready catalogue of *tools*.
+
+    One block per tool: its name and description, then a one-line summary of
+    the input and output schema fields.  This is the ecosystem context both
+    proposers feed to the LLM so it can reason across *all* tools at once.
+    """
+    lines: list[str] = []
+    for tool in tools:
+        lines.append(f"- {tool.name}: {tool.description}")
+        lines.append(f"    input:  {_field_summary(tool.input_schema)}")
+        lines.append(f"    output: {_field_summary(tool.output_schema)}")
+    return "\n".join(lines)
+
+
+def _field_summary(schema: type[BaseModel]) -> str:
+    """Return a ``name: type`` summary of a Pydantic *schema*'s fields.
+
+    Optional fields are suffixed with ``?``.  An empty schema renders as
+    ``(none)`` so the catalogue line is never blank.
+    """
+    parts: list[str] = []
+    for name, info in schema.model_fields.items():
+        annotation = info.annotation
+        type_name = getattr(annotation, "__name__", str(annotation))
+        suffix = "" if info.is_required() else "?"
+        parts.append(f"{name}{suffix}: {type_name}")
+    return ", ".join(parts) if parts else "(none)"
+
+
+def _strip_code_fence(raw: str) -> str:
+    """Drop a single surrounding Markdown code fence from *raw*, if present."""
+    stripped = raw.strip()
+    if not stripped.startswith("```"):
+        return raw
+    lines = stripped.splitlines()
+    # Drop the opening fence line (``` or ```yaml).
+    lines = lines[1:]
+    # Drop a matching trailing fence line if present.
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines)
+
+
+def _require_yaml() -> Any:
+    """Return the ``yaml`` module, or raise :class:`OfflineLLMError`."""
+    try:
+        import yaml
+    except ImportError as exc:
+        raise OfflineLLMError(
+            "Offline LLM proposers parse YAML completions and require 'pyyaml'. "
+            "Install it via 'pip install chainweaver[yaml]'."
+        ) from exc
+    return yaml

--- a/chainweaver/_offline_llm.py
+++ b/chainweaver/_offline_llm.py
@@ -66,6 +66,38 @@ def parse_llm_yaml(raw: str) -> Any:
         raise OfflineLLMError(f"LLM completion is not valid YAML: {exc}") from exc
 
 
+def coerce_proposal_list(parsed: Any) -> list[dict[str, Any]]:
+    """Normalise a parsed YAML document into a list of proposal mappings.
+
+    Both offline proposers ask the LLM for the same envelope — a top-level
+    list, or a mapping with a ``proposals`` key — so they share this coercion
+    instead of reimplementing it with subtly different error messages.
+
+    Args:
+        parsed: The object returned by :func:`parse_llm_yaml`.
+
+    Returns:
+        The list of proposal mappings.
+
+    Raises:
+        OfflineLLMError: When *parsed* is neither a list nor a mapping with a
+            ``proposals`` list, or when any entry is not a mapping.
+    """
+    if isinstance(parsed, dict):
+        parsed = parsed.get("proposals", [])
+    if not isinstance(parsed, list):
+        raise OfflineLLMError(
+            "Expected a YAML list of proposals (or a mapping with a 'proposals' "
+            f"key); got {type(parsed).__name__}."
+        )
+    entries: list[dict[str, Any]] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            raise OfflineLLMError(f"Each proposal must be a mapping; got {type(item).__name__}.")
+        entries.append(item)
+    return entries
+
+
 def render_tool_catalogue(tools: Iterable[Tool]) -> str:
     """Render a compact, prompt-ready catalogue of *tools*.
 

--- a/chainweaver/_offline_llm.py
+++ b/chainweaver/_offline_llm.py
@@ -10,12 +10,12 @@ YAML payload parser, and a compact tool-catalogue renderer for prompts.
 NOT be imported by :mod:`chainweaver.executor` — the executor stays free of
 any LLM coupling (AGENTS.md core invariant #1: *no LLM calls in
 ``executor.py``*).  ``tests/test_offline_llm_guardrail.py`` enforces this
-statically by parsing ``executor.py``'s import graph.
+statically by scanning ``executor.py``'s own import statements.
 
 The single LLM seam is :data:`LLMFn` — ChainWeaver never imports an LLM SDK,
 so it carries zero dependency on any provider.  Parsing YAML requires
 ``pyyaml`` (the ``chainweaver[yaml]`` extra); the base install is unaffected
-because nothing imports this module at import time.
+because ``pyyaml`` is imported lazily, only when a completion is parsed.
 """
 
 from __future__ import annotations

--- a/chainweaver/compiler_llm.py
+++ b/chainweaver/compiler_llm.py
@@ -1,0 +1,258 @@
+"""Offline, build-time LLM-assisted flow compiler (issue #28).
+
+The static :class:`~chainweaver.analyzer.ChainAnalyzer` discovers chains by
+*schema* matching.  Some valid chains only become apparent with *semantic*
+understanding of tool descriptions — a ``summarize`` tool's output might feed
+a ``translate`` tool even when the field names differ.  :func:`llm_propose_flows`
+bridges that gap with an LLM, but **offline, at build time** — it proposes
+:class:`~chainweaver.flow.Flow` definitions for human review, the way a code
+formatter suggests changes a developer approves.
+
+This is explicitly **not** an LLM in the executor loop.  The guarantees:
+
+* The LLM is reached only through the provider-agnostic
+  :data:`~chainweaver._offline_llm.LLMFn` seam — ChainWeaver depends on no
+  LLM SDK.
+* :mod:`chainweaver.executor` MUST NOT import this module
+  (``tests/test_offline_llm_guardrail.py`` enforces it statically).
+* Proposals are returned as data (:class:`LLMProposal`) and are **never**
+  auto-registered — they go to a human, governance, or
+  :func:`write_proposals` for a PR.
+
+Output contract
+---------------
+
+The LLM is asked to return YAML — a list of proposals, each with a ``flow``
+mapping (in the :func:`~chainweaver.serialization.flow_to_dict` shape), a
+``rationale`` string, and a ``confidence`` number in ``[0, 1]``.  Proposed
+flows are linear :class:`~chainweaver.flow.Flow` objects; a missing ``type``
+discriminator defaults to ``"Flow"``.  Parsing YAML requires ``pyyaml``
+(the ``chainweaver[yaml]`` extra).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from chainweaver._offline_llm import LLMFn, parse_llm_yaml, render_tool_catalogue
+from chainweaver.exceptions import FlowSerializationError, OfflineLLMError
+from chainweaver.flow import Flow
+from chainweaver.serialization import flow_from_dict, flow_to_yaml
+from chainweaver.tools import Tool
+
+__all__ = ["LLMProposal", "llm_propose_flows", "write_proposals"]
+
+
+@dataclass
+class LLMProposal:
+    """One flow proposed by the offline LLM compiler.
+
+    Attributes:
+        proposed_flow: The parsed, ready-to-review :class:`Flow`.
+        rationale: The LLM's explanation of why this chain makes sense.
+        confidence: The LLM's self-reported confidence, clamped to ``[0, 1]``.
+        source: Provenance tag distinguishing these from static-analysis
+            proposals.  Always ``"llm-compiler"``.
+    """
+
+    proposed_flow: Flow
+    rationale: str
+    confidence: float
+    source: str = "llm-compiler"
+
+
+_PROMPT_TEMPLATE = """\
+You are an offline build-time compiler for ChainWeaver, a deterministic
+orchestration layer. Propose deterministic tool chains ("flows") that wire
+the available tools together so an agent can run them without an LLM in the
+loop.
+
+Available tools (name, description, then input/output schema fields):
+{catalogue}
+{hints}
+Rules:
+- Each step invokes one tool by its exact name from the catalogue above.
+- A later step may consume fields produced by an earlier step.
+- Propose at most {max_proposals} flows. Prefer high-value, genuinely
+  deterministic chains over speculative ones.
+
+Output ONLY YAML: a list under the key "proposals". Each proposal has:
+  - flow: a mapping with keys
+      type: Flow
+      name: <snake_case unique name>
+      version: "0.0.0"
+      description: <one line>
+      steps: a list of {{tool_name: <name>, input_mapping: {{<target>: <source>}}}}
+  - rationale: <why this chain makes sense, especially any semantic link>
+  - confidence: <number between 0 and 1>
+"""
+
+
+def llm_propose_flows(
+    tools: Iterable[Tool],
+    *,
+    llm_fn: LLMFn,
+    max_proposals: int = 5,
+    static_candidates: Iterable[Flow] | None = None,
+) -> list[LLMProposal]:
+    """Propose flows from tool metadata using an offline LLM.
+
+    Args:
+        tools: The tools the LLM may chain.  When empty, no LLM call is made
+            and an empty list is returned.
+        llm_fn: A provider-agnostic ``prompt -> completion`` callable.  Never
+            invoked at runtime — this is a build-time tool.
+        max_proposals: Upper bound on returned proposals.  Extra proposals in
+            the completion are truncated; must be ``>= 1``.
+        static_candidates: Optional :class:`Flow` hints (e.g. from
+            :meth:`ChainAnalyzer.suggest_flows`) rendered into the prompt as
+            already-known schema-valid chains the LLM can refine or extend.
+
+    Returns:
+        A list of :class:`LLMProposal` objects, at most *max_proposals* long.
+
+    Raises:
+        OfflineLLMError: When the completion is blank, not valid YAML,
+            structurally malformed, references an unknown tool, or yields a
+            non-linear flow.
+        ValueError: When *max_proposals* is less than 1.
+    """
+    if max_proposals < 1:
+        raise ValueError(f"max_proposals must be >= 1, got {max_proposals}.")
+
+    tools_list = list(tools)
+    if not tools_list:
+        return []
+    known_names = {tool.name for tool in tools_list}
+
+    prompt = _PROMPT_TEMPLATE.format(
+        catalogue=render_tool_catalogue(tools_list),
+        hints=_render_hints(static_candidates),
+        max_proposals=max_proposals,
+    )
+    raw = llm_fn(prompt)
+    entries = _proposal_entries(parse_llm_yaml(raw))
+
+    proposals: list[LLMProposal] = []
+    for entry in entries[:max_proposals]:
+        proposals.append(_build_proposal(entry, known_names))
+    return proposals
+
+
+def write_proposals(proposals: Iterable[LLMProposal], directory: str | Path) -> list[Path]:
+    """Write *proposals* as PR-ready ``.flow.yaml`` files plus a summary.
+
+    Each proposal's flow is written to ``<directory>/<flow_name>.flow.yaml``
+    using :func:`~chainweaver.serialization.flow_to_yaml`, and a
+    ``PROPOSALS.md`` index lists every proposal with its confidence and
+    rationale.  The directory is created if it does not exist.
+
+    Args:
+        proposals: The proposals to serialise.
+        directory: Target directory for the ``.flow.yaml`` files and
+            ``PROPOSALS.md``.
+
+    Returns:
+        The list of written paths, in write order (flow files first, then
+        ``PROPOSALS.md``).
+
+    Raises:
+        OfflineLLMError: When ``pyyaml`` (the ``chainweaver[yaml]`` extra) is
+            not installed.
+    """
+    target = Path(directory)
+    target.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    summary_lines = ["# Proposed flows", ""]
+    for proposal in proposals:
+        flow = proposal.proposed_flow
+        flow_path = target / f"{flow.name}.flow.yaml"
+        try:
+            flow_path.write_text(flow_to_yaml(flow), encoding="utf-8")
+        except FlowSerializationError as exc:
+            # Re-raise under the offline-LLM error so callers catch one type.
+            raise OfflineLLMError(str(exc)) from exc
+        written.append(flow_path)
+        summary_lines.append(
+            f"- **{flow.name}** (confidence {proposal.confidence:.2f}, "
+            f"source `{proposal.source}`): {proposal.rationale}"
+        )
+
+    summary_path = target / "PROPOSALS.md"
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    written.append(summary_path)
+    return written
+
+
+def _render_hints(static_candidates: Iterable[Flow] | None) -> str:
+    """Render optional static-analysis hint flows for the prompt."""
+    if static_candidates is None:
+        return ""
+    lines: list[str] = []
+    for flow in static_candidates:
+        sequence = " -> ".join(step.tool_name or f"<flow:{step.flow_name}>" for step in flow.steps)
+        lines.append(f"- {flow.name}: {sequence}")
+    if not lines:
+        return ""
+    header = "\nKnown schema-valid chains (hints you may refine or extend):\n"
+    return header + "\n".join(lines) + "\n"
+
+
+def _proposal_entries(parsed: Any) -> list[dict[str, Any]]:
+    """Normalise a parsed YAML document into a list of proposal mappings."""
+    if isinstance(parsed, dict):
+        parsed = parsed.get("proposals", [])
+    if not isinstance(parsed, list):
+        raise OfflineLLMError(
+            "Expected a YAML list of proposals (or a mapping with a 'proposals' "
+            f"key); got {type(parsed).__name__}."
+        )
+    entries: list[dict[str, Any]] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            raise OfflineLLMError(f"Each proposal must be a mapping; got {type(item).__name__}.")
+        entries.append(item)
+    return entries
+
+
+def _build_proposal(entry: dict[str, Any], known_names: set[str]) -> LLMProposal:
+    """Build one :class:`LLMProposal` from a parsed proposal mapping."""
+    flow_data = entry.get("flow")
+    if not isinstance(flow_data, dict):
+        raise OfflineLLMError("Proposal is missing a 'flow' mapping.")
+    # Default the discriminator: the compiler proposes linear flows.
+    flow_payload = {"type": "Flow", **flow_data}
+    try:
+        flow = flow_from_dict(flow_payload)
+    except FlowSerializationError as exc:
+        raise OfflineLLMError(f"Proposed flow is invalid: {exc}") from exc
+    if not isinstance(flow, Flow):
+        raise OfflineLLMError(
+            f"Proposed flow '{flow.name}' is not a linear Flow; the LLM compiler "
+            "only proposes Flow objects."
+        )
+
+    unknown = [
+        step.tool_name
+        for step in flow.steps
+        if step.tool_name is not None and step.tool_name not in known_names
+    ]
+    if unknown:
+        raise OfflineLLMError(
+            f"Proposed flow '{flow.name}' references unknown tools: {sorted(unknown)}."
+        )
+
+    rationale = entry.get("rationale", "")
+    if not isinstance(rationale, str):
+        raise OfflineLLMError("Proposal 'rationale' must be a string.")
+
+    raw_confidence = entry.get("confidence")
+    if not isinstance(raw_confidence, (int, float)) or isinstance(raw_confidence, bool):
+        raise OfflineLLMError("Proposal 'confidence' must be a number in [0, 1].")
+    confidence = max(0.0, min(1.0, float(raw_confidence)))
+
+    return LLMProposal(proposed_flow=flow, rationale=rationale, confidence=confidence)

--- a/chainweaver/compiler_llm.py
+++ b/chainweaver/compiler_llm.py
@@ -32,6 +32,7 @@ discriminator defaults to ``"Flow"``.  Parsing YAML requires ``pyyaml``
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -161,7 +162,8 @@ def write_proposals(proposals: Iterable[LLMProposal], directory: str | Path) -> 
 
     Raises:
         OfflineLLMError: When ``pyyaml`` (the ``chainweaver[yaml]`` extra) is
-            not installed.
+            not installed, or when a proposed flow name is not safe to use as
+            a filename (see :func:`_safe_flow_filename`).
     """
     target = Path(directory)
     target.mkdir(parents=True, exist_ok=True)
@@ -170,7 +172,7 @@ def write_proposals(proposals: Iterable[LLMProposal], directory: str | Path) -> 
     summary_lines = ["# Proposed flows", ""]
     for proposal in proposals:
         flow = proposal.proposed_flow
-        flow_path = target / f"{flow.name}.flow.yaml"
+        flow_path = _safe_flow_filename(flow.name, target)
         try:
             flow_path.write_text(flow_to_yaml(flow), encoding="utf-8")
         except FlowSerializationError as exc:
@@ -186,6 +188,44 @@ def write_proposals(proposals: Iterable[LLMProposal], directory: str | Path) -> 
     summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
     written.append(summary_path)
     return written
+
+
+_SAFE_FLOW_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_flow_filename(name: str, target: Path) -> Path:
+    """Return ``<target>/<name>.flow.yaml``, rejecting unsafe flow names.
+
+    ``Flow.name`` is LLM-proposed and otherwise unvalidated, so a malformed or
+    adversarial completion could embed path separators or ``..`` segments and
+    write outside *target* (path traversal).  The name is restricted to a
+    conservative filename-safe character set, the bare ``.``/``..`` segments
+    are rejected, and the resolved path is confirmed to land directly inside
+    *target* as defence in depth.
+
+    Args:
+        name: The proposed flow name to turn into a filename.
+        target: The directory the file must stay within.
+
+    Returns:
+        The resolved ``.flow.yaml`` path inside *target*.
+
+    Raises:
+        OfflineLLMError: When *name* is empty, contains characters outside
+            ``[A-Za-z0-9._-]`` (e.g. a path separator), is ``.`` or ``..``, or
+            otherwise resolves outside *target*.
+    """
+    if not _SAFE_FLOW_NAME.fullmatch(name) or name in {".", ".."}:
+        raise OfflineLLMError(
+            f"Proposed flow name '{name}' is not safe for a filename; expected "
+            "only letters, digits, '.', '_', and '-' with no path separators."
+        )
+    candidate = (target / f"{name}.flow.yaml").resolve()
+    if candidate.parent != target.resolve():
+        raise OfflineLLMError(
+            f"Proposed flow name '{name}' resolves outside the target directory."
+        )
+    return candidate
 
 
 def _render_hints(static_candidates: Iterable[Flow] | None) -> str:

--- a/chainweaver/compiler_llm.py
+++ b/chainweaver/compiler_llm.py
@@ -38,7 +38,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from chainweaver._offline_llm import LLMFn, parse_llm_yaml, render_tool_catalogue
+from chainweaver._offline_llm import (
+    LLMFn,
+    coerce_proposal_list,
+    parse_llm_yaml,
+    render_tool_catalogue,
+)
 from chainweaver.exceptions import FlowSerializationError, OfflineLLMError
 from chainweaver.flow import Flow
 from chainweaver.serialization import flow_from_dict, flow_to_yaml
@@ -135,7 +140,7 @@ def llm_propose_flows(
         max_proposals=max_proposals,
     )
     raw = llm_fn(prompt)
-    entries = _proposal_entries(parse_llm_yaml(raw))
+    entries = coerce_proposal_list(parse_llm_yaml(raw))
 
     proposals: list[LLMProposal] = []
     for entry in entries[:max_proposals]:
@@ -240,23 +245,6 @@ def _render_hints(static_candidates: Iterable[Flow] | None) -> str:
         return ""
     header = "\nKnown schema-valid chains (hints you may refine or extend):\n"
     return header + "\n".join(lines) + "\n"
-
-
-def _proposal_entries(parsed: Any) -> list[dict[str, Any]]:
-    """Normalise a parsed YAML document into a list of proposal mappings."""
-    if isinstance(parsed, dict):
-        parsed = parsed.get("proposals", [])
-    if not isinstance(parsed, list):
-        raise OfflineLLMError(
-            "Expected a YAML list of proposals (or a mapping with a 'proposals' "
-            f"key); got {type(parsed).__name__}."
-        )
-    entries: list[dict[str, Any]] = []
-    for item in parsed:
-        if not isinstance(item, dict):
-            raise OfflineLLMError(f"Each proposal must be a mapping; got {type(item).__name__}.")
-        entries.append(item)
-    return entries
 
 
 def _build_proposal(entry: dict[str, Any], known_names: set[str]) -> LLMProposal:

--- a/chainweaver/exceptions.py
+++ b/chainweaver/exceptions.py
@@ -462,6 +462,28 @@ class CostProfileError(ChainWeaverError):
         )
 
 
+class OfflineLLMError(ChainWeaverError):
+    """Raised when an offline, build-time LLM-assisted proposer cannot use a completion.
+
+    Shared by :mod:`chainweaver.compiler_llm` (issue #28) and
+    :mod:`chainweaver.optimizer` (issue #100).  These modules run the LLM
+    *offline, at build time* — never inside :mod:`chainweaver.executor` — and
+    turn its completion into reviewable proposals.  This error surfaces a
+    clear, typed failure when the completion is blank, is not valid YAML, is
+    structurally malformed, or references tools/flows that do not exist —
+    rather than leaking a raw ``yaml.YAMLError`` or ``KeyError`` to the
+    caller.  It is also raised when ``pyyaml`` (the ``chainweaver[yaml]``
+    extra) is needed to parse a completion but is not installed.
+
+    Attributes:
+        detail: Human-readable explanation of what failed.
+    """
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
 class PredicateSyntaxError(ChainWeaverError):
     """Raised when a conditional-branch predicate cannot be parsed or evaluated.
 

--- a/chainweaver/optimizer.py
+++ b/chainweaver/optimizer.py
@@ -33,7 +33,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from chainweaver._offline_llm import LLMFn, parse_llm_yaml, render_tool_catalogue
+from chainweaver._offline_llm import (
+    LLMFn,
+    coerce_proposal_list,
+    parse_llm_yaml,
+    render_tool_catalogue,
+)
 from chainweaver.exceptions import OfflineLLMError
 from chainweaver.tools import Tool
 
@@ -204,19 +209,10 @@ def _parse_proposals(
     originals: dict[str, str],
 ) -> list[ToolDescriptionProposal]:
     """Parse an LLM completion into validated description proposals."""
-    parsed = parse_llm_yaml(raw)
-    if isinstance(parsed, dict):
-        parsed = parsed.get("proposals", [])
-    if not isinstance(parsed, list):
-        raise OfflineLLMError(
-            "Expected a YAML list of proposals (or a mapping with a 'proposals' "
-            f"key); got {type(parsed).__name__}."
-        )
+    entries = coerce_proposal_list(parse_llm_yaml(raw))
 
     proposals: list[ToolDescriptionProposal] = []
-    for item in parsed:
-        if not isinstance(item, dict):
-            raise OfflineLLMError(f"Each proposal must be a mapping; got {type(item).__name__}.")
+    for item in entries:
         tool_name = item.get("tool_name")
         if not isinstance(tool_name, str) or tool_name not in originals:
             raise OfflineLLMError(

--- a/chainweaver/optimizer.py
+++ b/chainweaver/optimizer.py
@@ -1,0 +1,257 @@
+"""Offline, build-time tool-description optimizer (issue #100).
+
+MCP tool descriptions are authored in isolation: each server writes its own
+without knowing what other tools exist, so an agent's LLM sees ambiguous,
+inconsistently-scoped, token-heavy descriptions.  :func:`optimize_tool_descriptions`
+gives an LLM visibility across **all** registered tools at once and asks it to
+rewrite descriptions to be maximally discriminative, concise, and
+LLM-friendly — something no single tool author can do, because *discrimination
+is a property of the set, not the individual tool*.
+
+Like :mod:`chainweaver.compiler_llm`, this is an **offline, build-time** tool:
+
+* The LLM is reached only through the provider-agnostic
+  :data:`~chainweaver._offline_llm.LLMFn` seam.
+* :mod:`chainweaver.executor` MUST NOT import this module
+  (``tests/test_offline_llm_guardrail.py`` enforces it statically).
+* Rewrites are returned as :class:`ToolDescriptionProposal` data objects for
+  human review and are **never** applied automatically.
+
+Output contract
+---------------
+
+The LLM is asked to return YAML — a list under ``proposals``, each with a
+``tool_name``, ``proposed_description``, ``rationale``, and an optional
+``similarity_group`` (other tool names it was disambiguated against).
+Parsing YAML requires ``pyyaml`` (the ``chainweaver[yaml]`` extra).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from chainweaver._offline_llm import LLMFn, parse_llm_yaml, render_tool_catalogue
+from chainweaver.exceptions import OfflineLLMError
+from chainweaver.tools import Tool
+
+__all__ = [
+    "OptimizationStrategy",
+    "ToolDescriptionProposal",
+    "optimize_new_tool_description",
+    "optimize_tool_descriptions",
+]
+
+
+class OptimizationStrategy(str, Enum):
+    """How the optimizer should reshape descriptions.
+
+    Attributes:
+        DISCRIMINATIVE: Maximise the distinction between similar tools
+            (the default — disambiguation is the highest-value rewrite).
+        CONCISE: Minimise token count while preserving the semantics.
+        STRUCTURED: Enforce a consistent format across all descriptions.
+    """
+
+    DISCRIMINATIVE = "discriminative"
+    CONCISE = "concise"
+    STRUCTURED = "structured"
+
+
+@dataclass
+class ToolDescriptionProposal:
+    """One description rewrite proposed by the offline optimizer.
+
+    Attributes:
+        tool_name: The tool whose description is being rewritten.
+        original_description: The description as authored today.
+        proposed_description: The LLM's rewrite.
+        rationale: Why this change improves discriminability or clarity.
+        similarity_group: Other tool names this was disambiguated against.
+        token_delta: Approximate change in token count (``word_count * 1.3``).
+            Negative means the rewrite is shorter (an improvement).
+        source: Provenance tag.  Always ``"description-optimizer"``.
+    """
+
+    tool_name: str
+    original_description: str
+    proposed_description: str
+    rationale: str
+    similarity_group: list[str] = field(default_factory=list)
+    token_delta: int = 0
+    source: str = "description-optimizer"
+
+
+_STRATEGY_GUIDANCE: dict[OptimizationStrategy, str] = {
+    OptimizationStrategy.DISCRIMINATIVE: (
+        "Rewrite each description to help an LLM agent choose the correct tool "
+        "with minimal ambiguity. Focus on what makes each tool DIFFERENT from "
+        "similar tools."
+    ),
+    OptimizationStrategy.CONCISE: (
+        "Rewrite each description to the fewest tokens that still preserve its "
+        "semantics. Drop filler an LLM does not need to pick the tool."
+    ),
+    OptimizationStrategy.STRUCTURED: (
+        "Rewrite every description into one consistent structure: a single "
+        "imperative sentence stating what the tool does and on what input."
+    ),
+}
+
+_PROMPT_TEMPLATE = """\
+You optimize MCP tool descriptions offline, at build time, with visibility
+across the WHOLE tool ecosystem below. {guidance}
+
+Tools (name, current description, then input/output schema fields):
+{catalogue}
+
+Only propose a rewrite for a tool when it is a genuine improvement; omit tools
+whose description is already optimal.
+
+Output ONLY YAML: a list under the key "proposals". Each proposal has:
+  - tool_name: <exact tool name from above>
+  - proposed_description: <the rewrite>
+  - rationale: <why it improves discriminability or clarity>
+  - similarity_group: <list of other tool names it was disambiguated against>
+"""
+
+
+def optimize_tool_descriptions(
+    tools: Iterable[Tool],
+    *,
+    llm_fn: LLMFn,
+    strategy: OptimizationStrategy = OptimizationStrategy.DISCRIMINATIVE,
+) -> list[ToolDescriptionProposal]:
+    """Rewrite tool descriptions for ecosystem-wide discriminability.
+
+    Args:
+        tools: All tools in the ecosystem.  When empty, no LLM call is made
+            and an empty list is returned.
+        llm_fn: A provider-agnostic ``prompt -> completion`` callable.  Never
+            invoked at runtime — this is a build-time tool.
+        strategy: Which :class:`OptimizationStrategy` to instruct the LLM with.
+
+    Returns:
+        A list of :class:`ToolDescriptionProposal` objects, one per rewrite
+        the LLM proposed.
+
+    Raises:
+        OfflineLLMError: When the completion is blank, not valid YAML,
+            structurally malformed, or names a tool absent from *tools*.
+    """
+    tools_list = list(tools)
+    if not tools_list:
+        return []
+    originals = {tool.name: tool.description for tool in tools_list}
+
+    prompt = _PROMPT_TEMPLATE.format(
+        guidance=_STRATEGY_GUIDANCE[strategy],
+        catalogue=render_tool_catalogue(tools_list),
+    )
+    return _parse_proposals(llm_fn(prompt), originals)
+
+
+def optimize_new_tool_description(
+    new_tool: Tool,
+    existing_tools: Iterable[Tool],
+    *,
+    llm_fn: LLMFn,
+    strategy: OptimizationStrategy = OptimizationStrategy.DISCRIMINATIVE,
+) -> list[ToolDescriptionProposal]:
+    """Optimize a single new tool's description against an existing ecosystem.
+
+    The incremental counterpart to :func:`optimize_tool_descriptions`: the LLM
+    is shown the existing tools and the newcomer, then proposes a rewrite for
+    the new tool and may also flag existing tools whose descriptions should
+    change now that the newcomer exists.
+
+    Args:
+        new_tool: The tool being added.
+        existing_tools: The tools already in the ecosystem.
+        llm_fn: A provider-agnostic ``prompt -> completion`` callable.
+        strategy: Which :class:`OptimizationStrategy` to instruct the LLM with.
+
+    Returns:
+        A list of :class:`ToolDescriptionProposal` objects for the new tool
+        and/or affected existing tools.
+
+    Raises:
+        OfflineLLMError: When the completion is blank, not valid YAML,
+            structurally malformed, or names an unknown tool.
+    """
+    ecosystem = [new_tool, *existing_tools]
+    originals = {tool.name: tool.description for tool in ecosystem}
+
+    prompt = (
+        f"A new tool '{new_tool.name}' is being added to the ecosystem below. "
+        + _PROMPT_TEMPLATE.format(
+            guidance=_STRATEGY_GUIDANCE[strategy],
+            catalogue=render_tool_catalogue(ecosystem),
+        )
+    )
+    return _parse_proposals(llm_fn(prompt), originals)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Approximate the token count of *text* as ``word_count * 1.3``."""
+    return round(len(text.split()) * 1.3)
+
+
+def _parse_proposals(
+    raw: str,
+    originals: dict[str, str],
+) -> list[ToolDescriptionProposal]:
+    """Parse an LLM completion into validated description proposals."""
+    parsed = parse_llm_yaml(raw)
+    if isinstance(parsed, dict):
+        parsed = parsed.get("proposals", [])
+    if not isinstance(parsed, list):
+        raise OfflineLLMError(
+            "Expected a YAML list of proposals (or a mapping with a 'proposals' "
+            f"key); got {type(parsed).__name__}."
+        )
+
+    proposals: list[ToolDescriptionProposal] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            raise OfflineLLMError(f"Each proposal must be a mapping; got {type(item).__name__}.")
+        tool_name = item.get("tool_name")
+        if not isinstance(tool_name, str) or tool_name not in originals:
+            raise OfflineLLMError(
+                f"Proposal names an unknown tool: {tool_name!r}. Known tools: {sorted(originals)}."
+            )
+        proposed = item.get("proposed_description")
+        if not isinstance(proposed, str):
+            raise OfflineLLMError(
+                f"Proposal for '{tool_name}' is missing a string 'proposed_description'."
+            )
+        rationale = item.get("rationale", "")
+        if not isinstance(rationale, str):
+            raise OfflineLLMError(f"Proposal for '{tool_name}' has a non-string 'rationale'.")
+        similarity_group = _string_list(item.get("similarity_group"), tool_name)
+
+        original = originals[tool_name]
+        proposals.append(
+            ToolDescriptionProposal(
+                tool_name=tool_name,
+                original_description=original,
+                proposed_description=proposed,
+                rationale=rationale,
+                similarity_group=similarity_group,
+                token_delta=_estimate_tokens(proposed) - _estimate_tokens(original),
+            )
+        )
+    return proposals
+
+
+def _string_list(value: Any, tool_name: str) -> list[str]:
+    """Coerce an optional ``similarity_group`` into a list of strings."""
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise OfflineLLMError(
+            f"Proposal for '{tool_name}' has a non-string-list 'similarity_group'."
+        )
+    return value

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -27,6 +27,8 @@ deterministic workflow engine. The two framework recipes need an optional extra
 | [OpenAI Agents SDK tool](openai-agents-tool.md) | A compiled flow exposed as one agent tool (dry-run). | `chainweaver[openai-agents]` |
 | [Release-readiness workflow](release-readiness.md) | A deterministic pre-release gate with branching. | — |
 | [Offline policy evaluation (skdr-eval)](policy-eval-skdr.md) | A fixture-based policy-eval flow with a deterministic gate. | — |
+| [Offline LLM-assisted flow proposals](offline-llm-flow-proposals.md) | An LLM proposing reviewable flows at build time. | — |
+| [Offline tool-description optimizer](offline-description-optimizer.md) | Set-level description rewrites for discriminability. | — |
 
 ## Conventions used in the cookbook
 

--- a/docs/cookbook/offline-description-optimizer.md
+++ b/docs/cookbook/offline-description-optimizer.md
@@ -1,0 +1,64 @@
+# Recipe — Offline tool-description optimizer
+
+**You have:** several tools with overlapping, isolated descriptions —
+`search`, `query`, `lookup` — that an agent's LLM can't reliably tell apart.
+**You want:** descriptions rewritten to be maximally *discriminative* across
+the whole tool set, **offline, at build time**.
+
+Paired script: `examples/description_optimizer.py`. It runs fully offline with
+a canned `llm_fn`.
+
+## Why a set-level rewrite
+
+Discrimination is a property of the *set*, not the individual tool: you can't
+write a good `search` description without knowing about the other `query` and
+`lookup` tools it will be confused with. `optimize_tool_descriptions` gives the
+LLM visibility across every tool at once.
+
+```python
+from chainweaver import OptimizationStrategy, optimize_tool_descriptions
+
+proposals = optimize_tool_descriptions(
+    [search, query, lookup],
+    llm_fn=my_llm,
+    strategy=OptimizationStrategy.DISCRIMINATIVE,  # or CONCISE / STRUCTURED
+)
+
+for p in proposals:
+    print(p.tool_name, p.token_delta)   # negative delta = shorter rewrite
+    print("  before:", p.original_description)
+    print("  after: ", p.proposed_description)
+    print("  vs:    ", p.similarity_group)
+```
+
+Each `ToolDescriptionProposal` keeps the `original_description` for
+side-by-side review, the `proposed_description`, a `rationale`, the
+`similarity_group` it was disambiguated against, and an approximate
+`token_delta` (`word_count * 1.3`).
+
+## Strategies
+
+| Strategy | Goal |
+|---|---|
+| `DISCRIMINATIVE` (default) | Maximise the distinction between similar tools. |
+| `CONCISE` | Minimise tokens while preserving semantics. |
+| `STRUCTURED` | Enforce one consistent format across all descriptions. |
+
+## Incremental mode
+
+When a single tool is added, optimize just it against the existing ecosystem —
+and let the LLM flag existing tools whose descriptions should change now that
+the newcomer exists:
+
+```python
+from chainweaver import optimize_new_tool_description
+
+proposals = optimize_new_tool_description(new_tool, existing_tools, llm_fn=my_llm)
+```
+
+## Guarantees
+
+Same as the [flow compiler](offline-llm-flow-proposals.md): the LLM is reached
+only through `llm_fn`, the module is banned from the executor, proposals are
+**never applied automatically**, and malformed completions raise a typed
+`OfflineLLMError`.

--- a/docs/cookbook/offline-llm-flow-proposals.md
+++ b/docs/cookbook/offline-llm-flow-proposals.md
@@ -1,0 +1,62 @@
+# Recipe — Offline LLM-assisted flow proposals
+
+**You have:** a set of tools whose useful chains aren't obvious from their
+schemas alone — a `summarize` output that should feed `translate`, say, even
+though the field names differ.
+**You want:** an LLM to *propose* deterministic flows for you to review —
+**offline, at build time**, never in the executor loop.
+
+Paired script: `examples/llm_flow_proposals.py`. It runs fully offline with a
+canned `llm_fn`, so there's no network and no API key.
+
+## The seam: `llm_fn`, not an SDK
+
+ChainWeaver never imports an LLM provider. `llm_propose_flows` reaches a model
+only through a callable you supply:
+
+```python
+LLMFn = Callable[[str], str]  # prompt in, completion out
+```
+
+Adapt any model — a local Llama, GPT, Claude, or an offline stub — to that
+signature. This keeps the dependency surface at zero and keeps the LLM
+strictly at build time.
+
+## Propose flows
+
+```python
+from chainweaver import Tool, llm_propose_flows, write_proposals
+
+proposals = llm_propose_flows([search, summarize], llm_fn=my_llm)
+
+for p in proposals:
+    print(p.proposed_flow.name, p.confidence, p.rationale)
+
+# Optionally write PR-ready artifacts: one <name>.flow.yaml per proposal
+# plus a PROPOSALS.md summary (needs the chainweaver[yaml] extra).
+write_proposals(proposals, "proposed_flows/")
+```
+
+Each `LLMProposal` carries the parsed `proposed_flow`, the LLM's `rationale`,
+its self-reported `confidence` (clamped to `[0, 1]`), and a `source` tag of
+`"llm-compiler"`.
+
+## Guarantees
+
+- **Never auto-registered.** Proposals are plain data for a human, governance,
+  or a PR — `write_proposals` exists precisely so the output is reviewable.
+- **Banned from the executor.** `chainweaver/executor.py` must not import this
+  module; a guard test (`tests/test_offline_llm_guardrail.py`) enforces it.
+- **Validated.** Unknown tool references, malformed flows, and non-YAML
+  completions raise a typed `OfflineLLMError` rather than leaking a raw parser
+  error.
+
+You can hand `llm_propose_flows` the output of
+`ChainAnalyzer.suggest_flows()` via `static_candidates=` to seed the prompt
+with schema-valid chains the LLM can refine or extend.
+
+## What next
+
+Pair this with the [tool-description optimizer](offline-description-optimizer.md),
+which rewrites tool descriptions so an agent picks the right tool in the first
+place.

--- a/examples/description_optimizer.py
+++ b/examples/description_optimizer.py
@@ -1,0 +1,83 @@
+"""Rewrite tool descriptions for discriminability with an offline LLM (issue #100).
+
+Run with::
+
+    python examples/description_optimizer.py
+
+Tool descriptions are authored in isolation, so an agent's LLM sees several
+near-identical "search"/"query"/"lookup" blurbs with no disambiguation. An
+offline optimizer with visibility across *all* tools can rewrite them to be
+maximally distinct — because discrimination is a property of the set, not the
+individual tool.
+
+ChainWeaver reaches the model only through an ``llm_fn(prompt) -> completion``
+callable, offline and at build time. This example uses a canned ``llm_fn`` so
+it runs deterministically. Proposals are returned for human review and are
+never applied automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from chainweaver import OptimizationStrategy, Tool, optimize_tool_descriptions
+
+
+class QueryIn(BaseModel):
+    query: str
+
+
+class ResultsOut(BaseModel):
+    results: str
+
+
+def _noop(inp: Any) -> dict[str, Any]:
+    return {}
+
+
+def _tool(name: str, description: str) -> Tool:
+    return Tool(
+        name=name,
+        description=description,
+        input_schema=QueryIn,
+        output_schema=ResultsOut,
+        fn=_noop,
+    )
+
+
+tools = [
+    _tool("search", "Search the web and return the top matching documents for a query."),
+    _tool("query", "Query a data source and return matching records for the given query."),
+    _tool("lookup", "Look up a single record by its key in the store."),
+]
+
+
+def fake_llm(prompt: str) -> str:
+    """Return fixed rewrites, ignoring the prompt (demo only)."""
+    return """
+    proposals:
+      - tool_name: search
+        proposed_description: Full-text WEB search; returns ranked documents.
+        rationale: Marks it as unstructured/web, unlike query and lookup.
+        similarity_group: [query, lookup]
+      - tool_name: query
+        proposed_description: STRUCTURED query over a data source; returns records.
+        rationale: Marks it as structured, unlike web search.
+        similarity_group: [search, lookup]
+    """
+
+
+proposals = optimize_tool_descriptions(
+    tools, llm_fn=fake_llm, strategy=OptimizationStrategy.DISCRIMINATIVE
+)
+
+for proposal in proposals:
+    print(f"{proposal.tool_name}: token_delta={proposal.token_delta:+d}")
+    print(f"  before: {proposal.original_description}")
+    print(f"  after:  {proposal.proposed_description}")
+    print(f"  vs:     {', '.join(proposal.similarity_group)}")
+
+assert {p.tool_name for p in proposals} == {"search", "query"}
+print("\nProposals are data for human review — never applied automatically.")

--- a/examples/llm_flow_proposals.py
+++ b/examples/llm_flow_proposals.py
@@ -1,0 +1,110 @@
+"""Propose flows from tool metadata with an offline LLM (issue #28).
+
+Run with::
+
+    python examples/llm_flow_proposals.py
+
+ChainWeaver never imports an LLM SDK: the compiler reaches a model only
+through an ``llm_fn(prompt) -> completion`` callable, *offline, at build
+time* — never inside the executor. This example uses a canned ``llm_fn`` so
+it runs deterministically with no network and no API key. Swap in a real
+model (local Llama, GPT, Claude, ...) by adapting it to the same signature.
+
+Output: one proposed Flow (search -> summarize) with its rationale and
+confidence, then the PR-ready ``.flow.yaml`` files written to a temp dir.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from chainweaver import Tool, llm_propose_flows, write_proposals
+
+# --- 1. Declare a small tool ecosystem -------------------------------------
+
+
+class QueryIn(BaseModel):
+    query: str
+
+
+class ResultsOut(BaseModel):
+    results: str
+
+
+class SummaryOut(BaseModel):
+    summary: str
+
+
+def _noop(inp: Any) -> dict[str, Any]:
+    # Build-time only: the compiler never calls the tool functions.
+    return {}
+
+
+search = Tool(
+    name="search",
+    description="Search the web for a query.",
+    input_schema=QueryIn,
+    output_schema=ResultsOut,
+    fn=_noop,
+)
+summarize = Tool(
+    name="summarize",
+    description="Summarize a block of text.",
+    input_schema=ResultsOut,
+    output_schema=SummaryOut,
+    fn=_noop,
+)
+
+
+# --- 2. A stand-in llm_fn (replace with a real model) ----------------------
+
+
+def fake_llm(prompt: str) -> str:
+    """Return a fixed YAML proposal, ignoring the prompt (demo only)."""
+    return """
+    proposals:
+      - flow:
+          name: search_then_summarize
+          version: "0.0.0"
+          description: Search the web, then summarize the results.
+          steps:
+            - tool_name: search
+              input_mapping: {query: query}
+            - tool_name: summarize
+              input_mapping: {results: results}
+        rationale: >-
+          A summarize step semantically follows a search even though the
+          field names ('results' -> input) differ; static schema matching
+          alone would miss the intent.
+        confidence: 0.88
+    """
+
+
+# --- 3. Propose flows offline ----------------------------------------------
+
+proposals = llm_propose_flows([search, summarize], llm_fn=fake_llm)
+
+for proposal in proposals:
+    flow = proposal.proposed_flow
+    steps = " -> ".join(step.tool_name or "?" for step in flow.steps)
+    print(f"Proposed flow: {flow.name}  [{steps}]")
+    print(f"  confidence: {proposal.confidence:.2f}  source: {proposal.source}")
+    print(f"  rationale:  {proposal.rationale.strip()}")
+
+assert len(proposals) == 1
+assert proposals[0].proposed_flow.name == "search_then_summarize"
+
+# --- 4. Write PR-ready proposal files --------------------------------------
+
+with tempfile.TemporaryDirectory() as tmp:
+    written = write_proposals(proposals, tmp)
+    print("\nWrote:")
+    for path in written:
+        print(f"  {Path(path).name}")
+    assert any(p.name == "PROPOSALS.md" for p in written)
+
+print("\nProposals are data for human review — never auto-registered.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,8 @@ nav:
           - OpenAI Agents SDK tool: cookbook/openai-agents-tool.md
           - Release-readiness workflow: cookbook/release-readiness.md
           - Offline policy evaluation (skdr-eval): cookbook/policy-eval-skdr.md
+          - Offline LLM-assisted flow proposals: cookbook/offline-llm-flow-proposals.md
+          - Offline tool-description optimizer: cookbook/offline-description-optimizer.md
   - Reference:
       - CLI: cli.md
       - Error table: reference/error-table.md

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -68,11 +68,14 @@
     "InputMappingError",
     "InvalidFlowVersionError",
     "KernelInvocationError",
+    "LLMProposal",
     "MCPError",
     "MCPSchemaConversionError",
     "MCPToolInvocationError",
     "ObservedStep",
     "ObservedTrace",
+    "OfflineLLMError",
+    "OptimizationStrategy",
     "PROVIDER_PRICES",
     "PluginDiscoveryError",
     "PredicateSyntaxError",
@@ -96,6 +99,7 @@
     "Tool",
     "ToolChain",
     "ToolDefinitionError",
+    "ToolDescriptionProposal",
     "ToolNotFoundError",
     "ToolOutputSizeError",
     "ToolSafetyContract",
@@ -119,14 +123,18 @@
     "flow_to_json",
     "flow_to_mermaid",
     "flow_to_yaml",
+    "llm_propose_flows",
     "lookup_price",
     "merge_safety",
     "minimize_failure",
+    "optimize_new_tool_description",
+    "optimize_tool_descriptions",
     "result_to_mermaid",
     "schema_fingerprint",
     "suggest_optimizations",
     "tool",
-    "validate_dag_topology"
+    "validate_dag_topology",
+    "write_proposals"
   ],
   "python_version": [
     3,
@@ -696,6 +704,12 @@
       "qualname": "KernelInvocationError",
       "signature": "(capability_id: str, step_index: int, detail: str) -> None"
     },
+    "LLMProposal": {
+      "kind": "class",
+      "module": "chainweaver.compiler_llm",
+      "qualname": "LLMProposal",
+      "signature": "(proposed_flow: Flow, rationale: str, confidence: float, source: str = 'llm-compiler') -> None"
+    },
     "MCPError": {
       "kind": "class",
       "module": "chainweaver.exceptions",
@@ -737,6 +751,17 @@
       },
       "module": "chainweaver.observation",
       "qualname": "ObservedTrace"
+    },
+    "OfflineLLMError": {
+      "kind": "class",
+      "module": "chainweaver.exceptions",
+      "qualname": "OfflineLLMError",
+      "signature": "(detail: str) -> None"
+    },
+    "OptimizationStrategy": {
+      "kind": "enum",
+      "module": "chainweaver.optimizer",
+      "qualname": "OptimizationStrategy"
     },
     "PROVIDER_PRICES": {
       "kind": "mappingproxy",
@@ -945,6 +970,12 @@
       "qualname": "ToolDefinitionError",
       "signature": "(function_name: str, detail: str) -> None"
     },
+    "ToolDescriptionProposal": {
+      "kind": "class",
+      "module": "chainweaver.optimizer",
+      "qualname": "ToolDescriptionProposal",
+      "signature": "(tool_name: str, original_description: str, proposed_description: str, rationale: str, similarity_group: list[str] = <factory>, token_delta: int = 0, source: str = 'description-optimizer') -> None"
+    },
     "ToolNotFoundError": {
       "kind": "class",
       "module": "chainweaver.exceptions",
@@ -1089,6 +1120,12 @@
       "qualname": "flow_to_yaml",
       "signature": "(flow: AnyFlow) -> str"
     },
+    "llm_propose_flows": {
+      "kind": "function",
+      "module": "chainweaver.compiler_llm",
+      "qualname": "llm_propose_flows",
+      "signature": "(tools: Iterable[Tool], *, llm_fn: LLMFn, max_proposals: int = 5, static_candidates: Iterable[Flow] | None = None) -> list[LLMProposal]"
+    },
     "lookup_price": {
       "kind": "function",
       "module": "chainweaver.cost",
@@ -1106,6 +1143,18 @@
       "module": "chainweaver.fuzz",
       "qualname": "minimize_failure",
       "signature": "(executor: FlowExecutor, flow: Flow | DAGFlow, failing_input: dict[str, Any], prop: FlowProperty, *, max_rounds: int = 50) -> dict[str, Any]"
+    },
+    "optimize_new_tool_description": {
+      "kind": "function",
+      "module": "chainweaver.optimizer",
+      "qualname": "optimize_new_tool_description",
+      "signature": "(new_tool: Tool, existing_tools: Iterable[Tool], *, llm_fn: LLMFn, strategy: OptimizationStrategy = chainweaver.optimizer.OptimizationStrategy.DISCRIMINATIVE) -> list[ToolDescriptionProposal]"
+    },
+    "optimize_tool_descriptions": {
+      "kind": "function",
+      "module": "chainweaver.optimizer",
+      "qualname": "optimize_tool_descriptions",
+      "signature": "(tools: Iterable[Tool], *, llm_fn: LLMFn, strategy: OptimizationStrategy = chainweaver.optimizer.OptimizationStrategy.DISCRIMINATIVE) -> list[ToolDescriptionProposal]"
     },
     "result_to_mermaid": {
       "kind": "function",
@@ -1136,6 +1185,12 @@
       "module": "chainweaver.flow",
       "qualname": "validate_dag_topology",
       "signature": "(flow: DAGFlow) -> None"
+    },
+    "write_proposals": {
+      "kind": "function",
+      "module": "chainweaver.compiler_llm",
+      "qualname": "write_proposals",
+      "signature": "(proposals: Iterable[LLMProposal], directory: str | Path) -> list[Path]"
     }
   }
 }

--- a/tests/test_compiler_llm.py
+++ b/tests/test_compiler_llm.py
@@ -228,6 +228,27 @@ def test_invalid_flow_payload_raises() -> None:
         llm_propose_flows([SEARCH], llm_fn=_FakeLLM(completion))
 
 
+def test_non_linear_dag_flow_payload_raises() -> None:
+    # An LLM-supplied `type: DAGFlow` overrides the default linear discriminator;
+    # the compiler only proposes linear Flow objects, so it must reject this.
+    completion = (
+        "proposals:\n"
+        "  - flow:\n"
+        "      type: DAGFlow\n"
+        "      name: diamond\n"
+        '      version: "1.0.0"\n'
+        "      description: A DAG, not a linear flow.\n"
+        "      steps:\n"
+        "        - tool_name: search\n"
+        "          step_id: A\n"
+        "          depends_on: []\n"
+        "    rationale: dag\n"
+        "    confidence: 0.5\n"
+    )
+    with pytest.raises(OfflineLLMError, match="not a linear Flow"):
+        llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(completion))
+
+
 def test_non_string_rationale_raises() -> None:
     completion = _VALID_YAML.replace(
         "rationale: A summary naturally follows a search.", "rationale: [not, a, string]"

--- a/tests/test_compiler_llm.py
+++ b/tests/test_compiler_llm.py
@@ -1,0 +1,216 @@
+"""Tests for the offline LLM-assisted flow compiler (issue #28)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from chainweaver.compiler_llm import LLMProposal, llm_propose_flows, write_proposals
+from chainweaver.exceptions import OfflineLLMError
+from chainweaver.flow import Flow, FlowStep
+from chainweaver.tools import Tool
+
+# ---------------------------------------------------------------------------
+# Schemas + tools (build-time only; the fn is never invoked)
+# ---------------------------------------------------------------------------
+
+
+class QueryIn(BaseModel):
+    query: str
+
+
+class ResultsOut(BaseModel):
+    results: str
+
+
+class SummaryOut(BaseModel):
+    summary: str
+
+
+def _noop(inp: Any) -> dict[str, Any]:
+    return {}
+
+
+SEARCH = Tool(
+    name="search",
+    description="Search the web.",
+    input_schema=QueryIn,
+    output_schema=ResultsOut,
+    fn=_noop,
+)
+SUMMARIZE = Tool(
+    name="summarize",
+    description="Summarize text.",
+    input_schema=ResultsOut,
+    output_schema=SummaryOut,
+    fn=_noop,
+)
+
+
+class _FakeLLM:
+    """Records the last prompt and returns a canned completion."""
+
+    def __init__(self, completion: str) -> None:
+        self.completion = completion
+        self.prompt: str | None = None
+
+    def __call__(self, prompt: str) -> str:
+        self.prompt = prompt
+        return self.completion
+
+
+def _boom(prompt: str) -> str:  # pragma: no cover - must never be called
+    raise AssertionError("llm_fn should not be called")
+
+
+_VALID_YAML = """
+proposals:
+  - flow:
+      name: search_summarize
+      version: "0.0.0"
+      description: Search then summarize.
+      steps:
+        - tool_name: search
+          input_mapping: {query: query}
+        - tool_name: summarize
+          input_mapping: {results: results}
+    rationale: A summary naturally follows a search.
+    confidence: 0.9
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_valid_completion_yields_proposal() -> None:
+    proposals = llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(_VALID_YAML))
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert isinstance(proposal, LLMProposal)
+    assert proposal.proposed_flow.name == "search_summarize"
+    assert [step.tool_name for step in proposal.proposed_flow.steps] == ["search", "summarize"]
+    assert proposal.rationale == "A summary naturally follows a search."
+    assert proposal.confidence == 0.9
+    assert proposal.source == "llm-compiler"
+
+
+def test_confidence_is_clamped() -> None:
+    completion = _VALID_YAML.replace("confidence: 0.9", "confidence: 1.5")
+    proposals = llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(completion))
+    assert proposals[0].confidence == 1.0
+
+
+def test_code_fenced_completion_is_parsed() -> None:
+    fenced = f"```yaml\n{_VALID_YAML.strip()}\n```"
+    proposals = llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(fenced))
+    assert proposals[0].proposed_flow.name == "search_summarize"
+
+
+def test_invalid_yaml_raises_offline_llm_error() -> None:
+    with pytest.raises(OfflineLLMError, match="not valid YAML"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM("{ this is: not: valid: yaml"))
+
+
+def test_empty_completion_raises() -> None:
+    with pytest.raises(OfflineLLMError, match="empty completion"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM("   "))
+
+
+def test_no_tools_returns_empty_without_calling_llm() -> None:
+    assert llm_propose_flows([], llm_fn=_boom) == []
+
+
+def test_unknown_tool_reference_raises() -> None:
+    completion = _VALID_YAML.replace("tool_name: summarize", "tool_name: nonexistent")
+    with pytest.raises(OfflineLLMError, match="unknown tools"):
+        llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(completion))
+
+
+def test_missing_confidence_raises() -> None:
+    completion = _VALID_YAML.replace("    confidence: 0.9", "")
+    with pytest.raises(OfflineLLMError, match="confidence"):
+        llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(completion))
+
+
+def test_max_proposals_truncates() -> None:
+    two = _VALID_YAML + _VALID_YAML.replace("proposals:\n", "").replace(
+        "search_summarize", "search_summarize_two"
+    )
+    proposals = llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(two), max_proposals=1)
+    assert len(proposals) == 1
+
+
+def test_invalid_max_proposals_raises() -> None:
+    with pytest.raises(ValueError, match="max_proposals"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM(_VALID_YAML), max_proposals=0)
+
+
+def test_static_candidates_are_rendered_into_prompt() -> None:
+    hint = Flow(
+        name="hint_chain",
+        description="A known schema-valid chain.",
+        steps=[FlowStep(tool_name="search"), FlowStep(tool_name="summarize")],
+    )
+    fake = _FakeLLM(_VALID_YAML)
+    llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=fake, static_candidates=[hint])
+    assert fake.prompt is not None
+    assert "hint_chain" in fake.prompt
+    assert "search -> summarize" in fake.prompt
+
+
+def test_write_proposals_emits_flow_files_and_summary(tmp_path: Path) -> None:
+    pytest.importorskip("yaml")
+    proposals = llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(_VALID_YAML))
+
+    written = write_proposals(proposals, tmp_path)
+
+    flow_file = tmp_path / "search_summarize.flow.yaml"
+    summary = tmp_path / "PROPOSALS.md"
+    assert flow_file in written
+    assert summary in written
+    assert "type: Flow" in flow_file.read_text(encoding="utf-8")
+    summary_text = summary.read_text(encoding="utf-8")
+    assert "search_summarize" in summary_text
+    assert "confidence 0.90" in summary_text
+
+
+def test_non_list_payload_raises() -> None:
+    with pytest.raises(OfflineLLMError, match="Expected a YAML list"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM("just a string"))
+
+
+def test_proposal_item_not_a_mapping_raises() -> None:
+    with pytest.raises(OfflineLLMError, match="must be a mapping"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM("proposals: [42]"))
+
+
+def test_proposal_missing_flow_raises() -> None:
+    completion = "proposals:\n  - rationale: x\n    confidence: 0.5\n"
+    with pytest.raises(OfflineLLMError, match="missing a 'flow' mapping"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM(completion))
+
+
+def test_invalid_flow_payload_raises() -> None:
+    # 'steps' must be a list; a string fails Flow validation.
+    completion = (
+        "proposals:\n"
+        "  - flow: {name: bad, description: d, steps: nope}\n"
+        "    rationale: x\n"
+        "    confidence: 0.5\n"
+    )
+    with pytest.raises(OfflineLLMError, match="Proposed flow is invalid"):
+        llm_propose_flows([SEARCH], llm_fn=_FakeLLM(completion))
+
+
+def test_non_string_rationale_raises() -> None:
+    completion = _VALID_YAML.replace(
+        "rationale: A summary naturally follows a search.", "rationale: [not, a, string]"
+    )
+    with pytest.raises(OfflineLLMError, match="rationale"):
+        llm_propose_flows([SEARCH, SUMMARIZE], llm_fn=_FakeLLM(completion))

--- a/tests/test_compiler_llm.py
+++ b/tests/test_compiler_llm.py
@@ -180,6 +180,26 @@ def test_write_proposals_emits_flow_files_and_summary(tmp_path: Path) -> None:
     assert "confidence 0.90" in summary_text
 
 
+@pytest.mark.parametrize("unsafe_name", ["../evil", "sub/dir", "..", "with space", ""])
+def test_write_proposals_rejects_unsafe_flow_names(tmp_path: Path, unsafe_name: str) -> None:
+    pytest.importorskip("yaml")
+    proposal = LLMProposal(
+        proposed_flow=Flow(
+            name=unsafe_name,
+            description="Adversarial name.",
+            steps=[FlowStep(tool_name="search")],
+        ),
+        rationale="n/a",
+        confidence=0.5,
+    )
+
+    with pytest.raises(OfflineLLMError, match=r"not safe for a filename|resolves outside"):
+        write_proposals([proposal], tmp_path)
+
+    # Nothing escaped the target directory.
+    assert not (tmp_path.parent / "evil.flow.yaml").exists()
+
+
 def test_non_list_payload_raises() -> None:
     with pytest.raises(OfflineLLMError, match="Expected a YAML list"):
         llm_propose_flows([SEARCH], llm_fn=_FakeLLM("just a string"))

--- a/tests/test_offline_llm_examples.py
+++ b/tests/test_offline_llm_examples.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the offline LLM proposer example scripts (#28, #100).
+
+Each script is a standalone, deterministic demo (a canned ``llm_fn``, no
+network). These tests keep them runnable from a fresh checkout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = (
+    _ROOT / "examples" / "llm_flow_proposals.py",
+    _ROOT / "examples" / "description_optimizer.py",
+)
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda path: path.name)
+def test_example_script_runs_cleanly(script: Path) -> None:
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+    assert completed.returncode == 0, output
+    assert "Traceback (most recent call last):" not in completed.stderr, output

--- a/tests/test_offline_llm_guardrail.py
+++ b/tests/test_offline_llm_guardrail.py
@@ -1,0 +1,60 @@
+"""Guardrail: the executor must never import the offline LLM proposers.
+
+AGENTS.md core invariant #1 — *no LLM calls in ``executor.py``* — is the
+reason :mod:`chainweaver.compiler_llm` (issue #28) and
+:mod:`chainweaver.optimizer` (issue #100) exist as build-time-only modules.
+This test statically parses ``executor.py``'s import graph (including
+function-local and deferred imports) and fails if it reaches any of the
+offline-LLM modules, directly or via ``from chainweaver import ...``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import chainweaver
+
+_EXECUTOR = Path(chainweaver.__file__).resolve().parent / "executor.py"
+
+# Modules the executor must never reach.
+_BANNED_MODULES = {
+    "chainweaver.compiler_llm",
+    "chainweaver.optimizer",
+    "chainweaver._offline_llm",
+}
+_BANNED_LEAVES = {name.rsplit(".", 1)[1] for name in _BANNED_MODULES}
+
+
+def _imports(path: Path) -> set[str]:
+    """Return every module path ``path`` imports, anywhere in the file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            found.add(module)
+            # Catch `from chainweaver import optimizer` style imports too.
+            if module == "chainweaver":
+                for alias in node.names:
+                    found.add(f"chainweaver.{alias.name}")
+    return found
+
+
+def test_executor_module_exists() -> None:
+    assert _EXECUTOR.is_file(), f"missing executor module: {_EXECUTOR}"
+
+
+def test_executor_does_not_import_offline_llm_modules() -> None:
+    imported = _imports(_EXECUTOR)
+    leaked = imported & _BANNED_MODULES
+    assert not leaked, (
+        "chainweaver/executor.py must not import the offline LLM proposers "
+        f"(AGENTS.md invariant #1); found: {sorted(leaked)}."
+    )
+    # Defence in depth: also reject bare leaf names just in case.
+    leaked_leaves = {name for name in imported if name in _BANNED_LEAVES}
+    assert not leaked_leaves, f"executor imported banned module leaves: {sorted(leaked_leaves)}."

--- a/tests/test_offline_llm_guardrail.py
+++ b/tests/test_offline_llm_guardrail.py
@@ -3,9 +3,11 @@
 AGENTS.md core invariant #1 — *no LLM calls in ``executor.py``* — is the
 reason :mod:`chainweaver.compiler_llm` (issue #28) and
 :mod:`chainweaver.optimizer` (issue #100) exist as build-time-only modules.
-This test statically parses ``executor.py``'s import graph (including
-function-local and deferred imports) and fails if it reaches any of the
-offline-LLM modules, directly or via ``from chainweaver import ...``.
+This test statically walks ``executor.py``'s AST and collects every import
+statement it contains (including function-local and deferred imports),
+failing if any names an offline-LLM module, directly or via
+``from chainweaver import ...``.  It inspects ``executor.py`` itself, not the
+transitive import graph.
 """
 
 from __future__ import annotations

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -156,6 +156,18 @@ def test_non_list_payload_raises() -> None:
         optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM("just a string"))
 
 
+def test_non_string_list_similarity_group_raises() -> None:
+    completion = """
+    proposals:
+      - tool_name: search
+        proposed_description: Web search.
+        rationale: x
+        similarity_group: "not-a-list"
+    """
+    with pytest.raises(OfflineLLMError, match="non-string-list 'similarity_group'"):
+        optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM(completion))
+
+
 def test_incremental_mode_optimizes_new_and_flags_existing() -> None:
     new_tool = _tool("semantic_search", "Find things using embeddings.")
     completion = """

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,184 @@
+"""Tests for the offline tool-description optimizer (issue #100)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from chainweaver.exceptions import OfflineLLMError
+from chainweaver.optimizer import (
+    OptimizationStrategy,
+    ToolDescriptionProposal,
+    optimize_new_tool_description,
+    optimize_tool_descriptions,
+)
+from chainweaver.tools import Tool
+
+# ---------------------------------------------------------------------------
+# Schemas + tools
+# ---------------------------------------------------------------------------
+
+
+class QueryIn(BaseModel):
+    query: str
+
+
+class ResultsOut(BaseModel):
+    results: str
+
+
+def _noop(inp: Any) -> dict[str, Any]:
+    return {}
+
+
+def _tool(name: str, description: str) -> Tool:
+    return Tool(
+        name=name,
+        description=description,
+        input_schema=QueryIn,
+        output_schema=ResultsOut,
+        fn=_noop,
+    )
+
+
+# Three semantically-overlapping tools — the ecosystem the optimizer
+# disambiguates.
+SEARCH = _tool("search", "Search the web and return the top matching documents for a query.")
+QUERY = _tool("query", "Query a data source and return matching records for the given query.")
+LOOKUP = _tool("lookup", "Look up a single record by its key in the store.")
+
+
+class _FakeLLM:
+    def __init__(self, completion: str) -> None:
+        self.completion = completion
+        self.prompt: str | None = None
+
+    def __call__(self, prompt: str) -> str:
+        self.prompt = prompt
+        return self.completion
+
+
+def _boom(prompt: str) -> str:  # pragma: no cover - must never be called
+    raise AssertionError("llm_fn should not be called")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_valid_completion_yields_proposals() -> None:
+    completion = """
+    proposals:
+      - tool_name: search
+        proposed_description: Full-text web search; returns ranked documents.
+        rationale: Distinguishes from structured query/lookup.
+        similarity_group: [query, lookup]
+    """
+    proposals = optimize_tool_descriptions([SEARCH, QUERY, LOOKUP], llm_fn=_FakeLLM(completion))
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert isinstance(proposal, ToolDescriptionProposal)
+    assert proposal.tool_name == "search"
+    assert proposal.original_description == SEARCH.description
+    assert proposal.proposed_description == "Full-text web search; returns ranked documents."
+    assert proposal.similarity_group == ["query", "lookup"]
+    assert proposal.source == "description-optimizer"
+    # The rewrite is shorter than the original, so the token delta is negative.
+    assert proposal.token_delta < 0
+
+
+def test_handles_multiple_similar_tools() -> None:
+    completion = """
+    proposals:
+      - tool_name: search
+        proposed_description: Full-text web search.
+        rationale: x
+        similarity_group: [query]
+      - tool_name: query
+        proposed_description: Structured record query.
+        rationale: y
+        similarity_group: [search]
+    """
+    proposals = optimize_tool_descriptions([SEARCH, QUERY, LOOKUP], llm_fn=_FakeLLM(completion))
+    assert {p.tool_name for p in proposals} == {"search", "query"}
+
+
+def test_unique_tools_need_no_changes() -> None:
+    # The LLM judges everything already optimal and returns an empty list.
+    proposals = optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM("proposals: []"))
+    assert proposals == []
+
+
+def test_empty_tools_returns_empty_without_calling_llm() -> None:
+    assert optimize_tool_descriptions([], llm_fn=_boom) == []
+
+
+def test_missing_similarity_group_defaults_to_empty() -> None:
+    completion = """
+    proposals:
+      - tool_name: search
+        proposed_description: Web search.
+        rationale: shorter
+    """
+    proposals = optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM(completion))
+    assert proposals[0].similarity_group == []
+
+
+def test_strategy_guidance_is_in_prompt() -> None:
+    fake = _FakeLLM("proposals: []")
+    optimize_tool_descriptions([SEARCH], llm_fn=fake, strategy=OptimizationStrategy.CONCISE)
+    assert fake.prompt is not None
+    assert "fewest tokens" in fake.prompt
+
+
+def test_invalid_yaml_raises() -> None:
+    with pytest.raises(OfflineLLMError, match="not valid YAML"):
+        optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM("key: : :"))
+
+
+def test_unknown_tool_raises() -> None:
+    completion = """
+    proposals:
+      - tool_name: ghost
+        proposed_description: x
+        rationale: y
+    """
+    with pytest.raises(OfflineLLMError, match="unknown tool"):
+        optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM(completion))
+
+
+def test_non_list_payload_raises() -> None:
+    with pytest.raises(OfflineLLMError, match="Expected a YAML list"):
+        optimize_tool_descriptions([SEARCH], llm_fn=_FakeLLM("just a string"))
+
+
+def test_incremental_mode_optimizes_new_and_flags_existing() -> None:
+    new_tool = _tool("semantic_search", "Find things using embeddings.")
+    completion = """
+    proposals:
+      - tool_name: semantic_search
+        proposed_description: Embedding-based semantic search over documents.
+        rationale: Disambiguate from keyword search.
+        similarity_group: [search]
+      - tool_name: search
+        proposed_description: Keyword (full-text) web search.
+        rationale: Now contrasts with semantic_search.
+        similarity_group: [semantic_search]
+    """
+    proposals = optimize_new_tool_description(
+        new_tool, [SEARCH, QUERY], llm_fn=_FakeLLM(completion)
+    )
+    assert {p.tool_name for p in proposals} == {"semantic_search", "search"}
+
+
+def test_incremental_prompt_announces_new_tool() -> None:
+    new_tool = _tool("semantic_search", "Find things using embeddings.")
+    fake = _FakeLLM("proposals: []")
+    optimize_new_tool_description(new_tool, [SEARCH], llm_fn=fake)
+    assert fake.prompt is not None
+    assert "semantic_search" in fake.prompt
+    assert "being added" in fake.prompt


### PR DESCRIPTION
## Summary

Adds the two sibling **offline, build-time** LLM-assisted proposers from the backlog. Both reach an LLM only through a provider-agnostic `llm_fn(prompt) -> completion` seam — ChainWeaver depends on no LLM SDK, and neither module is reachable from the executor (core invariant #1). All output is reviewable data: nothing is auto-registered or auto-applied.

Closes #28. Closes #100.

## Changes

- **`chainweaver/compiler_llm.py` (#28)** — `LLMProposal`, `llm_propose_flows(tools, *, llm_fn, max_proposals=5, static_candidates=None)`, and `write_proposals()`. Proposes deterministic `Flow` definitions from tool metadata (the semantic complement to `ChainAnalyzer`'s schema matching) and can write PR-ready `<name>.flow.yaml` files + a `PROPOSALS.md`.
- **`chainweaver/optimizer.py` (#100)** — `OptimizationStrategy` (discriminative/concise/structured), `ToolDescriptionProposal`, `optimize_tool_descriptions()`, and incremental `optimize_new_tool_description()`. Rewrites descriptions for ecosystem-wide discriminability with an approximate `token_delta` (`word_count * 1.3`).
- **`chainweaver/_offline_llm.py`** — private shared internals: the `LLMFn` type, `parse_llm_yaml()` (tolerates Markdown code fences), and `render_tool_catalogue()`.
- **`chainweaver/exceptions.py`** — new typed `OfflineLLMError(ChainWeaverError)` so malformed completions surface cleanly instead of leaking a raw `yaml.YAMLError`/`KeyError`.
- **`chainweaver/__init__.py`** — exports all new public symbols in `__all__`.
- **Tests** — `tests/test_compiler_llm.py`, `tests/test_optimizer.py`, `tests/test_offline_llm_guardrail.py` (AST scan proving `executor.py` imports neither module), `tests/test_offline_llm_examples.py`.
- **Examples + docs** — `examples/llm_flow_proposals.py`, `examples/description_optimizer.py`, two cookbook pages wired into `docs/cookbook/index.md` + `mkdocs.yml`.
- **Housekeeping** — `tests/fixtures/public_api.json` regenerated, `AGENTS.md` repo map + `CHANGELOG.md` updated.

## Why

Implements the two backlog issues exactly as specified, preserving the project's #1 invariant (no LLM in `executor.py`) via a static guard test. Design notes / deltas from the issue text (owner-approved):

- **YAML output contract** as written in #28, parsed via the existing `chainweaver[yaml]` extra. `OfflineLLMError` is raised with an install hint if `pyyaml` is absent, so the **base install is unaffected**.
- **`static_candidates: Iterable[Flow]`** instead of #28's hypothetical `CandidateChain` (which doesn't exist in this codebase) — accepts `ChainAnalyzer.suggest_flows()` output directly as prompt hints.

## How verified

- `ruff check chainweaver/ tests/ examples/` — **All checks passed!**
- `ruff format --check chainweaver/ tests/ examples/` — **175 files already formatted**
- `python -m mypy` on all new/changed files — **Success: no issues found**. (The only mypy errors in the tree are 25 pre-existing `import-not-found` errors in untouched optional-integration test files — otel/langchain/llamaindex/mcp — whose deps aren't installable in this sandbox due to a Debian PyJWT conflict; CI installs the full `dev` extra and covers them.)
- `pytest` (full suite minus the 5 dep-gated integration files) — **1215 passed, 2 skipped**, including the public-API-snapshot and metadata-consistency guards.
- New modules pass `pytest tests/test_compiler_llm.py tests/test_optimizer.py tests/test_offline_llm_guardrail.py tests/test_offline_llm_examples.py` — **32 passed**, per-module coverage `_offline_llm` 96% / `compiler_llm` 96% / `optimizer` 94% (≥80% gate).
- Both example scripts run cleanly end-to-end.

## Testing checklist
- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/`) — clean on all changed files; remaining errors are pre-existing/environmental (see above)
- [x] All existing tests pass (`python -m pytest tests/ -v`) — 1215 passed locally minus dep-gated files; CI runs the full matrix
- [x] New tests added for new functionality

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented (`__all__`, snapshot, CHANGELOG, AGENTS, cookbook)
- [x] No secrets or credentials included

## Tradeoffs / risks
- The offline proposers require the `chainweaver[yaml]` extra to parse completions; surfaced via a clear `OfflineLLMError` and documented. Base install and standalone executor use are unaffected.
- LLM completion parsing is deliberately strict (typed errors on malformed/unknown-tool output) rather than silently dropping entries.

https://claude.ai/code/session_01Pb9geaMv2JpZrcGwf6QS2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb9geaMv2JpZrcGwf6QS2L)_