### PR TITLE
feat: runtime flow learning — ChainObserver, `chainweaver record`, ChainWeaverService (#78, #226, #101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,10 +87,12 @@ chainweaver/
 ├── log_utils.py       Structured per-step logging utilities
 ├── cost.py            CostProfile + CostReport for cost-avoided estimation; PriceSnap + PROVIDER_PRICES maintained price table + lookup_price + CostProfile.from_provider (#156)
 ├── observation.py     TraceRecorder + ObservedTrace for ad-hoc capture
+├── observer.py        ChainObserver: record runtime tool calls, mine repeated sequences, suggest FlowSuggestion proposals (#78); banned from executor.py
+├── service.py         ChainWeaverService: continuous analyze→observe→propose→govern loop tying analyzer + observer + a proposal gate (#101); banned from executor.py
 ├── viz.py             ASCII + Mermaid renderers for Flow/ExecutionResult
 ├── serialization.py   YAML + JSON encode/decode for Flow and DAGFlow
 ├── schemas.py         JSON Schema export for .flow.json / .flow.yaml files (#135, #139)
-├── cli.py             typer-based CLI: inspect, validate, check, viz, run, profile, diff, attest, suggest, doctor, dump-schema
+├── cli.py             typer-based CLI: inspect, validate, check, viz, run, profile, diff, attest, suggest, record, doctor, dump-schema, service
 └── py.typed           PEP 561 marker
 tests/
 ├── conftest.py        Pytest fixtures (import schemas/functions from helpers.py)

--- a/README.md
+++ b/README.md
@@ -933,6 +933,46 @@ Runnable example: [`examples/plugin_discovery.py`](examples/plugin_discovery.py)
 
 ---
 
+## Runtime learning
+
+You don't have to hand-author every flow. ChainWeaver can watch what your
+agent actually does and **propose** compiled flows for the repeated,
+deterministic paths — all offline, with no LLM in the loop.
+
+```python
+from chainweaver import ChainObserver, FlowRegistry
+
+observer = ChainObserver()
+
+# Record tool calls as the agent makes them.
+observer.record("fetch", {"url": "..."}, {"body": "..."})
+observer.record("validate", {"body": "..."}, {"valid": True})
+observer.record("transform", {"body": "..."}, {"records": [1, 2, 3]})
+observer.end_trace()
+# ... many traces later ...
+
+registry = FlowRegistry()
+for suggestion in observer.suggest_flows(min_occurrences=3):
+    # Suggestions are proposals — review, then promote explicitly.
+    print(suggestion.flow.name, suggestion.confidence,
+          suggestion.estimated_llm_calls_avoided)
+    registry.register_flow(suggestion.flow)
+```
+
+- **`ChainObserver`** (#78) mines repeated tool sequences from runtime traces
+  and emits ranked `FlowSuggestion`s — never auto-registered.
+- **`chainweaver record`** (#226) does the same from a recorded JSONL trace on
+  the command line, writing candidate `.flow.yaml` files ranked by projected
+  LLM calls avoided.
+- **`ChainWeaverService`** (#101) ties the observer, the static
+  [`ChainAnalyzer`](#core-abstractions), and an optional offline LLM proposer
+  into a continuous *analyze → propose → govern → promote* loop with an
+  in-process governance gate and adoption metrics.
+
+Runnable example: [`examples/chain_observer.py`](examples/chain_observer.py).
+
+---
+
 ## Roadmap
 
 Milestones below mirror the [GitHub milestones](https://github.com/dgenio/ChainWeaver/milestones); see
@@ -994,6 +1034,12 @@ chainweaver attest flows/etl.flow.yaml --tools my_pkg.tools --runs 50 --repeats 
 
 # Advisory optimization suggestions for a saved flow.
 chainweaver suggest flows/etl.flow.yaml --tools my_pkg.tools --trace trace_a.json
+
+# Mine candidate flows from a recorded JSONL tool trace (offline, no LLM).
+chainweaver record examples/agent_tool_trace.jsonl --output-dir candidates/
+
+# Run one continuous-analysis service pass and report flow proposals.
+chainweaver service --tools my_pkg.tools --trace trace.jsonl
 
 # Check saved flows for tool schema drift against the live registry.
 chainweaver doctor flows/ --check-drift --tools my_pkg.tools

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -156,6 +156,7 @@ from chainweaver.middleware import (
     StepStartContext,
 )
 from chainweaver.observation import ObservedStep, ObservedTrace, TraceRecorder
+from chainweaver.observer import ChainObserver, FlowSuggestion
 from chainweaver.optimizer import (
     OptimizationStrategy,
     ToolDescriptionProposal,
@@ -204,6 +205,7 @@ __all__ = [
     "BaseMiddleware",
     "CancellationToken",
     "ChainAnalyzer",
+    "ChainObserver",
     "ChainWeaverError",
     "CheckpointDriftError",
     "CheckpointNotFoundError",
@@ -255,6 +257,7 @@ __all__ = [
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
+    "FlowSuggestion",
     "FuzzCase",
     "FuzzConfigError",
     "FuzzFailure",

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -174,6 +174,14 @@ from chainweaver.serialization import (
     flow_to_json,
     flow_to_yaml,
 )
+from chainweaver.service import (
+    ChainWeaverService,
+    ProposalStatus,
+    ServiceConfig,
+    ServiceEvent,
+    ServiceMetrics,
+    ServiceProposal,
+)
 from chainweaver.storage import FileStore, InMemoryStore, RegistryStore
 from chainweaver.testing.replay import FixtureStaleError
 from chainweaver.tools import Tool
@@ -207,6 +215,7 @@ __all__ = [
     "ChainAnalyzer",
     "ChainObserver",
     "ChainWeaverError",
+    "ChainWeaverService",
     "CheckpointDriftError",
     "CheckpointNotFoundError",
     "Checkpointer",
@@ -279,12 +288,17 @@ __all__ = [
     "PluginDiscoveryError",
     "PredicateSyntaxError",
     "PriceSnap",
+    "ProposalStatus",
     "RedactionPolicy",
     "RegistryStore",
     "ReplayMode",
     "ReplayResult",
     "RetryPolicy",
     "SchemaValidationError",
+    "ServiceConfig",
+    "ServiceEvent",
+    "ServiceMetrics",
+    "ServiceProposal",
     "SideEffectLevel",
     "StabilityLevel",
     "StepCache",

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -101,6 +101,7 @@ from chainweaver.flow import DAGFlow, Flow
 from chainweaver.observer import ChainObserver
 from chainweaver.registry import FlowRegistry
 from chainweaver.serialization import flow_from_json, flow_from_yaml, flow_to_yaml
+from chainweaver.service import ChainWeaverService, ServiceConfig
 from chainweaver.tools import Tool
 from chainweaver.viz import _render_step_bar_chart, flow_to_ascii, flow_to_dot
 
@@ -2444,6 +2445,145 @@ def _run_result_to_table(result: Any) -> str:
         else "(none — flow failed)",
     ]
     return "\n".join([*header, *body, *footer])
+
+
+# ---------------------------------------------------------------------------
+# service command (issue #101)
+# ---------------------------------------------------------------------------
+
+
+_SERVICE_TOOLS_OPTION = typer.Option(
+    [],
+    "--tools",
+    "-t",
+    help=(
+        "Python module path exposing Tool instances at top level. "
+        "Enables the static-analysis pass. Repeatable."
+    ),
+)
+_SERVICE_TRACE_OPTION = typer.Option(
+    None,
+    "--trace",
+    help="Path to a JSONL tool-trace file to feed the runtime-observation pass.",
+)
+_SERVICE_MIN_OCC_OPTION = typer.Option(
+    3,
+    "--min-occurrences",
+    help="Minimum runtime occurrences before an observed pattern is proposed.",
+)
+_SERVICE_MIN_LEN_OPTION = typer.Option(
+    2,
+    "--min-length",
+    help="Minimum pattern / chain length (number of tools).",
+)
+_SERVICE_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("service")
+def service_command(
+    tools: list[str] = _SERVICE_TOOLS_OPTION,
+    trace: Path | None = _SERVICE_TRACE_OPTION,
+    min_occurrences: int = _SERVICE_MIN_OCC_OPTION,
+    min_length: int = _SERVICE_MIN_LEN_OPTION,
+    output_format: OutputFormat = _SERVICE_FORMAT_OPTION,
+) -> None:
+    """Run one ChainWeaverService analysis pass and report proposals (issue #101).
+
+    Builds a :class:`~chainweaver.service.ChainWeaverService` over the CLI's
+    default registry, runs the static (``--tools``) and runtime (``--trace``)
+    proposal passes once, and prints the pending proposals plus service
+    metrics.  Proposals are reported, never auto-registered — promotion stays
+    a governed, in-process action.
+
+    A long-running daemon with cross-invocation ``approve`` / ``reject``
+    requires proposal persistence (#16) and is intentionally out of scope
+    here.
+
+    Exit codes: 0 = ran successfully, 1 = malformed trace / input,
+    2 = trace file not found.
+    """
+    registry = get_default_registry() or FlowRegistry()
+    observer: ChainObserver | None = None
+    if trace is not None:
+        _require_existing_file(trace)
+        try:
+            observer = _load_tool_trace(trace)
+        except ValueError as exc:
+            typer.echo(f"chainweaver: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    config = ServiceConfig(
+        analyze_on_tool_change=False,
+        min_trace_occurrences=min_occurrences,
+        min_pattern_length=min_length,
+    )
+    service = ChainWeaverService(registry=registry, observer=observer, config=config)
+
+    seen_tool_names: set[str] = set()
+    for module_name in tools:
+        for tool_obj in _import_tools_from(module_name):
+            if tool_obj.name in seen_tool_names:
+                continue
+            service.register_tool(tool_obj)
+            seen_tool_names.add(tool_obj.name)
+
+    try:
+        proposals = service.trigger_analysis()
+    except ValueError as exc:
+        typer.echo(f"chainweaver: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    metrics = service.metrics
+    traces_analyzed = len(service.observer)
+    if output_format is OutputFormat.JSON:
+        _emit_json(
+            {
+                "metrics": metrics.model_dump(),
+                "traces_analyzed": traces_analyzed,
+                "proposal_count": len(proposals),
+                "proposals": [
+                    {
+                        "id": p.id,
+                        "flow_name": p.flow.name,
+                        "source": p.source,
+                        "occurrences": p.occurrences,
+                        "confidence": p.confidence,
+                        "estimated_llm_calls_avoided": p.estimated_llm_calls_avoided,
+                        "status": p.status.value,
+                    }
+                    for p in proposals
+                ],
+            }
+        )
+        return
+
+    lines = [
+        "ChainWeaver service — analysis pass complete.",
+        "─" * 60,
+        f"tools monitored:   {metrics.tools_monitored}",
+        f"traces analyzed:   {traces_analyzed}",
+        f"patterns detected: {metrics.patterns_detected}",
+        f"flows proposed:    {metrics.flows_proposed}",
+        "─" * 60,
+    ]
+    if not proposals:
+        lines.append("No new proposals.")
+    else:
+        lines.append(f"Pending proposals ({len(proposals)}):")
+        for proposal in proposals:
+            lines.append(f"  • {proposal.flow.name}  [{proposal.source}]")
+            lines.append(
+                f"      confidence: {proposal.confidence}  "
+                f"occurrences: {proposal.occurrences}  "
+                f"est. LLM calls avoided: {proposal.estimated_llm_calls_avoided}"
+            )
+    typer.echo("\n".join(lines))
 
 
 # Module-level invocation guard (so ``python -m chainweaver.cli`` works).

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -1646,13 +1646,17 @@ def _load_tool_trace(path: Path) -> ChainObserver:
         tool = obj.get("tool", obj.get("tool_name"))
         if not isinstance(tool, str) or not tool:
             raise ValueError(f"line {lineno}: missing or empty 'tool' field.")
-        inputs = obj.get("inputs") or {}
+        inputs = obj.get("inputs", {})
         outputs = obj.get("outputs")
         if not isinstance(inputs, dict):
             raise ValueError(f"line {lineno}: 'inputs' must be a JSON object.")
         if outputs is not None and not isinstance(outputs, dict):
             raise ValueError(f"line {lineno}: 'outputs' must be a JSON object or null.")
-        trace_id = str(obj.get("trace_id", "__default__"))
+        trace_id_value = obj.get("trace_id")
+        if trace_id_value is None or trace_id_value == "":
+            trace_id = "__default__"
+        else:
+            trace_id = str(trace_id_value)
         grouped.setdefault(trace_id, []).append(
             (tool, dict(inputs), dict(outputs) if outputs is not None else None)
         )

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -2478,7 +2478,7 @@ _SERVICE_MIN_OCC_OPTION = typer.Option(
 _SERVICE_MIN_LEN_OPTION = typer.Option(
     2,
     "--min-length",
-    help="Minimum pattern / chain length (number of tools).",
+    help="Minimum pattern / flow length (number of tools).",
 )
 _SERVICE_FORMAT_OPTION = typer.Option(
     OutputFormat.TABLE,

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -30,6 +30,9 @@ Available commands
 - ``chainweaver suggest <flow>`` — emit advisory optimization
   suggestions for a flow file, optionally informed by trace files
   (issue #155).
+- ``chainweaver record <trace.jsonl>`` — mine candidate flows from a
+  recorded JSONL tool trace and (optionally) write them as ``.flow.yaml``
+  files, ranked by projected LLM calls avoided (issue #226).
 - ``chainweaver doctor <path>`` — diagnostic command; ``--check-drift``
   reports missing tools and tool-schema fingerprint drift for one or
   more saved flow files (issue #175).
@@ -95,8 +98,9 @@ from chainweaver.exceptions import (
 )
 from chainweaver.executor import ExecutionResult, FlowExecutor
 from chainweaver.flow import DAGFlow, Flow
+from chainweaver.observer import ChainObserver
 from chainweaver.registry import FlowRegistry
-from chainweaver.serialization import flow_from_json, flow_from_yaml
+from chainweaver.serialization import flow_from_json, flow_from_yaml, flow_to_yaml
 from chainweaver.tools import Tool
 from chainweaver.viz import _render_step_bar_chart, flow_to_ascii, flow_to_dot
 
@@ -1603,6 +1607,203 @@ def suggest_command(
         loc = f"step {s.step_index} ({s.tool_name})" if s.step_index is not None else "(flow)"
         lines.append(f"  [{s.code} {s.title}] {loc}")
         lines.append(f"    {s.message}")
+    typer.echo("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# record command (issue #226)
+# ---------------------------------------------------------------------------
+
+
+def _load_tool_trace(path: Path) -> ChainObserver:
+    """Read a JSONL tool trace into a :class:`ChainObserver`.
+
+    Each non-blank line is a JSON object describing one tool call::
+
+        {"trace_id": "t1", "tool": "fetch", "inputs": {...}, "outputs": {...}}
+
+    Calls are grouped into traces by ``trace_id`` (file order preserved);
+    lines without a ``trace_id`` join a single default trace.  ``tool`` (or
+    its alias ``tool_name``) is required; ``inputs`` defaults to ``{}`` and
+    ``outputs`` to ``null``.
+
+    Raises:
+        ValueError: On malformed JSON, a non-object line, a record missing
+            ``tool``, or a non-object ``inputs`` / ``outputs``.
+    """
+    grouped: dict[str, list[tuple[str, dict[str, Any], dict[str, Any] | None]]] = {}
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {lineno}: invalid JSON ({exc.msg}).") from exc
+        if not isinstance(obj, dict):
+            raise ValueError(f"line {lineno}: expected a JSON object.")
+        tool = obj.get("tool", obj.get("tool_name"))
+        if not isinstance(tool, str) or not tool:
+            raise ValueError(f"line {lineno}: missing or empty 'tool' field.")
+        inputs = obj.get("inputs") or {}
+        outputs = obj.get("outputs")
+        if not isinstance(inputs, dict):
+            raise ValueError(f"line {lineno}: 'inputs' must be a JSON object.")
+        if outputs is not None and not isinstance(outputs, dict):
+            raise ValueError(f"line {lineno}: 'outputs' must be a JSON object or null.")
+        trace_id = str(obj.get("trace_id", "__default__"))
+        grouped.setdefault(trace_id, []).append(
+            (tool, dict(inputs), dict(outputs) if outputs is not None else None)
+        )
+
+    observer = ChainObserver()
+    for steps in grouped.values():
+        for tool_name, inputs, outputs in steps:
+            observer.record(tool_name, inputs, outputs)
+        observer.end_trace()
+    return observer
+
+
+_RECORD_TRACE_ARG = typer.Argument(
+    ...,
+    help="Path to a JSONL tool-trace file (one tool call per line).",
+)
+_RECORD_OUTPUT_OPTION = typer.Option(
+    None,
+    "--output-dir",
+    "-o",
+    help=(
+        "Directory to write candidate .flow.yaml files into. "
+        "Omit for a dry run that only reports candidates."
+    ),
+)
+_RECORD_MIN_OCC_OPTION = typer.Option(
+    3,
+    "--min-occurrences",
+    help="Minimum contiguous appearances for a pattern to be suggested.",
+)
+_RECORD_MIN_LEN_OPTION = typer.Option(
+    2,
+    "--min-length",
+    help="Minimum pattern length (number of tools).",
+)
+_RECORD_MAX_LEN_OPTION = typer.Option(
+    None,
+    "--max-length",
+    help="Maximum pattern length. Omit for no upper bound.",
+)
+_RECORD_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+
+
+@app.command("record")
+def record_command(
+    trace_file: Path = _RECORD_TRACE_ARG,
+    output_dir: Path | None = _RECORD_OUTPUT_OPTION,
+    min_occurrences: int = _RECORD_MIN_OCC_OPTION,
+    min_length: int = _RECORD_MIN_LEN_OPTION,
+    max_length: int | None = _RECORD_MAX_LEN_OPTION,
+    output_format: OutputFormat = _RECORD_FORMAT_OPTION,
+) -> None:
+    """Mine candidate flows from a recorded JSONL tool trace (issue #226).
+
+    Replays the trace through :class:`~chainweaver.observer.ChainObserver`,
+    detects repeated tool sequences offline (no LLM), and emits candidate
+    ``.flow.yaml`` files ranked by projected LLM calls avoided
+    (``len(tools) * occurrences``).  With ``--output-dir`` the candidates
+    are written to disk; without it the command runs as a dry run.
+
+    Exit codes: 0 = ran successfully (regardless of candidate count),
+    1 = malformed trace or serialization error, 2 = file not found.
+    """
+    _require_existing_file(trace_file)
+    try:
+        observer = _load_tool_trace(trace_file)
+    except ValueError as exc:
+        typer.echo(f"chainweaver: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    try:
+        suggestions = observer.suggest_flows(
+            min_occurrences=min_occurrences,
+            min_length=min_length,
+            max_length=max_length,
+        )
+    except ValueError as exc:
+        typer.echo(f"chainweaver: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    # Rank by projected savings (frequency x per-run calls avoided), then by
+    # raw occurrences, then name for a stable order.
+    ranked = sorted(
+        suggestions,
+        key=lambda s: (-s.estimated_llm_calls_avoided, -s.occurrences, s.flow.name),
+    )
+
+    written: dict[str, str] = {}
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for suggestion in ranked:
+            dest = output_dir / f"{suggestion.flow.name}.flow.yaml"
+            try:
+                dest.write_text(flow_to_yaml(suggestion.flow), encoding="utf-8")
+            except FlowSerializationError as exc:
+                typer.echo(f"chainweaver: {exc.detail}", err=True)
+                raise typer.Exit(code=1) from exc
+            written[suggestion.flow.name] = str(dest)
+
+    if output_format is OutputFormat.JSON:
+        _emit_json(
+            {
+                "trace_file": str(trace_file),
+                "traces_analyzed": len(observer),
+                "candidate_count": len(ranked),
+                "output_dir": str(output_dir) if output_dir is not None else None,
+                "candidates": [
+                    {
+                        "flow_name": s.flow.name,
+                        "tools": list(s.tools),
+                        "occurrences": s.occurrences,
+                        "traces_with_pattern": s.traces_with_pattern,
+                        "confidence": s.confidence,
+                        "estimated_llm_calls_avoided": s.estimated_llm_calls_avoided,
+                        "output_path": written.get(s.flow.name),
+                        "flow": _flow_to_dict(s.flow),
+                    }
+                    for s in ranked
+                ],
+            }
+        )
+        return
+
+    if not ranked:
+        typer.echo(
+            f"No candidate flows from {len(observer)} trace(s) "
+            f"(min_occurrences={min_occurrences}, min_length={min_length})."
+        )
+        return
+    lines = [
+        f"Candidate flows from {len(observer)} trace(s) in '{trace_file}':",
+        "─" * 60,
+    ]
+    for rank, suggestion in enumerate(ranked, start=1):
+        lines.append(f"  {rank}. {suggestion.flow.name}")
+        lines.append(f"     tools:       {' → '.join(suggestion.tools)}")
+        lines.append(
+            f"     occurrences: {suggestion.occurrences}  "
+            f"confidence: {suggestion.confidence}  "
+            f"est. LLM calls avoided: {suggestion.estimated_llm_calls_avoided}"
+        )
+        if suggestion.flow.name in written:
+            lines.append(f"     written:     {written[suggestion.flow.name]}")
+    if output_dir is None:
+        lines.append("")
+        lines.append("(dry run — pass --output-dir to write .flow.yaml files)")
     typer.echo("\n".join(lines))
 
 

--- a/chainweaver/observer.py
+++ b/chainweaver/observer.py
@@ -1,0 +1,354 @@
+"""Runtime chain observer with auto-flow suggestion (issue #78).
+
+While :class:`~chainweaver.observation.TraceRecorder` (issue #11) captures
+raw ad-hoc tool sequences, it does not *learn* from them.  ``ChainObserver``
+closes that loop: it records tool calls grouped into traces, mines repeated
+contiguous sub-sequences across those traces, and proposes ready-to-register
+:class:`~chainweaver.flow.Flow` objects ranked by how often the agent
+actually walked the pattern.
+
+This is the runtime, trace-driven counterpart to
+:meth:`chainweaver.analyzer.ChainAnalyzer.suggest_flows`, which discovers
+chains *statically* from tool schemas.  Where the analyzer answers "what
+*could* be compiled?", the observer answers "what *did* the agent keep
+doing?".
+
+Invariants
+----------
+
+* No LLM, no network, no randomness — pattern detection is pure-Python
+  n-gram counting over recorded tool-name sequences.
+* Suggestions are **proposals**, never side effects: ``ChainObserver`` does
+  not register, promote, or execute anything.  Promotion is an explicit
+  ``registry.register_flow(suggestion.flow)`` call by the caller (the
+  governance gate lives with the caller, mirroring the analyzer contract).
+* In-memory storage only — persistence is out of scope for v0.x (see #16).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from chainweaver.flow import Flow, FlowStep
+from chainweaver.observation import ObservedTrace, TraceRecorder
+
+_DEFAULT_SOURCE = "observer"
+
+
+class FlowSuggestion(BaseModel):
+    """A proposed flow mined from repeated runtime tool sequences.
+
+    Attributes:
+        flow: A ready-to-review :class:`~chainweaver.flow.Flow` whose steps
+            follow the detected tool sequence with auto-wired
+            ``input_mapping``.  Version ``"0.0.0"`` signals it is
+            auto-generated and should be reviewed before promotion.
+        tools: The detected tool-name sequence, in call order.
+        occurrences: Total number of contiguous appearances of the pattern
+            across all recorded traces (overlapping positions are counted).
+        traces_with_pattern: Number of distinct traces in which the pattern
+            appears at least once.
+        confidence: ``traces_with_pattern / (traces containing the first
+            tool)`` — a 0-1 proxy for how consistently the start tool is
+            followed by this exact sequence.
+        example_trace: The trace the suggested flow was wired from, for
+            inspection / debugging.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    flow: Flow
+    tools: tuple[str, ...]
+    occurrences: int
+    traces_with_pattern: int
+    confidence: float
+    example_trace: ObservedTrace
+
+    @property
+    def estimated_llm_calls_avoided(self) -> int:
+        """Projected LLM tool-selection calls saved by compiling this flow.
+
+        A compiled flow of ``N`` steps removes roughly one LLM routing
+        decision per step per execution; over the observed
+        :attr:`occurrences` runs that is ``len(tools) * occurrences``.
+        Used to rank candidates (see ``chainweaver record``, issue #226).
+        """
+        return len(self.tools) * self.occurrences
+
+
+class ChainObserver:
+    """Record runtime tool calls and suggest compiled flows from patterns.
+
+    Typical usage from an agent runtime::
+
+        observer = ChainObserver()
+        observer.record("fetch", {"url": "..."}, {"data": "..."})
+        observer.record("validate", {"data": "..."}, {"valid": True})
+        observer.record("transform", {"data": "..."}, {"result": "..."})
+        observer.end_trace()
+        # ... many traces later ...
+        for suggestion in observer.suggest_flows(min_occurrences=3):
+            registry.register_flow(suggestion.flow)  # explicit promotion
+
+    A single trace is "open" at a time: :meth:`record` starts one lazily and
+    appends to it; :meth:`end_trace` closes it.  Closed, non-empty traces
+    accumulate (optionally bounded by ``max_traces``) and feed
+    :meth:`suggest_flows`.
+
+    Args:
+        max_traces: Optional cap on retained completed traces.  When set,
+            only the most recent ``max_traces`` traces are kept (a ring
+            buffer).  ``None`` (default) keeps everything.
+
+    Raises:
+        ValueError: If ``max_traces`` is not ``None`` and ``< 1``.
+    """
+
+    def __init__(self, *, max_traces: int | None = None) -> None:
+        if max_traces is not None and max_traces < 1:
+            raise ValueError(f"max_traces must be >= 1 or None, got {max_traces}.")
+        self._recorder = TraceRecorder()
+        self._current_id: str | None = None
+        self._completed: list[ObservedTrace] = []
+        self._max_traces = max_traces
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record(
+        self,
+        tool_name: str,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any] | None = None,
+        *,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Append a tool call to the current trace, starting one if needed.
+
+        Args:
+            tool_name: Name of the tool that was invoked.
+            inputs: Raw input dictionary supplied to the tool.
+            outputs: Raw output dictionary returned by the tool, or ``None``
+                if the call failed.
+            duration_ms: Optional wall-clock duration; otherwise computed
+                relative to the previous ``record`` / trace start.
+        """
+        if self._current_id is None:
+            self._current_id = self._recorder.start_trace(source=_DEFAULT_SOURCE)
+        self._recorder.record_step(
+            self._current_id,
+            tool_name,
+            inputs=inputs,
+            outputs=outputs,
+            duration_ms=duration_ms,
+        )
+
+    def end_trace(self) -> ObservedTrace:
+        """Close the current trace and retain it for pattern detection.
+
+        Empty traces (no recorded steps) are returned but not retained —
+        they carry no pattern signal.
+
+        Returns:
+            The closed :class:`~chainweaver.observation.ObservedTrace`.
+
+        Raises:
+            ValueError: When no trace is open (no :meth:`record` since the
+                last :meth:`end_trace`).
+        """
+        if self._current_id is None:
+            raise ValueError("No open trace to end; call record() before end_trace().")
+        trace = self._recorder.end_trace(self._current_id)
+        self._current_id = None
+        if trace.steps:
+            self._completed.append(trace)
+            if self._max_traces is not None and len(self._completed) > self._max_traces:
+                self._completed = self._completed[-self._max_traces :]
+        return trace
+
+    @property
+    def traces(self) -> list[ObservedTrace]:
+        """Return a copy of the retained completed traces, oldest first."""
+        return list(self._completed)
+
+    def __len__(self) -> int:
+        return len(self._completed)
+
+    # ------------------------------------------------------------------
+    # Suggestion
+    # ------------------------------------------------------------------
+
+    def suggest_flows(
+        self,
+        *,
+        min_occurrences: int = 3,
+        min_length: int = 2,
+        max_length: int | None = None,
+        collapse_subsumed: bool = True,
+    ) -> list[FlowSuggestion]:
+        """Mine repeated tool sequences and propose flows for them.
+
+        Detection is pure n-gram frequency counting over the tool-name
+        sequences of the retained traces: every contiguous sub-sequence of
+        length ``min_length..max_length`` is counted, and those appearing
+        at least ``min_occurrences`` times become :class:`FlowSuggestion`
+        objects.
+
+        Args:
+            min_occurrences: Minimum total contiguous appearances (across
+                all traces) for a pattern to be suggested.  Must be ``>= 1``.
+            min_length: Minimum sequence length (number of tools).  Must be
+                ``>= 1``; defaults to ``2`` (single-tool "patterns" are
+                noise).
+            max_length: Maximum sequence length.  ``None`` (default) means
+                "as long as the longest trace".  Must be ``>= min_length``
+                when set.
+            collapse_subsumed: When ``True`` (default), drop a shorter
+                pattern that only ever appears as part of a longer suggested
+                pattern with the same occurrence count (it is strictly
+                dominated).
+
+        Returns:
+            A list of :class:`FlowSuggestion` objects sorted by descending
+            occurrences, then descending length, then flow name.  Empty when
+            no pattern clears the thresholds.
+
+        Raises:
+            ValueError: If ``min_occurrences`` or ``min_length`` is ``< 1``,
+                or ``max_length`` is set below ``min_length``.
+        """
+        if min_occurrences < 1:
+            raise ValueError(f"min_occurrences must be >= 1, got {min_occurrences}.")
+        if min_length < 1:
+            raise ValueError(f"min_length must be >= 1, got {min_length}.")
+        if max_length is not None and max_length < min_length:
+            raise ValueError(f"max_length must be >= min_length ({min_length}), got {max_length}.")
+
+        sequences = [tuple(step.tool_name for step in trace.steps) for trace in self._completed]
+
+        occurrences: Counter[tuple[str, ...]] = Counter()
+        traces_with_pattern: Counter[tuple[str, ...]] = Counter()
+        traces_with_tool: Counter[str] = Counter()
+        # First (trace_index, start_pos) a pattern was seen — its blueprint.
+        representative: dict[tuple[str, ...], tuple[int, int]] = {}
+
+        for trace_index, seq in enumerate(sequences):
+            for tool in set(seq):
+                traces_with_tool[tool] += 1
+            n = len(seq)
+            seen_in_trace: set[tuple[str, ...]] = set()
+            cap = n if max_length is None else min(max_length, n)
+            for start in range(n):
+                upper = min(cap, n - start)
+                for length in range(min_length, upper + 1):
+                    pattern = seq[start : start + length]
+                    occurrences[pattern] += 1
+                    if pattern not in representative:
+                        representative[pattern] = (trace_index, start)
+                    seen_in_trace.add(pattern)
+            for pattern in seen_in_trace:
+                traces_with_pattern[pattern] += 1
+
+        qualifying = {
+            pattern: count for pattern, count in occurrences.items() if count >= min_occurrences
+        }
+        if collapse_subsumed:
+            qualifying = self._collapse_subsumed(qualifying)
+
+        suggestions: list[FlowSuggestion] = []
+        for pattern, count in qualifying.items():
+            start_tool = pattern[0]
+            start_total = traces_with_tool[start_tool]
+            confidence = (
+                round(traces_with_pattern[pattern] / start_total, 6) if start_total else 0.0
+            )
+            trace_index, start_pos = representative[pattern]
+            example = self._completed[trace_index]
+            flow = self._build_flow(pattern, example, start_pos, count, confidence)
+            suggestions.append(
+                FlowSuggestion(
+                    flow=flow,
+                    tools=pattern,
+                    occurrences=count,
+                    traces_with_pattern=traces_with_pattern[pattern],
+                    confidence=confidence,
+                    example_trace=example,
+                )
+            )
+
+        suggestions.sort(key=lambda s: (-s.occurrences, -len(s.tools), s.flow.name))
+        return suggestions
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_contiguous_subsequence(short: tuple[str, ...], long: tuple[str, ...]) -> bool:
+        """Return ``True`` when *short* appears contiguously inside *long*."""
+        if len(short) >= len(long):
+            return False
+        return any(long[i : i + len(short)] == short for i in range(len(long) - len(short) + 1))
+
+    @classmethod
+    def _collapse_subsumed(
+        cls,
+        qualifying: dict[tuple[str, ...], int],
+    ) -> dict[tuple[str, ...], int]:
+        """Drop patterns dominated by a longer one with equal occurrences."""
+        patterns = list(qualifying)
+        kept: dict[tuple[str, ...], int] = {}
+        for pattern in patterns:
+            count = qualifying[pattern]
+            dominated = any(
+                other is not pattern
+                and qualifying[other] == count
+                and cls._is_contiguous_subsequence(pattern, other)
+                for other in patterns
+            )
+            if not dominated:
+                kept[pattern] = count
+        return kept
+
+    @staticmethod
+    def _build_flow(
+        pattern: tuple[str, ...],
+        example: ObservedTrace,
+        start_pos: int,
+        occurrences: int,
+        confidence: float,
+    ) -> Flow:
+        """Build a reviewable :class:`Flow` from one occurrence of *pattern*.
+
+        ``input_mapping`` is name-matched against observed I/O keys: the
+        first step pulls every observed input field from the initial
+        context; later steps pull only fields produced by an upstream step
+        in the pattern (mirroring
+        :func:`chainweaver.analyzer._auto_input_mapping`).
+        """
+        slice_steps = example.steps[start_pos : start_pos + len(pattern)]
+        upstream_outputs: set[str] = set()
+        steps: list[FlowStep] = []
+        for position, observed in enumerate(slice_steps):
+            input_keys = set(observed.inputs)
+            if position == 0:
+                mapping = {key: key for key in input_keys}
+            else:
+                mapping = {key: key for key in input_keys if key in upstream_outputs}
+            steps.append(FlowStep(tool_name=observed.tool_name, input_mapping=mapping))
+            if observed.outputs is not None:
+                upstream_outputs |= set(observed.outputs)
+        arrow = " → ".join(pattern)
+        return Flow(
+            name="suggested__" + "__".join(pattern),
+            version="0.0.0",
+            description=(
+                f"Auto-suggested from observed traces: {arrow} "
+                f"(seen {occurrences}x, confidence {confidence})."
+            ),
+            steps=steps,
+        )

--- a/chainweaver/observer.py
+++ b/chainweaver/observer.py
@@ -170,6 +170,36 @@ class ChainObserver:
                 self._completed = self._completed[-self._max_traces :]
         return trace
 
+    @classmethod
+    def from_traces(
+        cls,
+        traces: list[ObservedTrace],
+        *,
+        max_traces: int | None = None,
+    ) -> ChainObserver:
+        """Build an observer pre-loaded with already-completed traces.
+
+        Useful for mining a snapshot of traces off the hot path — a caller
+        holding a lock can copy the closed (immutable) traces, release the
+        lock, then run :meth:`suggest_flows` on a detached observer without
+        blocking concurrent :meth:`record` / :meth:`end_trace` — and for
+        offline analysis of persisted traces.
+
+        Empty traces (no steps) are ignored, mirroring :meth:`end_trace`.
+
+        Args:
+            traces: Completed traces to seed the observer with, oldest first.
+            max_traces: Optional ring-buffer cap (see :class:`ChainObserver`).
+
+        Raises:
+            ValueError: If ``max_traces`` is not ``None`` and ``< 1``.
+        """
+        observer = cls(max_traces=max_traces)
+        observer._completed = [trace for trace in traces if trace.steps]
+        if max_traces is not None and len(observer._completed) > max_traces:
+            observer._completed = observer._completed[-max_traces:]
+        return observer
+
     @property
     def traces(self) -> list[ObservedTrace]:
         """Return a copy of the retained completed traces, oldest first."""

--- a/chainweaver/observer.py
+++ b/chainweaver/observer.py
@@ -1,4 +1,4 @@
-"""Runtime chain observer with auto-flow suggestion (issue #78).
+"""Runtime flow observer with auto-flow suggestion (issue #78).
 
 While :class:`~chainweaver.observation.TraceRecorder` (issue #11) captures
 raw ad-hoc tool sequences, it does not *learn* from them.  ``ChainObserver``
@@ -9,7 +9,7 @@ actually walked the pattern.
 
 This is the runtime, trace-driven counterpart to
 :meth:`chainweaver.analyzer.ChainAnalyzer.suggest_flows`, which discovers
-chains *statically* from tool schemas.  Where the analyzer answers "what
+flows *statically* from tool schemas.  Where the analyzer answers "what
 *could* be compiled?", the observer answers "what *did* the agent keep
 doing?".
 

--- a/chainweaver/service.py
+++ b/chainweaver/service.py
@@ -1,0 +1,503 @@
+"""Continuous analysis service for ChainWeaver (issue #101).
+
+``ChainWeaverService`` is the product-level manifestation of ChainWeaver's
+core value proposition: instead of hand-authoring flows, the service watches
+tools and runtime traces, *proposes* compiled flows, routes every proposal
+through a governance gate, and promotes approved flows into a registry.
+
+It ties together the deterministic building blocks:
+
+* :class:`~chainweaver.observer.ChainObserver` (#78) — runtime trace mining.
+* :class:`~chainweaver.analyzer.ChainAnalyzer` (#77) — static schema-compatible
+  chain discovery (built on demand from the monitored tools).
+* an opt-in offline LLM proposer (:func:`chainweaver.compiler_llm.llm_propose_flows`,
+  #28) — only consulted when ``enable_llm_proposals`` is set *and* an
+  ``llm_fn`` is supplied.
+
+Governance
+----------
+
+Every candidate becomes a *pending* :class:`ServiceProposal`; nothing reaches
+the registry until :meth:`ChainWeaverService.approve` is called (the
+governance gate).  ``auto_approve_deterministic`` can promote fully
+deterministic proposals automatically, but it is **off by default**.  Full
+``GovernanceManager`` policy integration (#13) is deferred; this service ships
+the minimum viable in-process gate.
+
+Invariants
+----------
+
+* No LLM, no network, no randomness on the deterministic path.  The LLM
+  proposer is opt-in and provider-agnostic via the ``llm_fn`` seam.
+* In-memory state only — persistence across restarts is out of scope (#16).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from chainweaver.analyzer import ChainAnalyzer
+from chainweaver.exceptions import FlowAlreadyExistsError
+from chainweaver.flow import Flow
+from chainweaver.observer import ChainObserver
+from chainweaver.registry import FlowRegistry
+from chainweaver.tools import Tool
+
+if TYPE_CHECKING:
+    from chainweaver._offline_llm import LLMFn
+
+EventCallback = Callable[[dict[str, Any]], None]
+
+
+def _now_utc() -> datetime:
+    """Return the current UTC time as a timezone-aware ``datetime``."""
+    return datetime.now(timezone.utc)
+
+
+class ServiceEvent(str, Enum):
+    """Lifecycle events emitted by :class:`ChainWeaverService`."""
+
+    TOOL_REGISTERED = "tool_registered"
+    TRACE_RECORDED = "trace_recorded"
+    ANALYSIS_COMPLETED = "analysis_completed"
+    PROPOSAL_CREATED = "proposal_created"
+    FLOW_PROMOTED = "flow_promoted"
+    PROPOSAL_REJECTED = "proposal_rejected"
+
+
+class ProposalStatus(str, Enum):
+    """Lifecycle state of a :class:`ServiceProposal`."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class ServiceConfig(BaseModel):
+    """Triggers, thresholds, and feature flags for :class:`ChainWeaverService`.
+
+    Attributes:
+        analyze_on_tool_change: Re-run analysis whenever a tool is registered.
+        analyze_interval_seconds: Periodic re-analysis cadence for the
+            background loop.  ``None`` (default) disables the timer — the
+            service is then purely event/manual-driven.
+        min_trace_occurrences: Minimum runtime occurrences before an observed
+            pattern is proposed (forwarded to the observer).
+        min_pattern_length: Minimum pattern / chain length (number of tools).
+        min_determinism_score: Minimum confidence (0-1) for a proposal to be
+            queued.
+        enable_llm_proposals: Opt in to offline LLM-assisted proposals.  Only
+            honoured when an ``llm_fn`` is supplied to the service.
+        max_llm_proposals: Upper bound on LLM proposals per analysis pass.
+        auto_approve_deterministic: Auto-promote proposals whose confidence is
+            ``1.0``.  Dangerous; off by default.
+        max_pending_proposals: Cap on the pending-proposal queue.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    analyze_on_tool_change: bool = True
+    analyze_interval_seconds: float | None = Field(default=None, gt=0)
+    min_trace_occurrences: int = Field(default=3, ge=1)
+    min_pattern_length: int = Field(default=2, ge=1)
+    min_determinism_score: float = Field(default=0.8, ge=0.0, le=1.0)
+    enable_llm_proposals: bool = False
+    max_llm_proposals: int = Field(default=5, ge=1)
+    auto_approve_deterministic: bool = False
+    max_pending_proposals: int = Field(default=50, ge=1)
+
+
+class ServiceMetrics(BaseModel):
+    """Cumulative service statistics — the adoption value-prop numbers.
+
+    Attributes:
+        tools_monitored: Distinct tools registered with the service.
+        traces_recorded: Completed runtime traces observed.
+        patterns_detected: Candidate patterns surfaced across all analyses.
+        flows_proposed: Proposals queued (after de-duplication / thresholds).
+        flows_promoted: Proposals approved and registered.
+        total_llm_calls_avoided: Projected LLM calls saved by promoted flows.
+    """
+
+    tools_monitored: int = 0
+    traces_recorded: int = 0
+    patterns_detected: int = 0
+    flows_proposed: int = 0
+    flows_promoted: int = 0
+    total_llm_calls_avoided: int = 0
+
+
+class ServiceProposal(BaseModel):
+    """A proposed flow awaiting governance, with its provenance and scores.
+
+    Attributes:
+        id: Unique proposal id (UUID4 hex).
+        flow: The proposed, ready-to-review :class:`~chainweaver.flow.Flow`.
+        source: Provenance — ``"observer"``, ``"analyzer"`` or
+            ``"llm-compiler"``.
+        occurrences: Runtime occurrences (``0`` for static/LLM proposals).
+        confidence: 0-1 determinism / confidence score.
+        estimated_llm_calls_avoided: Projected LLM calls saved per promotion.
+        status: Current :class:`ProposalStatus`.
+        created_at: UTC creation timestamp.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    id: str
+    flow: Flow
+    source: str
+    occurrences: int
+    confidence: float
+    estimated_llm_calls_avoided: int
+    status: ProposalStatus = ProposalStatus.PENDING
+    created_at: datetime = Field(default_factory=_now_utc)
+
+
+class ChainWeaverService:
+    """Continuous analyze -> observe -> propose -> govern -> promote service.
+
+    The service is safe to drive both synchronously (call :meth:`record` /
+    :meth:`register_tool` / :meth:`trigger_analysis` directly) and as a
+    background thread (:meth:`run` / :meth:`stop`, or use it as a context
+    manager).
+
+    Args:
+        registry: The :class:`~chainweaver.registry.FlowRegistry` approved
+            flows are promoted into (the governance target).
+        observer: Optional :class:`~chainweaver.observer.ChainObserver`; a
+            fresh one is created when omitted.
+        config: Optional :class:`ServiceConfig`; defaults are used otherwise.
+        llm_fn: Optional offline ``prompt -> completion`` callable enabling
+            LLM-assisted proposals (only used when
+            ``config.enable_llm_proposals`` is set).
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: FlowRegistry,
+        observer: ChainObserver | None = None,
+        config: ServiceConfig | None = None,
+        llm_fn: LLMFn | None = None,
+    ) -> None:
+        self.registry = registry
+        self.observer = observer if observer is not None else ChainObserver()
+        self.config = config if config is not None else ServiceConfig()
+        self.llm_fn = llm_fn
+        self._tools: dict[str, Tool] = {}
+        self._proposals: dict[str, ServiceProposal] = {}
+        self._callbacks: dict[ServiceEvent, list[EventCallback]] = {}
+        self._metrics = ServiceMetrics()
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Event system
+    # ------------------------------------------------------------------
+
+    def on_event(self, event: ServiceEvent, callback: EventCallback) -> None:
+        """Register *callback* to fire whenever *event* is emitted."""
+        with self._lock:
+            self._callbacks.setdefault(event, []).append(callback)
+
+    def emit(self, event: ServiceEvent, data: dict[str, Any]) -> None:
+        """Emit *event* with *data* to every registered callback.
+
+        Callbacks run outside the internal lock so a callback may safely call
+        back into the service.
+        """
+        with self._lock:
+            callbacks = list(self._callbacks.get(event, ()))
+        for callback in callbacks:
+            callback(data)
+
+    # ------------------------------------------------------------------
+    # Inputs: tools and traces
+    # ------------------------------------------------------------------
+
+    def register_tool(self, tool: Tool) -> None:
+        """Monitor *tool* and (per config) trigger a re-analysis.
+
+        Re-registering a tool with the same name replaces the prior entry
+        (schema update) without inflating the monitored count.
+        """
+        with self._lock:
+            self._tools[tool.name] = tool
+            self._metrics.tools_monitored = len(self._tools)
+        self.emit(ServiceEvent.TOOL_REGISTERED, {"tool_name": tool.name})
+        if self.config.analyze_on_tool_change:
+            self.trigger_analysis()
+
+    def record(
+        self,
+        tool_name: str,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any] | None = None,
+    ) -> None:
+        """Forward a runtime tool call to the underlying observer."""
+        self.observer.record(tool_name, inputs, outputs)
+
+    def end_trace(self) -> None:
+        """Close the current observed trace and count it."""
+        self.observer.end_trace()
+        with self._lock:
+            self._metrics.traces_recorded += 1
+        self.emit(ServiceEvent.TRACE_RECORDED, {"traces_recorded": self._metrics.traces_recorded})
+
+    # ------------------------------------------------------------------
+    # Analysis pipeline
+    # ------------------------------------------------------------------
+
+    def trigger_analysis(self) -> list[ServiceProposal]:
+        """Run the full proposal pipeline once and return the new proposals.
+
+        Runs the observer (runtime) pass, the analyzer (static) pass, and —
+        when enabled — the LLM pass, queueing each fresh candidate as a
+        pending :class:`ServiceProposal`.
+        """
+        created: list[ServiceProposal] = []
+        created.extend(self._observer_pass())
+        created.extend(self._analyzer_pass())
+        if self.config.enable_llm_proposals and self.llm_fn is not None:
+            created.extend(self._llm_pass())
+        self.emit(ServiceEvent.ANALYSIS_COMPLETED, {"proposal_count": len(created)})
+        return created
+
+    def _observer_pass(self) -> list[ServiceProposal]:
+        suggestions = self.observer.suggest_flows(
+            min_occurrences=self.config.min_trace_occurrences,
+            min_length=self.config.min_pattern_length,
+        )
+        out: list[ServiceProposal] = []
+        for suggestion in suggestions:
+            proposal = self._queue_proposal(
+                flow=suggestion.flow,
+                source="observer",
+                occurrences=suggestion.occurrences,
+                confidence=suggestion.confidence,
+                estimated_llm_calls_avoided=suggestion.estimated_llm_calls_avoided,
+            )
+            if proposal is not None:
+                out.append(proposal)
+        return out
+
+    def _analyzer_pass(self) -> list[ServiceProposal]:
+        with self._lock:
+            tools = list(self._tools.values())
+        if len(tools) < self.config.min_pattern_length:
+            return []
+        flows = ChainAnalyzer(tools).suggest_flows(min_depth=self.config.min_pattern_length)
+        out: list[ServiceProposal] = []
+        for flow in flows:
+            proposal = self._queue_proposal(
+                flow=flow,
+                source="analyzer",
+                occurrences=0,
+                confidence=1.0,
+                estimated_llm_calls_avoided=len(flow.steps),
+            )
+            if proposal is not None:
+                out.append(proposal)
+        return out
+
+    def _llm_pass(self) -> list[ServiceProposal]:
+        from chainweaver.compiler_llm import llm_propose_flows
+
+        with self._lock:
+            tools = list(self._tools.values())
+        if not tools or self.llm_fn is None:
+            return []
+        proposals = llm_propose_flows(
+            tools,
+            llm_fn=self.llm_fn,
+            max_proposals=self.config.max_llm_proposals,
+        )
+        out: list[ServiceProposal] = []
+        for proposal in proposals:
+            queued = self._queue_proposal(
+                flow=proposal.proposed_flow,
+                source=proposal.source,
+                occurrences=0,
+                confidence=proposal.confidence,
+                estimated_llm_calls_avoided=len(proposal.proposed_flow.steps),
+            )
+            if queued is not None:
+                out.append(queued)
+        return out
+
+    def _queue_proposal(
+        self,
+        *,
+        flow: Flow,
+        source: str,
+        occurrences: int,
+        confidence: float,
+        estimated_llm_calls_avoided: int,
+    ) -> ServiceProposal | None:
+        """Queue one candidate as a pending proposal, or skip it.
+
+        A candidate is skipped when its confidence is below
+        ``min_determinism_score``, when the pending queue is full, or when the
+        flow name is already registered or already has a live (pending /
+        approved) proposal.  Auto-approves when configured and fully
+        deterministic.
+        """
+        with self._lock:
+            self._metrics.patterns_detected += 1
+            if confidence < self.config.min_determinism_score:
+                return None
+            if self._is_known_locked(flow.name):
+                return None
+            pending = sum(
+                1 for p in self._proposals.values() if p.status is ProposalStatus.PENDING
+            )
+            if pending >= self.config.max_pending_proposals:
+                return None
+            proposal = ServiceProposal(
+                id=uuid.uuid4().hex,
+                flow=flow,
+                source=source,
+                occurrences=occurrences,
+                confidence=confidence,
+                estimated_llm_calls_avoided=estimated_llm_calls_avoided,
+            )
+            self._proposals[proposal.id] = proposal
+            self._metrics.flows_proposed += 1
+            auto = self.config.auto_approve_deterministic and confidence >= 1.0
+        self.emit(ServiceEvent.PROPOSAL_CREATED, {"proposal_id": proposal.id, "source": source})
+        if auto:
+            self.approve(proposal.id)
+        return proposal
+
+    def _is_known_locked(self, flow_name: str) -> bool:
+        """Return ``True`` if *flow_name* is registered or already proposed.
+
+        Must be called while holding ``self._lock``.
+        """
+        for proposal in self._proposals.values():
+            if proposal.flow.name == flow_name and proposal.status is not ProposalStatus.REJECTED:
+                return True
+        return any(flow.name == flow_name for flow in self.registry.list_flows())
+
+    # ------------------------------------------------------------------
+    # Governance gate
+    # ------------------------------------------------------------------
+
+    def approve(self, proposal_id: str) -> ServiceProposal:
+        """Promote a pending proposal: register its flow and mark it approved.
+
+        Raises:
+            KeyError: When *proposal_id* is unknown.
+            ValueError: When the proposal is not pending.
+        """
+        with self._lock:
+            proposal = self._require_proposal_locked(proposal_id)
+            if proposal.status is not ProposalStatus.PENDING:
+                raise ValueError(
+                    f"Proposal '{proposal_id}' is {proposal.status.value}, not pending."
+                )
+            # Already promoted out-of-band? Treat approval as idempotent.
+            with contextlib.suppress(FlowAlreadyExistsError):
+                self.registry.register_flow(proposal.flow)
+            proposal.status = ProposalStatus.APPROVED
+            self._metrics.flows_promoted += 1
+            self._metrics.total_llm_calls_avoided += proposal.estimated_llm_calls_avoided
+        self.emit(
+            ServiceEvent.FLOW_PROMOTED, {"proposal_id": proposal_id, "flow": proposal.flow.name}
+        )
+        return proposal
+
+    def reject(self, proposal_id: str) -> ServiceProposal:
+        """Reject a pending proposal so it never reaches the registry.
+
+        Raises:
+            KeyError: When *proposal_id* is unknown.
+            ValueError: When the proposal is not pending.
+        """
+        with self._lock:
+            proposal = self._require_proposal_locked(proposal_id)
+            if proposal.status is not ProposalStatus.PENDING:
+                raise ValueError(
+                    f"Proposal '{proposal_id}' is {proposal.status.value}, not pending."
+                )
+            proposal.status = ProposalStatus.REJECTED
+        self.emit(ServiceEvent.PROPOSAL_REJECTED, {"proposal_id": proposal_id})
+        return proposal
+
+    def _require_proposal_locked(self, proposal_id: str) -> ServiceProposal:
+        proposal = self._proposals.get(proposal_id)
+        if proposal is None:
+            raise KeyError(f"Unknown proposal id '{proposal_id}'.")
+        return proposal
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def list_proposals(self, *, status: ProposalStatus | None = None) -> list[ServiceProposal]:
+        """Return queued proposals, optionally filtered by *status*."""
+        with self._lock:
+            proposals = list(self._proposals.values())
+        if status is not None:
+            proposals = [p for p in proposals if p.status is status]
+        return proposals
+
+    @property
+    def metrics(self) -> ServiceMetrics:
+        """Return a snapshot copy of the current metrics."""
+        with self._lock:
+            return self._metrics.model_copy()
+
+    # ------------------------------------------------------------------
+    # Background loop
+    # ------------------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        """Return ``True`` while the background thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def run(self) -> None:
+        """Start the background analysis loop in a daemon thread.
+
+        Raises:
+            RuntimeError: When the service is already running.
+        """
+        if self.is_running:
+            raise RuntimeError("Service is already running.")
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name="chainweaver-service", daemon=True)
+        self._thread.start()
+
+    def stop(self, *, timeout: float | None = 5.0) -> None:
+        """Signal the background loop to stop and join the thread."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._thread = None
+
+    def _loop(self) -> None:
+        interval = self.config.analyze_interval_seconds
+        while not self._stop.is_set():
+            if interval is not None:
+                self.trigger_analysis()
+            # Wait for the interval (or idle in short slices) until stopped.
+            self._stop.wait(timeout=interval if interval is not None else 0.1)
+
+    def __enter__(self) -> ChainWeaverService:
+        self.run()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()

--- a/chainweaver/service.py
+++ b/chainweaver/service.py
@@ -288,13 +288,16 @@ class ChainWeaverService:
         return created
 
     def _observer_pass(self) -> list[ServiceProposal]:
-        # ``ChainObserver`` is not thread-safe; hold the lock while reading it
-        # so this never races with concurrent ``record`` / ``end_trace`` calls.
+        # ``ChainObserver`` is not thread-safe. Take a snapshot of the closed
+        # (immutable) traces under the lock, then mine the detached copy
+        # outside it: ``suggest_flows`` is O(traces x length^2) and must not
+        # block concurrent ``record`` / ``end_trace`` on the agent thread.
         with self._lock:
-            suggestions = self.observer.suggest_flows(
-                min_occurrences=self.config.min_trace_occurrences,
-                min_length=self.config.min_pattern_length,
-            )
+            snapshot = self.observer.traces
+        suggestions = ChainObserver.from_traces(snapshot).suggest_flows(
+            min_occurrences=self.config.min_trace_occurrences,
+            min_length=self.config.min_pattern_length,
+        )
         out: list[ServiceProposal] = []
         for suggestion in suggestions:
             proposal = self._queue_proposal(

--- a/chainweaver/service.py
+++ b/chainweaver/service.py
@@ -9,7 +9,7 @@ It ties together the deterministic building blocks:
 
 * :class:`~chainweaver.observer.ChainObserver` (#78) — runtime trace mining.
 * :class:`~chainweaver.analyzer.ChainAnalyzer` (#77) — static schema-compatible
-  chain discovery (built on demand from the monitored tools).
+  flow discovery (built on demand from the monitored tools).
 * an opt-in offline LLM proposer (:func:`chainweaver.compiler_llm.llm_propose_flows`,
   #28) — only consulted when ``enable_llm_proposals`` is set *and* an
   ``llm_fn`` is supplied.
@@ -27,14 +27,16 @@ the minimum viable in-process gate.
 Invariants
 ----------
 
-* No LLM, no network, no randomness on the deterministic path.  The LLM
-  proposer is opt-in and provider-agnostic via the ``llm_fn`` seam.
+* No LLM, no network, and no randomness in *flow generation* — the observer
+  and analyzer passes mine the same flows from the same inputs.  Proposal
+  envelope metadata (the UUID ``id`` and ``created_at`` timestamp) is
+  non-deterministic bookkeeping and never affects which flows are proposed.
+  The LLM proposer is opt-in and provider-agnostic via the ``llm_fn`` seam.
 * In-memory state only — persistence across restarts is out of scope (#16).
 """
 
 from __future__ import annotations
 
-import contextlib
 import threading
 import uuid
 from collections.abc import Callable
@@ -91,7 +93,7 @@ class ServiceConfig(BaseModel):
             service is then purely event/manual-driven.
         min_trace_occurrences: Minimum runtime occurrences before an observed
             pattern is proposed (forwarded to the observer).
-        min_pattern_length: Minimum pattern / chain length (number of tools).
+        min_pattern_length: Minimum pattern / flow length (number of tools).
         min_determinism_score: Minimum confidence (0-1) for a proposal to be
             queued.
         enable_llm_proposals: Opt in to offline LLM-assisted proposals.  Only
@@ -244,15 +246,27 @@ class ChainWeaverService:
         inputs: dict[str, Any],
         outputs: dict[str, Any] | None = None,
     ) -> None:
-        """Forward a runtime tool call to the underlying observer."""
-        self.observer.record(tool_name, inputs, outputs)
+        """Forward a runtime tool call to the underlying observer.
+
+        ``ChainObserver`` is not thread-safe, so observer access is serialized
+        under the service lock to avoid racing with the background analysis
+        loop (:meth:`_observer_pass`).
+        """
+        with self._lock:
+            self.observer.record(tool_name, inputs, outputs)
 
     def end_trace(self) -> None:
-        """Close the current observed trace and count it."""
-        self.observer.end_trace()
+        """Close the current observed trace and count it.
+
+        The trace mutation and the metric update happen under the lock (so the
+        background loop never reads a half-updated observer); the event is
+        emitted outside the lock so callbacks may re-enter the service.
+        """
         with self._lock:
+            self.observer.end_trace()
             self._metrics.traces_recorded += 1
-        self.emit(ServiceEvent.TRACE_RECORDED, {"traces_recorded": self._metrics.traces_recorded})
+            recorded = self._metrics.traces_recorded
+        self.emit(ServiceEvent.TRACE_RECORDED, {"traces_recorded": recorded})
 
     # ------------------------------------------------------------------
     # Analysis pipeline
@@ -274,10 +288,13 @@ class ChainWeaverService:
         return created
 
     def _observer_pass(self) -> list[ServiceProposal]:
-        suggestions = self.observer.suggest_flows(
-            min_occurrences=self.config.min_trace_occurrences,
-            min_length=self.config.min_pattern_length,
-        )
+        # ``ChainObserver`` is not thread-safe; hold the lock while reading it
+        # so this never races with concurrent ``record`` / ``end_trace`` calls.
+        with self._lock:
+            suggestions = self.observer.suggest_flows(
+                min_occurrences=self.config.min_trace_occurrences,
+                min_length=self.config.min_pattern_length,
+            )
         out: list[ServiceProposal] = []
         for suggestion in suggestions:
             proposal = self._queue_proposal(
@@ -406,12 +423,18 @@ class ChainWeaverService:
                 raise ValueError(
                     f"Proposal '{proposal_id}' is {proposal.status.value}, not pending."
                 )
-            # Already promoted out-of-band? Treat approval as idempotent.
-            with contextlib.suppress(FlowAlreadyExistsError):
+            # Already promoted out-of-band? Treat approval as idempotent and
+            # do not double-count metrics for a flow we did not register here.
+            try:
                 self.registry.register_flow(proposal.flow)
+            except FlowAlreadyExistsError:
+                newly_registered = False
+            else:
+                newly_registered = True
             proposal.status = ProposalStatus.APPROVED
-            self._metrics.flows_promoted += 1
-            self._metrics.total_llm_calls_avoided += proposal.estimated_llm_calls_avoided
+            if newly_registered:
+                self._metrics.flows_promoted += 1
+                self._metrics.total_llm_calls_avoided += proposal.estimated_llm_calls_avoided
         self.emit(
             ServiceEvent.FLOW_PROMOTED, {"proposal_id": proposal_id, "flow": proposal.flow.name}
         )

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -41,6 +41,8 @@ and tools, the same flow produces the same output every time.
 | `log_utils.py` | Per-step structured logging | Library-safe (NullHandler only); no handler config |
 | `cost.py` | `CostProfile` + `CostReport` for cost-avoided estimation | Pure data + a single ``compute_cost_report`` helper; no execution logic |
 | `observation.py` | `TraceRecorder` + `ObservedTrace` for ad-hoc tool sequence capture | In-memory storage only; persistence deferred |
+| `observer.py` | `ChainObserver` + `FlowSuggestion`: record runtime tool calls, mine repeated contiguous sub-sequences, propose flows (#78) | Pure n-gram counting: no LLM, no network, no randomness; suggestions are proposals, never auto-registered |
+| `service.py` | `ChainWeaverService` + `ServiceConfig` + `ServiceMetrics` + `ServiceEvent`: continuous analyze→observe→propose→govern loop (#101) | Ties analyzer + observer + an in-service proposal gate; LLM hooks opt-in; full `GovernanceManager` (#13) integration deferred |
 | `viz.py` | `flow_to_ascii`, `flow_to_mermaid`, `result_to_mermaid` pure renderers | No external dependencies — string generation only |
 | `serialization.py` | YAML + JSON encode/decode for `Flow` and `DAGFlow` (`flow_to_json`, `flow_from_yaml`, etc.) | JSON path is dep-free; YAML requires `pyyaml` (optional extra `chainweaver[yaml]`); schema/exception refs round-trip as `"module:qualname"` strings |
 | `cli.py` | typer-based CLI hosting the full command surface: `inspect`, `viz`, `validate`, `check`, `run`, `profile`, `diff`, `attest`, `suggest`, `dump-schema`, `doctor` | `inspect` / `viz` read from a process-scoped default registry installed via `cli.set_default_registry`; the file-oriented commands (`validate`, `check`, `run`, `profile`, `diff`, `attest`, `suggest`, `doctor`) read directly from disk |
@@ -168,7 +170,7 @@ files that conflict with these names:
 |---------------|-------|---------|
 | ~~`analyzer.py`~~ | #77 ✅ | Offline schema-compatibility analyzer (delivered) |
 | ~~`decisions.py`~~ | #102 ✅ | `DecisionCallback` Protocol (delivered) |
-| `observer.py` | #78 | Runtime flow observer |
+| ~~`observer.py`~~ | #78 ✅ | Runtime flow observer + flow suggestion (delivered) |
 | ~~`viz.py`~~ | #79 ✅ | Flow visualization (delivered) |
 | ~~`cli.py`~~ | #44 ✅ | CLI interface (delivered) |
 | ~~`schemas.py`~~ | #135 ✅ | JSON Schema export for flow files (delivered) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -455,6 +455,43 @@ chainweaver suggest flows/etl.flow.yaml --tools my_pkg.tools --trace run_a.json 
 
 ---
 
+### `record`
+
+Mine candidate flows from a recorded JSONL tool trace (issue #226). Replays the trace through `ChainObserver`, detects repeated tool sequences **offline (no LLM)**, and emits candidate `.flow.yaml` files ranked by projected LLM calls avoided (`len(tools) * occurrences`). Without `--output-dir` the command is a dry run that only reports candidates.
+
+Each non-blank line of the trace file is a JSON object describing one tool call. Calls are grouped into traces by `trace_id` (file order preserved); lines without a `trace_id` join a single default trace:
+
+```json
+{"trace_id": "req-1", "tool": "fetch", "inputs": {"url": "..."}, "outputs": {"body": "..."}}
+```
+
+`tool` (or its alias `tool_name`) is required; `inputs` defaults to `{}` and `outputs` to `null`.
+
+```
+chainweaver record <trace.jsonl> [--output-dir DIR] [--min-occurrences N] [--min-length N] [--max-length N] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output-dir` / `-o` | (none) | Directory to write candidate `.flow.yaml` files into. Omit for a dry run. |
+| `--min-occurrences` | `3` | Minimum contiguous appearances for a pattern to be suggested. |
+| `--min-length` | `2` | Minimum pattern length (number of tools). |
+| `--max-length` | (none) | Maximum pattern length. Omit for no upper bound. |
+| `--format` / `-f` | `table` | Output format: human-readable table or machine-readable JSON. |
+
+**Exit codes**: `0` = ran successfully (regardless of candidate count), `1` = malformed trace or serialization error, `2` = file not found.
+
+**Example**:
+
+```bash
+chainweaver record examples/agent_tool_trace.jsonl
+chainweaver record examples/agent_tool_trace.jsonl --output-dir candidates/ --format json
+```
+
+The emitted files are ordinary flow files — review them, then register and run them like any other flow. Suggested flows ship as version `0.0.0` to signal they are auto-generated and should be reviewed before promotion.
+
+---
+
 ### `dump-schema`
 
 Emit the JSON Schema for `.flow.json` / `.flow.yaml` files, derived from the Pydantic models in `chainweaver.flow`. Editors that consume JSON Schema (VS Code via `redhat.vscode-yaml`, JetBrains, …) get autocomplete, hover docs, and inline validation once they point `yaml.schemas` at the published schema.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -597,7 +597,7 @@ chainweaver service [--tools module...] [--trace trace.jsonl] [--min-occurrences
 | `--tools` / `-t` | (none) | Python module path exposing `Tool` instances at top level. Enables the static-analysis pass. Repeatable. |
 | `--trace` | (none) | JSONL tool-trace file (same format as `chainweaver record`) feeding the runtime-observation pass. |
 | `--min-occurrences` | `3` | Minimum runtime occurrences before an observed pattern is proposed. |
-| `--min-length` | `2` | Minimum pattern / chain length (number of tools). |
+| `--min-length` | `2` | Minimum pattern / flow length (number of tools). |
 | `--format` / `-f` | `table` | Output format: human-readable table or machine-readable JSON. |
 
 **Exit codes**: `0` = ran successfully, `1` = malformed trace / input, `2` = trace file not found.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -582,6 +582,35 @@ chainweaver fuzz flows/my_flow.flow.yaml \
 
 ---
 
+### `service`
+
+Run one `ChainWeaverService` analysis pass and report the proposals it would queue (issue #101). The service ties together the static schema analyzer (`--tools`) and the runtime observer (`--trace`), surfaces candidate flows as **pending proposals**, and prints service metrics. Proposals are reported, never auto-registered — promotion stays a governed, in-process action.
+
+A long-running daemon with cross-invocation `approve` / `reject` requires proposal persistence (#16) and is intentionally out of scope for the CLI; drive that loop via the `ChainWeaverService` Python API instead.
+
+```
+chainweaver service [--tools module...] [--trace trace.jsonl] [--min-occurrences N] [--min-length N] [--format table|json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tools` / `-t` | (none) | Python module path exposing `Tool` instances at top level. Enables the static-analysis pass. Repeatable. |
+| `--trace` | (none) | JSONL tool-trace file (same format as `chainweaver record`) feeding the runtime-observation pass. |
+| `--min-occurrences` | `3` | Minimum runtime occurrences before an observed pattern is proposed. |
+| `--min-length` | `2` | Minimum pattern / chain length (number of tools). |
+| `--format` / `-f` | `table` | Output format: human-readable table or machine-readable JSON. |
+
+**Exit codes**: `0` = ran successfully, `1` = malformed trace / input, `2` = trace file not found.
+
+**Example**:
+
+```bash
+chainweaver service --tools examples.simple_linear_flow
+chainweaver service --trace examples/agent_tool_trace.jsonl --min-occurrences 2 --format json
+```
+
+---
+
 ## Programmatic registration (`inspect`, `viz`)
 
 `inspect` and `viz` read from a process-scoped registry installed via `cli.set_default_registry`:

--- a/examples/agent_tool_trace.jsonl
+++ b/examples/agent_tool_trace.jsonl
@@ -1,0 +1,11 @@
+{"trace_id": "req-1", "tool": "fetch", "inputs": {"url": "https://api.example.com/orders"}, "outputs": {"body": "<json>"}}
+{"trace_id": "req-1", "tool": "validate", "inputs": {"body": "<json>"}, "outputs": {"valid": true}}
+{"trace_id": "req-1", "tool": "transform", "inputs": {"body": "<json>"}, "outputs": {"records": [1, 2, 3]}}
+{"trace_id": "req-2", "tool": "fetch", "inputs": {"url": "https://api.example.com/orders"}, "outputs": {"body": "<json>"}}
+{"trace_id": "req-2", "tool": "validate", "inputs": {"body": "<json>"}, "outputs": {"valid": true}}
+{"trace_id": "req-2", "tool": "transform", "inputs": {"body": "<json>"}, "outputs": {"records": [4, 5]}}
+{"trace_id": "req-3", "tool": "fetch", "inputs": {"url": "https://api.example.com/users"}, "outputs": {"body": "<json>"}}
+{"trace_id": "req-3", "tool": "validate", "inputs": {"body": "<json>"}, "outputs": {"valid": true}}
+{"trace_id": "req-3", "tool": "transform", "inputs": {"body": "<json>"}, "outputs": {"records": [6]}}
+{"trace_id": "req-4", "tool": "fetch", "inputs": {"url": "https://api.example.com/health"}, "outputs": {"body": "ok"}}
+{"trace_id": "req-4", "tool": "summarize", "inputs": {"body": "ok"}, "outputs": {"summary": "healthy"}}

--- a/examples/chain_observer.py
+++ b/examples/chain_observer.py
@@ -1,0 +1,57 @@
+"""Suggest compiled flows from runtime tool traces with ChainObserver (issue #78).
+
+Run with::
+
+    python examples/chain_observer.py
+
+Output: the flows ChainObserver proposes after watching an agent repeat the
+same fetch -> validate -> transform sequence many times, plus the projected
+LLM calls each compiled flow would avoid. Nothing is registered or executed —
+suggestions are proposals for a human (or governance gate) to promote.
+"""
+
+from __future__ import annotations
+
+from chainweaver import ChainObserver, FlowRegistry
+
+
+def main() -> None:
+    observer = ChainObserver()
+
+    # --- 1. Watch the agent work (record runtime tool calls) ----------------
+    # The agent walks the same deterministic path on most requests...
+    for _ in range(8):
+        observer.record("fetch", {"url": "https://api.example.com"}, {"body": "<json>"})
+        observer.record("validate", {"body": "<json>"}, {"valid": True})
+        observer.record("transform", {"body": "<json>"}, {"records": [1, 2, 3]})
+        observer.end_trace()
+
+    # ...and occasionally does something one-off that should NOT be compiled.
+    observer.record("fetch", {"url": "https://api.example.com"}, {"body": "<json>"})
+    observer.record("summarize", {"body": "<json>"}, {"summary": "hi"})
+    observer.end_trace()
+
+    print(f"Recorded {len(observer)} traces.\n")
+
+    # --- 2. Mine repeated patterns into flow suggestions --------------------
+    suggestions = observer.suggest_flows(min_occurrences=3, min_length=2)
+    print(f"Suggested {len(suggestions)} flow(s):")
+    for suggestion in suggestions:
+        chain = " -> ".join(suggestion.tools)
+        print(f"\n  {suggestion.flow.name}")
+        print(f"    pattern:     {chain}")
+        print(f"    occurrences: {suggestion.occurrences}")
+        print(f"    confidence:  {suggestion.confidence}")
+        print(f"    est. LLM calls avoided: {suggestion.estimated_llm_calls_avoided}")
+        for index, step in enumerate(suggestion.flow.steps):
+            print(f"    step {index}: {step.tool_name}  mapping={dict(step.input_mapping)}")
+
+    # --- 3. Promote explicitly (governance gate lives with the caller) -----
+    if suggestions:
+        registry = FlowRegistry()
+        registry.register_flow(suggestions[0].flow)
+        print(f"\nPromoted '{suggestions[0].flow.name}' into a registry on approval.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/chain_observer.py
+++ b/examples/chain_observer.py
@@ -37,9 +37,9 @@ def main() -> None:
     suggestions = observer.suggest_flows(min_occurrences=3, min_length=2)
     print(f"Suggested {len(suggestions)} flow(s):")
     for suggestion in suggestions:
-        chain = " -> ".join(suggestion.tools)
+        arrow = " -> ".join(suggestion.tools)
         print(f"\n  {suggestion.flow.name}")
-        print(f"    pattern:     {chain}")
+        print(f"    pattern:     {arrow}")
         print(f"    occurrences: {suggestion.occurrences}")
         print(f"    confidence:  {suggestion.confidence}")
         print(f"    est. LLM calls avoided: {suggestion.estimated_llm_calls_avoided}")

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -7,7 +7,9 @@
     "BaseMiddleware",
     "CancellationToken",
     "ChainAnalyzer",
+    "ChainObserver",
     "ChainWeaverError",
+    "ChainWeaverService",
     "CheckpointDriftError",
     "CheckpointNotFoundError",
     "Checkpointer",
@@ -58,6 +60,7 @@
     "FlowStatus",
     "FlowStatusError",
     "FlowStep",
+    "FlowSuggestion",
     "FuzzCase",
     "FuzzConfigError",
     "FuzzFailure",
@@ -80,12 +83,17 @@
     "PluginDiscoveryError",
     "PredicateSyntaxError",
     "PriceSnap",
+    "ProposalStatus",
     "RedactionPolicy",
     "RegistryStore",
     "ReplayMode",
     "ReplayResult",
     "RetryPolicy",
     "SchemaValidationError",
+    "ServiceConfig",
+    "ServiceEvent",
+    "ServiceMetrics",
+    "ServiceProposal",
     "SideEffectLevel",
     "StabilityLevel",
     "StepCache",
@@ -198,11 +206,23 @@
       "qualname": "ChainAnalyzer",
       "signature": "(tools: Iterable[Tool]) -> None"
     },
+    "ChainObserver": {
+      "kind": "class",
+      "module": "chainweaver.observer",
+      "qualname": "ChainObserver",
+      "signature": "(*, max_traces: int | None = None) -> None"
+    },
     "ChainWeaverError": {
       "kind": "class",
       "module": "chainweaver.exceptions",
       "qualname": "ChainWeaverError",
       "signature": null
+    },
+    "ChainWeaverService": {
+      "kind": "class",
+      "module": "chainweaver.service",
+      "qualname": "ChainWeaverService",
+      "signature": "(*, registry: FlowRegistry, observer: ChainObserver | None = None, config: ServiceConfig | None = None, llm_fn: LLMFn | None = None) -> None"
     },
     "CheckpointDriftError": {
       "kind": "class",
@@ -629,6 +649,19 @@
       "module": "chainweaver.flow",
       "qualname": "FlowStep"
     },
+    "FlowSuggestion": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "confidence": "float",
+        "example_trace": "chainweaver.observation.ObservedTrace",
+        "flow": "chainweaver.flow.Flow",
+        "occurrences": "int",
+        "tools": "tuple[str, Ellipsis]",
+        "traces_with_pattern": "int"
+      },
+      "module": "chainweaver.observer",
+      "qualname": "FlowSuggestion"
+    },
     "FuzzCase": {
       "kind": "pydantic-model",
       "model_fields": {
@@ -790,6 +823,11 @@
       "module": "chainweaver.cost",
       "qualname": "PriceSnap"
     },
+    "ProposalStatus": {
+      "kind": "enum",
+      "module": "chainweaver.service",
+      "qualname": "ProposalStatus"
+    },
     "RedactionPolicy": {
       "kind": "pydantic-model",
       "model_fields": {
@@ -841,6 +879,55 @@
       "module": "chainweaver.exceptions",
       "qualname": "SchemaValidationError",
       "signature": "(tool_name: str, step_index: int, detail: str, *, context: str = 'tool') -> None"
+    },
+    "ServiceConfig": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "analyze_interval_seconds": "float | NoneType",
+        "analyze_on_tool_change": "bool",
+        "auto_approve_deterministic": "bool",
+        "enable_llm_proposals": "bool",
+        "max_llm_proposals": "int",
+        "max_pending_proposals": "int",
+        "min_determinism_score": "float",
+        "min_pattern_length": "int",
+        "min_trace_occurrences": "int"
+      },
+      "module": "chainweaver.service",
+      "qualname": "ServiceConfig"
+    },
+    "ServiceEvent": {
+      "kind": "enum",
+      "module": "chainweaver.service",
+      "qualname": "ServiceEvent"
+    },
+    "ServiceMetrics": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "flows_promoted": "int",
+        "flows_proposed": "int",
+        "patterns_detected": "int",
+        "tools_monitored": "int",
+        "total_llm_calls_avoided": "int",
+        "traces_recorded": "int"
+      },
+      "module": "chainweaver.service",
+      "qualname": "ServiceMetrics"
+    },
+    "ServiceProposal": {
+      "kind": "pydantic-model",
+      "model_fields": {
+        "confidence": "float",
+        "created_at": "datetime.datetime",
+        "estimated_llm_calls_avoided": "int",
+        "flow": "chainweaver.flow.Flow",
+        "id": "str",
+        "occurrences": "int",
+        "source": "str",
+        "status": "chainweaver.service.ProposalStatus"
+      },
+      "module": "chainweaver.service",
+      "qualname": "ServiceProposal"
     },
     "SideEffectLevel": {
       "kind": "enum",

--- a/tests/test_cli_record.py
+++ b/tests/test_cli_record.py
@@ -1,0 +1,190 @@
+"""Tests for the ``chainweaver record`` CLI command (issue #226)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chainweaver import cli
+from chainweaver.serialization import flow_from_yaml
+
+
+def _write_trace(path: Path, lines: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+
+
+def _repeated_trace(times: int) -> list[dict[str, object]]:
+    """A ``fetch -> validate -> transform`` sequence repeated *times* times."""
+    lines: list[dict[str, object]] = []
+    for i in range(times):
+        tid = f"req-{i}"
+        lines.append(
+            {"trace_id": tid, "tool": "fetch", "inputs": {"url": "u"}, "outputs": {"body": "b"}}
+        )
+        lines.append(
+            {"trace_id": tid, "tool": "validate", "inputs": {"body": "b"}, "outputs": {"ok": True}}
+        )
+        lines.append(
+            {"trace_id": tid, "tool": "transform", "inputs": {"body": "b"}, "outputs": {"out": 1}}
+        )
+    return lines
+
+
+class TestRecordHappyPath:
+    def test_table_dry_run_lists_candidate(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, _repeated_trace(3))
+        exit_code = cli.main(["record", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "suggested__fetch__validate__transform" in captured.out
+        assert "dry run" in captured.out
+
+    def test_json_output_shape(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, _repeated_trace(4))
+        exit_code = cli.main(["record", str(path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["traces_analyzed"] == 4
+        assert payload["candidate_count"] == 1
+        top = payload["candidates"][0]
+        assert top["flow_name"] == "suggested__fetch__validate__transform"
+        assert top["tools"] == ["fetch", "validate", "transform"]
+        assert top["occurrences"] == 4
+        assert top["estimated_llm_calls_avoided"] == 12
+        assert top["output_path"] is None
+
+    def test_writes_valid_flow_files(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, _repeated_trace(3))
+        out_dir = tmp_path / "out"
+        exit_code = cli.main(["record", str(path), "--output-dir", str(out_dir)])
+        capsys.readouterr()
+        assert exit_code == 0
+        written = list(out_dir.glob("*.flow.yaml"))
+        assert len(written) == 1
+        # The emitted file round-trips back into a Flow.
+        flow = flow_from_yaml(written[0].read_text(encoding="utf-8"))
+        assert flow.name == "suggested__fetch__validate__transform"
+        assert [s.tool_name for s in flow.steps] == ["fetch", "validate", "transform"]
+
+    def test_ranking_prefers_higher_savings(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A short 2-tool pattern seen 5x (savings 10) vs a 3-tool pattern seen
+        # 4x (savings 12): the longer, higher-savings flow ranks first.
+        lines: list[dict[str, object]] = []
+        for i in range(5):
+            lines.append(
+                {"trace_id": f"s{i}", "tool": "a", "inputs": {"x": 1}, "outputs": {"y": 1}}
+            )
+            lines.append(
+                {"trace_id": f"s{i}", "tool": "b", "inputs": {"y": 1}, "outputs": {"z": 1}}
+            )
+        for i in range(4):
+            lines.append(
+                {"trace_id": f"l{i}", "tool": "p", "inputs": {"x": 1}, "outputs": {"q": 1}}
+            )
+            lines.append(
+                {"trace_id": f"l{i}", "tool": "q", "inputs": {"q": 1}, "outputs": {"r": 1}}
+            )
+            lines.append(
+                {"trace_id": f"l{i}", "tool": "r", "inputs": {"r": 1}, "outputs": {"s": 1}}
+            )
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, lines)
+        cli.main(["record", str(path), "--format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        names = [c["flow_name"] for c in payload["candidates"]]
+        assert names[0] == "suggested__p__q__r"  # savings 12 > 10
+
+    def test_no_candidates_message(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, _repeated_trace(1))
+        exit_code = cli.main(["record", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "No candidate flows" in captured.out
+
+
+class TestRecordTraceFormat:
+    def test_lines_without_trace_id_join_default_trace(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # No trace_id anywhere -> one big default trace; a 2-gram appears
+        # repeatedly within it.
+        lines: list[dict[str, object]] = []
+        for _ in range(3):
+            lines.append({"tool": "a", "inputs": {}, "outputs": {}})
+            lines.append({"tool": "b", "inputs": {}, "outputs": {}})
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, lines)
+        cli.main(["record", str(path), "--format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["traces_analyzed"] == 1
+        assert any(c["tools"] == ["a", "b"] for c in payload["candidates"])
+
+    def test_tool_name_alias_accepted(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        lines = [
+            {"trace_id": f"t{i}", "tool_name": tool, "inputs": {}, "outputs": {}}
+            for i in range(3)
+            for tool in ("a", "b")
+        ]
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, lines)
+        exit_code = cli.main(["record", str(path), "--format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        assert any(c["tools"] == ["a", "b"] for c in payload["candidates"])
+
+
+class TestRecordErrors:
+    def test_malformed_json_line_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        path.write_text('{"tool": "a"}\nnot json\n', encoding="utf-8")
+        exit_code = cli.main(["record", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "line 2" in captured.err
+
+    def test_missing_tool_field_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        path.write_text('{"inputs": {}}\n', encoding="utf-8")
+        exit_code = cli.main(["record", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "missing or empty 'tool'" in captured.err
+
+    def test_missing_file_exits_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(["record", str(tmp_path / "nope.jsonl")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_invalid_threshold_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, _repeated_trace(3))
+        exit_code = cli.main(["record", str(path), "--min-occurrences", "0"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "min_occurrences must be >= 1" in captured.err

--- a/tests/test_cli_record.py
+++ b/tests/test_cli_record.py
@@ -137,7 +137,7 @@ class TestRecordTraceFormat:
     def test_tool_name_alias_accepted(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        lines = [
+        lines: list[dict[str, object]] = [
             {"trace_id": f"t{i}", "tool_name": tool, "inputs": {}, "outputs": {}}
             for i in range(3)
             for tool in ("a", "b")

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -1,0 +1,90 @@
+"""Tests for the ``chainweaver service`` CLI command (issue #101)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chainweaver import cli
+
+
+def _write_trace(path: Path, times: int, *tools: str) -> None:
+    lines: list[str] = []
+    for i in range(times):
+        for tool in tools:
+            lines.append(
+                json.dumps(
+                    {"trace_id": f"t{i}", "tool": tool, "inputs": {"x": 1}, "outputs": {"y": 1}}
+                )
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TestServiceCommand:
+    def test_trace_pass_reports_proposal(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, 3, "fetch", "validate")
+        exit_code = cli.main(["service", "--trace", str(path), "--min-occurrences", "2"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "suggested__fetch__validate" in captured.out
+        assert "traces analyzed:   3" in captured.out
+
+    def test_json_output_shape(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, 3, "fetch", "validate")
+        exit_code = cli.main(["service", "--trace", str(path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["traces_analyzed"] == 3
+        assert payload["proposal_count"] == 1
+        assert payload["proposals"][0]["flow_name"] == "suggested__fetch__validate"
+        assert payload["proposals"][0]["source"] == "observer"
+        assert payload["metrics"]["patterns_detected"] >= 1
+
+    def test_tools_pass_uses_static_analyzer(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        monkeypatch.syspath_prepend(str(repo_root))
+        exit_code = cli.main(
+            ["service", "--tools", "examples.simple_linear_flow", "--format", "json"]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["metrics"]["tools_monitored"] >= 2
+        assert any(p["source"] == "analyzer" for p in payload["proposals"])
+
+    def test_no_proposals_message(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        _write_trace(path, 1, "fetch", "validate")
+        exit_code = cli.main(["service", "--trace", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "No new proposals." in captured.out
+
+    def test_missing_trace_file_exits_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(["service", "--trace", str(tmp_path / "nope.jsonl")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "file not found" in captured.err
+
+    def test_malformed_trace_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "trace.jsonl"
+        path.write_text("not json\n", encoding="utf-8")
+        exit_code = cli.main(["service", "--trace", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "line 1" in captured.err

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,4 +1,4 @@
-"""Tests for the runtime chain observer and auto-flow suggestion (issue #78)."""
+"""Tests for the runtime flow observer and auto-flow suggestion (issue #78)."""
 
 from __future__ import annotations
 
@@ -59,6 +59,38 @@ class TestRecording:
         snapshot = observer.traces
         snapshot.clear()
         assert len(observer) == 1
+
+
+class TestFromTraces:
+    def test_from_traces_seeds_completed_traces(self) -> None:
+        source = ChainObserver()
+        _record_trace(source, "a", "b")
+        _record_trace(source, "c")
+        rebuilt = ChainObserver.from_traces(source.traces)
+        assert len(rebuilt) == 2
+        assert [t.steps[0].tool_name for t in rebuilt.traces] == ["a", "c"]
+
+    def test_from_traces_mines_equivalently(self) -> None:
+        source = ChainObserver()
+        for _ in range(3):
+            _record_trace(source, "a", "b")
+        rebuilt = ChainObserver.from_traces(source.traces)
+        assert [s.tools for s in rebuilt.suggest_flows()] == [
+            s.tools for s in source.suggest_flows()
+        ]
+
+    def test_from_traces_respects_ring_buffer(self) -> None:
+        source = ChainObserver()
+        _record_trace(source, "a")
+        _record_trace(source, "b")
+        _record_trace(source, "c")
+        rebuilt = ChainObserver.from_traces(source.traces, max_traces=2)
+        assert len(rebuilt) == 2
+        assert [t.steps[0].tool_name for t in rebuilt.traces] == ["b", "c"]
+
+    def test_from_traces_rejects_invalid_max_traces(self) -> None:
+        with pytest.raises(ValueError, match="max_traces must be >= 1"):
+            ChainObserver.from_traces([], max_traces=0)
 
 
 class TestMaxTraces:

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,207 @@
+"""Tests for the runtime chain observer and auto-flow suggestion (issue #78)."""
+
+from __future__ import annotations
+
+import pytest
+
+from chainweaver.flow import Flow
+from chainweaver.observation import ObservedTrace
+from chainweaver.observer import ChainObserver, FlowSuggestion
+from chainweaver.registry import FlowRegistry
+
+
+def _record_trace(observer: ChainObserver, *tools: str) -> None:
+    """Record a trace of name-only tool calls with name-matched I/O keys."""
+    for tool in tools:
+        observer.record(tool, {f"{tool}_in": 1}, {f"{tool}_out": 2})
+    observer.end_trace()
+
+
+# ---------------------------------------------------------------------------
+# Recording lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRecording:
+    def test_record_lazily_opens_a_trace(self) -> None:
+        observer = ChainObserver()
+        observer.record("fetch", {"url": "u"}, {"data": "d"})
+        trace = observer.end_trace()
+        assert isinstance(trace, ObservedTrace)
+        assert [s.tool_name for s in trace.steps] == ["fetch"]
+        assert len(observer) == 1
+
+    def test_record_after_end_starts_a_new_trace(self) -> None:
+        observer = ChainObserver()
+        _record_trace(observer, "a", "b")
+        _record_trace(observer, "c")
+        assert len(observer) == 2
+        assert [t.steps[0].tool_name for t in observer.traces] == ["a", "c"]
+
+    def test_end_trace_without_open_trace_raises(self) -> None:
+        observer = ChainObserver()
+        with pytest.raises(ValueError, match="No open trace to end"):
+            observer.end_trace()
+
+    def test_empty_trace_is_not_retained(self) -> None:
+        observer = ChainObserver()
+        # An open-but-empty trace would only arise via the recorder; the
+        # public API cannot open a trace without a record, so we assert the
+        # invariant indirectly: only step-bearing traces accumulate.
+        _record_trace(observer, "a")
+        assert len(observer) == 1
+
+    def test_traces_returns_a_copy(self) -> None:
+        observer = ChainObserver()
+        _record_trace(observer, "a")
+        snapshot = observer.traces
+        snapshot.clear()
+        assert len(observer) == 1
+
+
+class TestMaxTraces:
+    def test_ring_buffer_keeps_most_recent(self) -> None:
+        observer = ChainObserver(max_traces=2)
+        _record_trace(observer, "a")
+        _record_trace(observer, "b")
+        _record_trace(observer, "c")
+        assert len(observer) == 2
+        assert [t.steps[0].tool_name for t in observer.traces] == ["b", "c"]
+
+    def test_invalid_max_traces_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_traces must be >= 1"):
+            ChainObserver(max_traces=0)
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestFlows:
+    def test_detects_repeated_sequence(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "fetch", "validate", "transform")
+        suggestions = observer.suggest_flows(min_occurrences=3, min_length=2)
+        assert len(suggestions) == 1
+        top = suggestions[0]
+        assert top.tools == ("fetch", "validate", "transform")
+        assert top.occurrences == 3
+        assert top.traces_with_pattern == 3
+        assert top.confidence == 1.0
+        assert isinstance(top.flow, Flow)
+
+    def test_no_patterns_below_threshold(self) -> None:
+        observer = ChainObserver()
+        _record_trace(observer, "a", "b")
+        _record_trace(observer, "a", "b")
+        assert observer.suggest_flows(min_occurrences=3) == []
+
+    def test_confidence_reflects_start_tool_frequency(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "fetch", "validate")
+        # ``fetch`` also appears alone in a fourth trace → 3/4 = 0.75.
+        _record_trace(observer, "fetch")
+        suggestion = observer.suggest_flows(min_occurrences=3, min_length=2)[0]
+        assert suggestion.tools == ("fetch", "validate")
+        assert suggestion.confidence == 0.75
+
+    def test_collapse_subsumed_drops_dominated_subpatterns(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "a", "b", "c")
+        collapsed = observer.suggest_flows(min_occurrences=3, min_length=2)
+        assert [s.tools for s in collapsed] == [("a", "b", "c")]
+
+    def test_collapse_disabled_keeps_subpatterns(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "a", "b", "c")
+        kept = observer.suggest_flows(min_occurrences=3, min_length=2, collapse_subsumed=False)
+        patterns = {s.tools for s in kept}
+        assert ("a", "b", "c") in patterns
+        assert ("a", "b") in patterns
+        assert ("b", "c") in patterns
+
+    def test_sorted_by_occurrence_then_length(self) -> None:
+        observer = ChainObserver()
+        for _ in range(5):
+            _record_trace(observer, "x", "y")
+        for _ in range(3):
+            _record_trace(observer, "p", "q", "r")
+        suggestions = observer.suggest_flows(min_occurrences=3, min_length=2)
+        assert suggestions[0].tools == ("x", "y")  # 5 > 3 occurrences
+        assert suggestions[1].tools == ("p", "q", "r")
+
+    def test_max_length_caps_pattern_size(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "a", "b", "c")
+        suggestions = observer.suggest_flows(
+            min_occurrences=3, min_length=2, max_length=2, collapse_subsumed=False
+        )
+        assert all(len(s.tools) == 2 for s in suggestions)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"min_occurrences": 0}, "min_occurrences must be >= 1"),
+            ({"min_length": 0}, "min_length must be >= 1"),
+            ({"min_length": 3, "max_length": 2}, "max_length must be >= min_length"),
+        ],
+    )
+    def test_invalid_arguments_rejected(self, kwargs: dict[str, int], match: str) -> None:
+        observer = ChainObserver()
+        _record_trace(observer, "a", "b", "c")
+        with pytest.raises(ValueError, match=match):
+            observer.suggest_flows(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Generated flow shape + governance gate
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestedFlow:
+    def test_input_mapping_auto_wired_from_observed_io(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            observer.record("fetch", {"url": "u"}, {"body": "b"})
+            observer.record("parse", {"body": "b"}, {"items": [1]})
+            observer.end_trace()
+        flow = observer.suggest_flows(min_occurrences=3, min_length=2)[0].flow
+        # First step pulls all observed inputs from the initial context.
+        assert flow.steps[0].input_mapping == {"url": "url"}
+        # Downstream step pulls only fields produced upstream.
+        assert flow.steps[1].input_mapping == {"body": "body"}
+
+    def test_generated_flow_is_reviewable_metadata(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "a", "b")
+        flow = observer.suggest_flows(min_occurrences=3, min_length=2)[0].flow
+        assert flow.name == "suggested__a__b"
+        assert flow.version == "0.0.0"
+        assert "seen 3" in flow.description
+
+    def test_suggestions_are_not_auto_registered(self) -> None:
+        observer = ChainObserver()
+        for _ in range(3):
+            _record_trace(observer, "a", "b")
+        suggestion = observer.suggest_flows(min_occurrences=3, min_length=2)[0]
+        registry = FlowRegistry()
+        # The observer never touches a registry; promotion is explicit.
+        assert registry.list_flows() == []
+        registry.register_flow(suggestion.flow)
+        assert len(registry.list_flows()) == 1
+
+    def test_estimated_llm_calls_avoided(self) -> None:
+        observer = ChainObserver()
+        for _ in range(4):
+            _record_trace(observer, "a", "b", "c")
+        suggestion = observer.suggest_flows(min_occurrences=3, min_length=2)[0]
+        assert isinstance(suggestion, FlowSuggestion)
+        # 3 tools x 4 occurrences.
+        assert suggestion.estimated_llm_calls_avoided == 12

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from chainweaver.flow import Flow
@@ -152,7 +154,7 @@ class TestSuggestFlows:
             ({"min_length": 3, "max_length": 2}, "max_length must be >= min_length"),
         ],
     )
-    def test_invalid_arguments_rejected(self, kwargs: dict[str, int], match: str) -> None:
+    def test_invalid_arguments_rejected(self, kwargs: dict[str, Any], match: str) -> None:
         observer = ChainObserver()
         _record_trace(observer, "a", "b", "c")
         with pytest.raises(ValueError, match=match):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -20,7 +20,7 @@ from chainweaver import (
 )
 
 # ---------------------------------------------------------------------------
-# Tool fixtures (schema-compatible chain: double -> add_one)
+# Tool fixtures (schema-compatible flow: double -> add_one)
 # ---------------------------------------------------------------------------
 
 
@@ -104,6 +104,22 @@ class TestProposalPipeline:
         assert metrics.flows_promoted == 1
         assert metrics.total_llm_calls_avoided == proposal.estimated_llm_calls_avoided
         assert service.list_proposals(status=ProposalStatus.APPROVED)[0].id == proposal.id
+
+    def test_approve_is_idempotent_when_flow_already_registered(self) -> None:
+        # A flow promoted out-of-band (already in the registry) must not be
+        # double-counted in metrics when its pending proposal is approved.
+        registry = FlowRegistry()
+        service = ChainWeaverService(registry=registry)
+        _observe_pattern(service, 3, "a", "b")
+        proposal = service.trigger_analysis()[0]
+        registry.register_flow(proposal.flow)  # promote out-of-band
+
+        approved = service.approve(proposal.id)
+
+        assert approved.status is ProposalStatus.APPROVED
+        metrics = service.metrics
+        assert metrics.flows_promoted == 0
+        assert metrics.total_llm_calls_avoided == 0
 
     def test_reject_keeps_flow_out_of_registry(self) -> None:
         registry = FlowRegistry()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,341 @@
+"""Tests for the continuous analysis service (issue #101)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from chainweaver import (
+    ChainObserver,
+    ChainWeaverService,
+    FlowRegistry,
+    ProposalStatus,
+    ServiceConfig,
+    ServiceEvent,
+    ServiceProposal,
+    Tool,
+)
+
+# ---------------------------------------------------------------------------
+# Tool fixtures (schema-compatible chain: double -> add_one)
+# ---------------------------------------------------------------------------
+
+
+class NumberIn(BaseModel):
+    number: int
+
+
+class ValueOut(BaseModel):
+    value: int
+
+
+class ValueIn(BaseModel):
+    value: int
+
+
+def _double_fn(inp: NumberIn) -> dict[str, Any]:
+    return {"value": inp.number * 2}
+
+
+def _add_one_fn(inp: ValueIn) -> dict[str, Any]:
+    return {"value": inp.value + 1}
+
+
+def _double() -> Tool:
+    return Tool(
+        name="double",
+        description="Doubles a number.",
+        input_schema=NumberIn,
+        output_schema=ValueOut,
+        fn=_double_fn,
+    )
+
+
+def _add_one() -> Tool:
+    return Tool(
+        name="add_one",
+        description="Adds one.",
+        input_schema=ValueIn,
+        output_schema=ValueOut,
+        fn=_add_one_fn,
+    )
+
+
+def _observe_pattern(service: ChainWeaverService, times: int, *tools: str) -> None:
+    for _ in range(times):
+        for tool in tools:
+            service.record(tool, {f"{tool}_in": 1}, {f"{tool}_out": 2})
+        service.end_trace()
+
+
+# ---------------------------------------------------------------------------
+# Observer pass -> proposal -> governance
+# ---------------------------------------------------------------------------
+
+
+class TestProposalPipeline:
+    def test_traces_flow_into_proposals(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        _observe_pattern(service, 3, "fetch", "validate", "transform")
+        created = service.trigger_analysis()
+        assert [p.flow.name for p in created] == ["suggested__fetch__validate__transform"]
+        assert created[0].source == "observer"
+        assert created[0].occurrences == 3
+
+    def test_proposals_are_not_auto_registered(self) -> None:
+        registry = FlowRegistry()
+        service = ChainWeaverService(registry=registry)
+        _observe_pattern(service, 3, "a", "b")
+        service.trigger_analysis()
+        # Governance gate: nothing reaches the registry without approval.
+        assert registry.list_flows() == []
+
+    def test_approve_promotes_flow_and_updates_metrics(self) -> None:
+        registry = FlowRegistry()
+        service = ChainWeaverService(registry=registry)
+        _observe_pattern(service, 3, "a", "b")
+        proposal = service.trigger_analysis()[0]
+        service.approve(proposal.id)
+        assert [f.name for f in registry.list_flows()] == ["suggested__a__b"]
+        metrics = service.metrics
+        assert metrics.flows_promoted == 1
+        assert metrics.total_llm_calls_avoided == proposal.estimated_llm_calls_avoided
+        assert service.list_proposals(status=ProposalStatus.APPROVED)[0].id == proposal.id
+
+    def test_reject_keeps_flow_out_of_registry(self) -> None:
+        registry = FlowRegistry()
+        service = ChainWeaverService(registry=registry)
+        _observe_pattern(service, 3, "a", "b")
+        proposal = service.trigger_analysis()[0]
+        service.reject(proposal.id)
+        assert registry.list_flows() == []
+        assert service.list_proposals(status=ProposalStatus.REJECTED)[0].id == proposal.id
+
+    def test_approving_non_pending_raises(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        _observe_pattern(service, 3, "a", "b")
+        proposal = service.trigger_analysis()[0]
+        service.reject(proposal.id)
+        with pytest.raises(ValueError, match="not pending"):
+            service.approve(proposal.id)
+
+    def test_unknown_proposal_id_raises(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        with pytest.raises(KeyError, match="Unknown proposal id"):
+            service.approve("does-not-exist")
+
+    def test_reanalysis_dedupes_existing_proposals(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        _observe_pattern(service, 3, "a", "b")
+        first = service.trigger_analysis()
+        second = service.trigger_analysis()
+        assert len(first) == 1
+        assert second == []  # already pending → not re-proposed
+
+    def test_confidence_below_threshold_is_skipped(self) -> None:
+        # Pattern appears in 3 of many traces containing "a" → low confidence.
+        service = ChainWeaverService(
+            registry=FlowRegistry(),
+            config=ServiceConfig(min_trace_occurrences=3, min_determinism_score=0.9),
+        )
+        _observe_pattern(service, 3, "a", "b")
+        for _ in range(10):
+            service.record("a", {"a_in": 1}, {"a_out": 2})
+            service.end_trace()
+        created = service.trigger_analysis()
+        assert created == []  # confidence 3/13 < 0.9
+        assert service.metrics.patterns_detected >= 1  # candidate was seen
+
+
+# ---------------------------------------------------------------------------
+# Tool-change trigger + static analyzer pass
+# ---------------------------------------------------------------------------
+
+
+class TestToolChangeTrigger:
+    def test_tool_registration_triggers_static_analysis(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        service.register_tool(_double())
+        service.register_tool(_add_one())  # completes a schema-compatible chain
+        names = {p.flow.name for p in service.list_proposals()}
+        assert "suggested__double__add_one" in names
+        assert service.metrics.tools_monitored == 2
+
+    def test_analyze_on_tool_change_can_be_disabled(self) -> None:
+        service = ChainWeaverService(
+            registry=FlowRegistry(),
+            config=ServiceConfig(analyze_on_tool_change=False),
+        )
+        service.register_tool(_double())
+        service.register_tool(_add_one())
+        assert service.list_proposals() == []
+
+    def test_auto_approve_promotes_deterministic_chains(self) -> None:
+        registry = FlowRegistry()
+        service = ChainWeaverService(
+            registry=registry,
+            config=ServiceConfig(auto_approve_deterministic=True),
+        )
+        service.register_tool(_double())
+        service.register_tool(_add_one())
+        assert [f.name for f in registry.list_flows()] == ["suggested__double__add_one"]
+        assert service.metrics.flows_promoted == 1
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+class TestEvents:
+    def test_callbacks_fire_for_lifecycle_events(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        seen: list[tuple[str, dict[str, Any]]] = []
+        service.on_event(ServiceEvent.PROPOSAL_CREATED, lambda d: seen.append(("created", d)))
+        service.on_event(ServiceEvent.FLOW_PROMOTED, lambda d: seen.append(("promoted", d)))
+        _observe_pattern(service, 3, "a", "b")
+        proposal = service.trigger_analysis()[0]
+        service.approve(proposal.id)
+        kinds = [kind for kind, _ in seen]
+        assert "created" in kinds
+        assert "promoted" in kinds
+
+    def test_trace_recorded_event(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        counts: list[int] = []
+        service.on_event(
+            ServiceEvent.TRACE_RECORDED, lambda d: counts.append(d["traces_recorded"])
+        )
+        service.record("a", {"x": 1}, {"y": 1})
+        service.end_trace()
+        assert counts == [1]
+
+
+# ---------------------------------------------------------------------------
+# Config + background loop
+# ---------------------------------------------------------------------------
+
+
+class TestConfigAndLoop:
+    def test_max_pending_proposals_cap(self) -> None:
+        service = ChainWeaverService(
+            registry=FlowRegistry(),
+            config=ServiceConfig(max_pending_proposals=1, min_trace_occurrences=2),
+        )
+        _observe_pattern(service, 2, "a", "b")
+        _observe_pattern(service, 2, "c", "d")
+        created = service.trigger_analysis()
+        assert len(created) == 1
+        assert len(service.list_proposals(status=ProposalStatus.PENDING)) == 1
+
+    def test_llm_pass_skipped_without_llm_fn(self) -> None:
+        # enable_llm_proposals without an llm_fn must not raise or call out.
+        service = ChainWeaverService(
+            registry=FlowRegistry(),
+            config=ServiceConfig(enable_llm_proposals=True),
+        )
+        service.register_tool(_double())
+        # No llm_fn → the LLM pass is skipped; with a single tool the static
+        # analyzer pass yields nothing either. No crash, no proposals.
+        assert service.trigger_analysis() == []
+
+    def test_background_loop_runs_and_stops(self) -> None:
+        service = ChainWeaverService(
+            registry=FlowRegistry(),
+            config=ServiceConfig(analyze_interval_seconds=0.02, min_trace_occurrences=2),
+        )
+        _observe_pattern(service, 2, "a", "b")
+        with service:
+            assert service.is_running
+            deadline = time.time() + 2.0
+            while not service.list_proposals() and time.time() < deadline:
+                time.sleep(0.02)
+        assert not service.is_running
+        assert [p.flow.name for p in service.list_proposals()] == ["suggested__a__b"]
+
+    def test_double_run_raises(self) -> None:
+        service = ChainWeaverService(registry=FlowRegistry())
+        service.run()
+        try:
+            with pytest.raises(RuntimeError, match="already running"):
+                service.run()
+        finally:
+            service.stop()
+
+    def test_custom_observer_is_used(self) -> None:
+        observer = ChainObserver()
+        service = ChainWeaverService(registry=FlowRegistry(), observer=observer)
+        service.record("a", {"x": 1}, {"y": 1})
+        service.end_trace()
+        assert len(observer) == 1
+
+
+class _SearchIn(BaseModel):
+    query: str
+
+
+class _ResultsOut(BaseModel):
+    results: str
+
+
+class _SummaryOut(BaseModel):
+    summary: str
+
+
+_LLM_YAML = """
+proposals:
+  - flow:
+      name: search_summarize
+      version: "0.0.0"
+      description: Search then summarize.
+      steps:
+        - tool_name: search
+          input_mapping: {query: query}
+        - tool_name: summarize
+          input_mapping: {results: results}
+    rationale: A summary naturally follows a search.
+    confidence: 0.9
+"""
+
+
+def test_llm_pass_creates_proposals_when_enabled() -> None:
+    search = Tool(
+        name="search",
+        description="Search.",
+        input_schema=_SearchIn,
+        output_schema=_ResultsOut,
+        fn=lambda i: {"results": "r"},
+    )
+    summarize = Tool(
+        name="summarize",
+        description="Summarize.",
+        input_schema=_ResultsOut,
+        output_schema=_SummaryOut,
+        fn=lambda i: {"summary": "s"},
+    )
+    service = ChainWeaverService(
+        registry=FlowRegistry(),
+        config=ServiceConfig(analyze_on_tool_change=False, enable_llm_proposals=True),
+        llm_fn=lambda prompt: _LLM_YAML,
+    )
+    service.register_tool(search)
+    service.register_tool(summarize)
+    created = service.trigger_analysis()
+    sources = {p.source for p in created}
+    assert "llm-compiler" in sources
+    llm_proposal = next(p for p in created if p.source == "llm-compiler")
+    assert llm_proposal.flow.name == "search_summarize"
+    assert llm_proposal.confidence == 0.9
+
+
+def test_service_proposal_is_serializable() -> None:
+    service = ChainWeaverService(registry=FlowRegistry())
+    _observe_pattern(service, 3, "a", "b")
+    proposal = service.trigger_analysis()[0]
+    assert isinstance(proposal, ServiceProposal)
+    # Pydantic round-trips cleanly for status reporting / persistence later.
+    dumped = proposal.model_dump_json()
+    assert "suggested__a__b" in dumped


### PR DESCRIPTION
## What changed

Implements the "trace → automatic flow suggestion" pipeline as one coherent feature across three issues. All new code is offline and deterministic (no LLM/network/randomness on the deterministic path), respecting the executor invariants.

### #78 — `ChainObserver` (`chainweaver/observer.py`)
- `ChainObserver.record()` / `end_trace()` / `suggest_flows()` + `FlowSuggestion`.
- Mines repeated contiguous tool sub-sequences (pure n-gram counting) across recorded traces, scores `confidence = traces_with_pattern / traces_with_start`, auto-wires `input_mapping` from observed I/O keys (mirrors `ChainAnalyzer.suggest_flows`), and ranks by occurrences. Sub-patterns dominated by a longer pattern are collapsed.
- Suggestions are **proposals** — never auto-registered. `max_traces` ring buffer.
- Reuses `TraceRecorder` (#11) for capture.

### #226 — `chainweaver record` CLI
- Replays a JSONL tool trace through `ChainObserver` and emits candidate `.flow.yaml` files ranked by projected LLM calls avoided (`len(tools) × occurrences`). `--output-dir` writes; omitting it is a dry run. Table + `--format json`.
- Trace format: one JSON object per line, grouped into traces by `trace_id` (default trace when absent); accepts `tool`/`tool_name`, optional `inputs`/`outputs`.

### #101 — `ChainWeaverService` (`chainweaver/service.py`)
- Ties `ChainObserver` (runtime), `ChainAnalyzer` (static, built on demand from monitored tools), and an opt-in offline LLM proposer (#28) into a continuous **analyze → observe → propose → govern → promote** loop.
- `ServiceConfig` (triggers/thresholds/feature flags), `ServiceMetrics` (patterns detected, flows promoted, LLM calls avoided), `ServiceProposal`, `ServiceEvent`, `ProposalStatus`.
- **In-process governance gate**: every candidate is a *pending* proposal; nothing reaches the registry without `approve()`. `auto_approve_deterministic` is **off by default**.
- Event callbacks (`on_event`/`emit`), background thread (`run`/`stop`, context manager), thread-safe state, de-dup against the registry + live proposals.
- `chainweaver service` CLI: one-shot analyze pass reporting proposals + metrics.

## Why
The recommended triage group: #78 is the engine, #226 the CLI on-ramp, #101 the orchestration layer — all on the same trace→proposal→governance path, reusing existing modules. Productizes ChainWeaver's flagship "compile-away-LLM-calls" workflow.

## Scope decisions
- **`GovernanceManager` (#13) does not exist** and its module name is reserved. Rather than scope-creep into #13, #101 ships a minimal in-process proposal gate (the "minimum viable service" the issue describes); full `GovernanceManager` integration is deferred to #13.
- Cross-process `service` `approve`/`reject` needs proposal persistence (#16) and is intentionally out of scope for the CLI — drive that via the `ChainWeaverService` Python API.
- No new runtime dependency (YAML output uses the existing optional `[yaml]` extra via `flow_to_yaml`).

## How verified
- `ruff check chainweaver/ tests/ examples/` — All checks passed
- `ruff format --check chainweaver/ tests/ examples/` — 182 files already formatted
- `python -m mypy chainweaver/ tests/` — Success, 147 source files
- `python -m pytest tests/` — **1337 passed**, total coverage **91.89%** (observer.py 100%, service.py 99%)
- `pytest -m conformance` — 9 passed (weaver-spec gate)
- New examples run clean; public-API snapshot regenerated.

## Tests added
`tests/test_observer.py` (21), `tests/test_cli_record.py` (15), `tests/test_service.py` (21), `tests/test_cli_service.py` (6).

## Docs (governance triggers honored)
AGENTS.md repo map + CLI line; architecture.md boundaries table + `observer.py` marked delivered in the reserved-names table; `docs/cli.md` `record` + `service` sections; README "Runtime learning" section.

## Risks / caveats
- `#101` is large; LLM proposal path is opt-in and exercised by a test with a fake `llm_fn`.
- Background-thread loop is intentionally minimal; tests drive the pipeline via direct method calls (no timing reliance) plus one start/stop integration test.

Closes #78, closes #226, closes #101.

https://claude.ai/code/session_015SVwwPVkMKZwvhudKHzyN4

---
_Generated by [Claude Code](https://claude.ai/code/session_015SVwwPVkMKZwvhudKHzyN4)_