### PR TITLE
feat: chainweaver serve MCP server + integrations distribution (#230, #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`chainweaver serve` — first-class MCP server** (#230): a new CLI command that
+  loads a flow file plus its `--tools` modules and exposes the compiled flow as MCP
+  tools over `stdio` / `sse` / `streamable-http`, so MCP-aware agents call a whole
+  flow as one deterministic tool. Wraps the existing `chainweaver.mcp.FlowServer`
+  (#72); the MCP SDK stays behind the `chainweaver[mcp]` extra via a guarded lazy
+  import, so the base CLI is unaffected. New docs page
+  [`docs/mcp-server.md`](docs/mcp-server.md), a ready-to-submit MCP registry manifest
+  (`server.json`), and a distribution/listing checklist
+  ([`docs/distribution.md`](docs/distribution.md)).
+- **README Integrations section + verified recipe matrix** (#231): a consolidated
+  README "Integrations" section surfacing the MCP server, MCP adapter, and the
+  LangGraph / OpenAI Agents SDK / LangChain / LlamaIndex entry points. Recipes and
+  the MCP server verified runnable against current framework versions (mcp 1.27.2,
+  langgraph 1.2.4, openai-agents 0.17.4, langchain-core 1.4.0, llama-index-core
+  0.14.22), recorded in `docs/distribution.md`.
 - **Real Weaver Stack interop** (#233, #234): `chainweaver.integrations.weaver_spec`
   now consumes the published [`weaver-contracts`](https://pypi.org/project/weaver-contracts/)
   package directly (behind the `chainweaver[weaver-stack]` extra, pinned

--- a/README.md
+++ b/README.md
@@ -738,6 +738,28 @@ idempotency of side-effect tools, MCP authorisation).
 
 ---
 
+## Integrations
+
+ChainWeaver plugs into the MCP ecosystem and the major agent frameworks. Every
+entry point below ships with a runnable example or recipe.
+
+| Integration | What it does | Entry point |
+|---|---|---|
+| **MCP server** (outbound) | Expose your flows as MCP tools — agents call a whole compiled flow as one deterministic tool | [`chainweaver serve`](docs/cli.md) · [guide](docs/mcp-server.md) · [`FlowServer`](chainweaver/mcp/server.py) |
+| **MCP adapter** (inbound) | Wrap tools advertised by an MCP server as ChainWeaver `Tool`s | `chainweaver.mcp.MCPToolAdapter` |
+| **LangGraph** | Call a flow from a LangGraph node | [recipe](docs/cookbook/langgraph-node.md) · `examples/integrations/langgraph_node.py` |
+| **OpenAI Agents SDK** | Expose a flow as an Agents SDK `FunctionTool` | [recipe](docs/cookbook/openai-agents-tool.md) · `examples/integrations/openai_agents_tool.py` |
+| **LangChain / LlamaIndex** | Bidirectional tool bridges | `chainweaver.integrations.{langchain,llamaindex}` (see below) |
+
+Install the extra you need: `pip install 'chainweaver[mcp]'` (or `langgraph`,
+`openai-agents`, `langchain`, `llamaindex`). Importing any integration without its
+extra raises a clear `ImportError`.
+
+Looking to publish or list ChainWeaver in the MCP registry / awesome-lists / framework
+directories? See [`docs/distribution.md`](docs/distribution.md).
+
+---
+
 ## Error Handling
 
 All errors are typed and traceable:
@@ -1014,6 +1036,11 @@ invoked from the repository root.
 chainweaver run examples/double_add_format.flow.yaml \
     --tools examples.simple_linear_flow \
     --input '{"number": 5}'
+
+# Serve a flow as MCP tools (needs chainweaver[mcp]) — agents call the whole
+# compiled flow as one deterministic tool. See docs/mcp-server.md.
+chainweaver serve examples/double_add_format.flow.yaml \
+    --tools examples.simple_linear_flow
 
 # Validate a flow file (used by CI gates and editor tooling).
 chainweaver validate flows/etl.flow.yaml

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -19,9 +19,9 @@ Available commands
 - ``chainweaver run <file>`` — load a flow file from disk, register tools
   from one or more Python modules, and execute the flow (issue #129).
 - ``chainweaver serve <file>`` — load a flow file + tools and expose the
-  compiled flow as MCP tools over stdio/SSE/HTTP, so MCP-aware agents call
-  the whole flow as one deterministic tool (issues #72, #230). Requires
-  the ``mcp`` extra.
+  compiled flow as MCP tools over stdio/SSE/streamable-HTTP, so MCP-aware
+  agents call the whole flow as one deterministic tool (issues #72, #230).
+  Requires the ``mcp`` extra.
 - ``chainweaver profile <traces...>`` — analyze one or more
   ``ExecutionResult`` JSON files; surface bottlenecks, per-step p50/p95/p99,
   and per-step / per-tool reliability aggregates for retries, skips,

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -18,6 +18,10 @@ Available commands
   an image (issue #46).
 - ``chainweaver run <file>`` — load a flow file from disk, register tools
   from one or more Python modules, and execute the flow (issue #129).
+- ``chainweaver serve <file>`` — load a flow file + tools and expose the
+  compiled flow as MCP tools over stdio/SSE/HTTP, so MCP-aware agents call
+  the whole flow as one deterministic tool (issues #72, #230). Requires
+  the ``mcp`` extra.
 - ``chainweaver profile <traces...>`` — analyze one or more
   ``ExecutionResult`` JSON files; surface bottlenecks, per-step p50/p95/p99,
   and per-step / per-tool reliability aggregates for retries, skips,
@@ -108,6 +112,7 @@ from chainweaver.viz import _render_step_bar_chart, flow_to_ascii, flow_to_dot
 if TYPE_CHECKING:
     from chainweaver.attest import AttestationReport
     from chainweaver.fuzz import FlowProperty, FuzzReport
+    from chainweaver.mcp import FlowServer
 
 app = typer.Typer(
     name="chainweaver",
@@ -623,6 +628,147 @@ def run_command(
 
     if not result.success:
         raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# serve command (issues #72, #230)
+# ---------------------------------------------------------------------------
+
+
+class ServeTransport(str, Enum):
+    """Transport options for ``chainweaver serve``.
+
+    Mirrors :data:`chainweaver.mcp.server.TransportName`.
+    """
+
+    STDIO = "stdio"
+    SSE = "sse"
+    STREAMABLE_HTTP = "streamable-http"
+
+
+_SERVE_FILE_ARG = typer.Argument(
+    ...,
+    help="Path to a .flow.yaml, .flow.yml, or .flow.json file to expose over MCP.",
+)
+_SERVE_TOOLS_OPTION = typer.Option(
+    [],
+    "--tools",
+    "-t",
+    help=(
+        "Python module path that exposes Tool instances at top level "
+        "(e.g. 'my_pkg.tools'). Repeatable."
+    ),
+)
+_SERVE_TRANSPORT_OPTION = typer.Option(
+    ServeTransport.STDIO,
+    "--transport",
+    case_sensitive=False,
+    help="MCP transport: 'stdio' (default), 'sse', or 'streamable-http'.",
+)
+_SERVE_NAME_OPTION = typer.Option(
+    "chainweaver",
+    "--name",
+    help="Server name advertised to MCP clients.",
+)
+_SERVE_PREFIX_OPTION = typer.Option(
+    "",
+    "--prefix",
+    help="Optional prefix for exposed tool names (e.g. 'cw' → 'cw__my_flow').",
+)
+
+
+def _import_flow_server() -> type[FlowServer]:
+    """Import :class:`~chainweaver.mcp.FlowServer`, guarding the optional extra.
+
+    The MCP SDK ships behind the ``chainweaver[mcp]`` extra, so the import is
+    deferred to call time — keeping the base CLI usable without it.  A missing
+    extra exits with code 1 and a clear remediation message instead of a raw
+    ``ImportError``.
+    """
+    try:
+        from chainweaver.mcp import FlowServer
+    except ImportError as exc:
+        typer.echo(
+            "chainweaver: the 'serve' command requires the MCP extra. "
+            "Install with: pip install 'chainweaver[mcp]'.",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+    return FlowServer
+
+
+def _build_flow_server(
+    flow_file: Path,
+    tools: list[str],
+    *,
+    name: str,
+    server_prefix: str,
+) -> FlowServer:
+    """Load *flow_file* + ``--tools`` modules and build a :class:`FlowServer`.
+
+    Factored out of :func:`serve_command` so tests can assert the exposed
+    tool set without entering the blocking transport loop.  Mirrors the
+    flow/tool loading performed by ``run`` (issue #129).
+
+    Exit codes match the CLI contract: ``2`` for a missing flow file or
+    un-importable tools module, ``1`` for a malformed flow file or a missing
+    ``mcp`` extra.
+    """
+    flow_server_cls = _import_flow_server()
+
+    _require_existing_file(flow_file)
+    try:
+        flow = _load_flow_file(flow_file)
+    except FlowSerializationError as exc:
+        typer.echo(f"chainweaver: {exc.detail}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    executor = FlowExecutor(registry=registry)
+
+    seen_tool_names: set[str] = set()
+    for module_name in tools:
+        for tool_obj in _import_tools_from(module_name):
+            if tool_obj.name in seen_tool_names:
+                continue
+            executor.register_tool(tool_obj)
+            seen_tool_names.add(tool_obj.name)
+
+    return flow_server_cls(executor, name=name, server_prefix=server_prefix)
+
+
+@app.command("serve")
+def serve_command(
+    flow_file: Path = _SERVE_FILE_ARG,
+    tools: list[str] = _SERVE_TOOLS_OPTION,
+    transport: ServeTransport = _SERVE_TRANSPORT_OPTION,
+    name: str = _SERVE_NAME_OPTION,
+    prefix: str = _SERVE_PREFIX_OPTION,
+) -> None:
+    """Expose a flow's compiled tools over MCP (issues #72, #230).
+
+    Loads ``flow_file``, registers the tools from each ``--tools`` module,
+    and mounts the flow on a :class:`~chainweaver.mcp.FlowServer` so
+    MCP-aware agents see the whole compiled flow as a single deterministic
+    tool — the inverse of consuming MCP tools into a flow.  The process then
+    blocks serving the chosen transport (Ctrl-C to stop).
+
+    The startup banner is written to stderr so the ``stdio`` transport keeps
+    stdout as a clean MCP wire channel.
+
+    Requires the ``mcp`` extra: ``pip install 'chainweaver[mcp]'``.
+
+    Exit codes: ``1`` = malformed flow file or missing ``mcp`` extra,
+    ``2`` = flow file not found or tools module not importable.
+    """
+    server = _build_flow_server(flow_file, tools, name=name, server_prefix=prefix)
+    typer.echo(
+        f"chainweaver: serving {len(server.registered_tool_names)} flow tool(s) "
+        f"over {transport.value}: {', '.join(server.registered_tool_names)}",
+        err=True,
+    )
+    server.serve(transport=transport.value)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,6 +195,36 @@ chainweaver run flows/etl.flow.yaml --tools my_package.tools --input input.json 
 
 ---
 
+### `serve`
+
+Expose a flow as **MCP tools** over a chosen transport. Loads a flow file and its tool modules (exactly like `run`), mounts the flow on a [`FlowServer`](mcp-server.md), and serves it so MCP-aware agents call the whole compiled flow as a single deterministic tool. Requires the `mcp` extra (`pip install 'chainweaver[mcp]'`).
+
+```
+chainweaver serve <flow_file> [--tools module] [--transport stdio|sse|streamable-http] [--name NAME] [--prefix PREFIX]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tools` / `-t` | (none) | Python module path to import tools from (repeatable) |
+| `--transport` | `stdio` | MCP transport: `stdio`, `sse`, or `streamable-http` |
+| `--name` | `chainweaver` | Server name advertised to MCP clients |
+| `--prefix` | (none) | Prefix for exposed tool names (e.g. `cw` → `cw__my_flow`) |
+
+The startup banner is written to **stderr**, keeping stdout a clean MCP wire channel under `stdio`. The process blocks serving the transport until interrupted (Ctrl-C).
+
+**Exit codes**: `0` = clean shutdown, `1` = malformed flow file or missing `mcp` extra, `2` = flow file not found or tools module not importable.
+
+**Example**:
+
+```bash
+# Runnable from the repository root — flow file and tools both ship in examples/:
+chainweaver serve examples/double_add_format.flow.yaml --tools examples.simple_linear_flow
+```
+
+See [Use ChainWeaver as an MCP server](mcp-server.md) for the full guide.
+
+---
+
 ### `profile`
 
 Analyze one or more `ExecutionResult` JSON files. For a single file, surfaces per-step duration and bottlenecks. For multiple files, adds p50/p95/p99 statistics across runs. Every output (single or multi) also carries per-step and per-tool **reliability aggregates** — retries, skips, fallbacks, failures, and cache hits — so you can see at a glance which step or tool is responsible for instability.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,73 @@
+# Distribution & ecosystem listings
+
+ChainWeaver's discovery strategy is **passive reach**: be listed where its exact
+audience already looks — the MCP ecosystem and the major agent-framework
+integration directories. This page is the operational checklist for those
+submissions, plus the prepared copy to paste into each one.
+
+The in-repo artifacts (the [`serve` command](cli.md#serve), the
+[MCP server guide](mcp-server.md), the [`server.json`](#mcp-registry) manifest, and
+the verified recipes below) are maintained here. The external submissions are
+maintainer actions in *other* projects' repos and are tracked by
+[#230](https://github.com/dgenio/ChainWeaver/issues/230) and
+[#231](https://github.com/dgenio/ChainWeaver/issues/231).
+
+## Verified integration matrix
+
+Recipes and the MCP server are verified runnable against these versions
+(`python examples/...` + `pytest tests/test_integrations_*.py tests/test_mcp_server.py`):
+
+| Integration | Entry point | Verified against |
+|---|---|---|
+| MCP server (outbound) | `chainweaver serve` / `chainweaver.mcp.FlowServer` | `mcp` 1.27.2 |
+| LangGraph node | `examples/integrations/langgraph_node.py`, [recipe](cookbook/langgraph-node.md) | `langgraph` 1.2.4 |
+| OpenAI Agents SDK tool | `examples/integrations/openai_agents_tool.py`, [recipe](cookbook/openai-agents-tool.md) | `openai-agents` 0.17.4 |
+| LangChain bridge | `chainweaver.integrations.langchain` | `langchain-core` 1.4.0 |
+| LlamaIndex bridge | `chainweaver.integrations.llamaindex` | `llama-index-core` 0.14.22 |
+
+Re-run the verification before each submission and update this table with the
+versions tested.
+
+## MCP registry
+
+A draft manifest ships at the repo root as
+[`server.json`](https://github.com/dgenio/ChainWeaver/blob/main/server.json),
+conforming to the
+[`2025-12-11` server schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).
+
+**Before submitting:**
+
+- [ ] Validate and publish with the official
+      [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) tool —
+      it validates `server.json` against the live schema on publish.
+- [ ] Confirm the `version` field matches the published PyPI release.
+- [ ] Because `serve` needs a flow-file argument and the `mcp` extra, finalize the
+      package launch in the manifest (e.g. a `--from 'chainweaver[mcp]'` runtime
+      argument for `uvx`, plus the flow path as a templated `packageArguments`
+      value) so a fresh client can launch a working server.
+
+## awesome-* lists
+
+Open a PR adding ChainWeaver to each list. Suggested entry:
+
+> **[ChainWeaver](https://github.com/dgenio/ChainWeaver)** — Deterministic
+> orchestration layer for MCP agents. Compiles tool chains into schema-validated
+> flows and exposes each flow as a single MCP tool — no LLM at build or run time.
+
+- [ ] [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)
+- [ ] `awesome-ai-agents`
+- [ ] `awesome-llm-apps`
+
+## Framework ecosystem directories
+
+For each framework, verify the recipe against the current version (table above),
+then submit to its community/integration surface:
+
+- [ ] **LangGraph / LangChain** — community/ecosystem integration listing, linking
+      [the LangGraph node recipe](cookbook/langgraph-node.md).
+- [ ] **OpenAI Agents SDK** — community/showcase resources, linking
+      [the OpenAI Agents tool recipe](cookbook/openai-agents-tool.md).
+- [ ] **LlamaIndex** — integrations/community listing, linking the LlamaIndex
+      bridge.
+
+Once a listing is accepted, link it from the README **Integrations** section.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -51,7 +51,7 @@ conforming to the
 Open a PR adding ChainWeaver to each list. Suggested entry:
 
 > **[ChainWeaver](https://github.com/dgenio/ChainWeaver)** — Deterministic
-> orchestration layer for MCP agents. Compiles tool chains into schema-validated
+> orchestration layer for MCP agents. Compiles tool sequences into schema-validated
 > flows and exposes each flow as a single MCP tool — no LLM at build or run time.
 
 - [ ] [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,87 @@
+# Use ChainWeaver as an MCP server
+
+ChainWeaver is MCP-native in **both directions**:
+
+- **Inbound** — `chainweaver.mcp.MCPToolAdapter` wraps tools advertised by an
+  MCP server as ChainWeaver `Tool` objects so you can compose them into a flow.
+- **Outbound** — `FlowServer` exposes your **registered flows as MCP tools**, so an
+  MCP-aware agent (Claude Desktop, an IDE, another runtime) calls a whole compiled
+  flow as a *single deterministic tool*. An N-step flow collapses into one MCP wire
+  call — the headline "compiled, not interpreted" benefit.
+
+This page covers the **outbound** direction: turning ChainWeaver into an MCP server.
+
+!!! note "Requires the `mcp` extra"
+    The MCP server builds on the official [`mcp`](https://pypi.org/project/mcp/)
+    Python SDK (FastMCP):
+
+    ```bash
+    pip install 'chainweaver[mcp]'
+    ```
+
+## One command
+
+`chainweaver serve` loads a flow file and its tool modules (exactly like
+[`chainweaver run`](cli.md#run)) and serves the flow over MCP:
+
+```bash
+# Flow file and tools both ship in examples/ — runnable from the repo root.
+chainweaver serve examples/double_add_format.flow.yaml --tools examples.simple_linear_flow
+```
+
+This starts a `stdio` MCP server advertising one tool per registered flow. The
+startup banner goes to **stderr**, so under `stdio` your stdout stays a clean MCP
+channel. Use `--transport sse` or `--transport streamable-http` for network
+transports, `--name` to set the advertised server name, and `--prefix` to namespace
+the exposed tool names. Press Ctrl-C to stop.
+
+See the [`serve` CLI reference](cli.md#serve) for every flag and the exit-code
+contract.
+
+## Minimal client config
+
+Point any MCP client at the command. For a stdio client (e.g. a
+`claude_desktop_config.json`-style config):
+
+```json
+{
+  "mcpServers": {
+    "chainweaver": {
+      "command": "chainweaver",
+      "args": [
+        "serve",
+        "/abs/path/to/your.flow.yaml",
+        "--tools", "your_package.tools"
+      ]
+    }
+  }
+}
+```
+
+The client then sees each registered flow as a callable MCP tool, with an
+`inputSchema` (and, when determinable, an `outputSchema`) derived from the flow's
+own schemas.
+
+## Programmatic use
+
+When you already build a `FlowExecutor` in Python, mount it directly:
+
+```python
+from chainweaver.mcp import FlowServer
+
+server = FlowServer(executor, name="my-flows")
+print(server.registered_tool_names)  # one entry per exposed flow
+server.serve(transport="stdio")      # or "sse" / "streamable-http"
+```
+
+`FlowServer.fastmcp` exposes the underlying `FastMCP` instance if you want to add
+extra MCP capabilities (resources, prompts, raw tools) on the same transport. A
+full end-to-end demo that talks to the server with a real MCP client lives in
+`examples/mcp_flow_server.py`.
+
+## Publishing to the MCP ecosystem
+
+A ready-to-submit MCP registry manifest ships at
+[`server.json`](https://github.com/dgenio/ChainWeaver/blob/main/server.json). See
+[Distribution & ecosystem listings](distribution.md) for the registry and
+awesome-list submission checklist.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,9 @@ nav:
           - Offline policy evaluation (skdr-eval): cookbook/policy-eval-skdr.md
           - Offline LLM-assisted flow proposals: cookbook/offline-llm-flow-proposals.md
           - Offline tool-description optimizer: cookbook/offline-description-optimizer.md
+  - Integrations:
+      - Use ChainWeaver as an MCP server: mcp-server.md
+      - Distribution & ecosystem listings: distribution.md
   - Reference:
       - CLI: cli.md
       - Error table: reference/error-table.md

--- a/server.json
+++ b/server.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.dgenio/chainweaver",
+  "description": "Deterministic orchestration layer for MCP agents. Compiles tool chains into schema-validated flows and exposes each flow as a single MCP tool — no LLM at build or run time.",
+  "version": "0.11.0",
+  "repository": {
+    "url": "https://github.com/dgenio/ChainWeaver",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "chainweaver",
+      "version": "0.11.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        },
+        {
+          "type": "positional",
+          "valueHint": "flow_file",
+          "description": "Path to a .flow.yaml/.flow.json file to expose as MCP tools.",
+          "isRequired": true
+        },
+        {
+          "type": "named",
+          "name": "--tools",
+          "description": "Python module path exposing Tool instances at top level. Repeatable.",
+          "isRepeated": true
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dgenio/chainweaver",
-  "description": "Deterministic orchestration layer for MCP agents. Compiles tool chains into schema-validated flows and exposes each flow as a single MCP tool — no LLM at build or run time.",
+  "description": "Deterministic orchestration layer for MCP agents. Compiles tool sequences into schema-validated flows and exposes each flow as a single MCP tool — no LLM at build or run time.",
   "version": "0.11.0",
   "repository": {
     "url": "https://github.com/dgenio/ChainWeaver",

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -30,6 +30,20 @@ class TestServeCommandRegistration:
         names = [c.name for c in app.registered_commands]
         assert "serve" in names
 
+    def test_transport_enum_matches_library_literal(self) -> None:
+        """``ServeTransport`` must stay in sync with ``mcp.server.TransportName``.
+
+        The CLI mirrors the library's transport list as an ``Enum`` (typer needs
+        an enum for the option); this guard fails if a transport is added to one
+        source without the other.
+        """
+        pytest.importorskip("mcp")
+        from typing import get_args
+
+        from chainweaver.mcp.server import TransportName
+
+        assert {t.value for t in cli.ServeTransport} == set(get_args(TransportName))
+
 
 class TestBuildFlowServer:
     def test_exposes_one_tool_per_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -1,0 +1,92 @@
+"""Tests for the ``chainweaver serve`` MCP-server CLI command (issues #72, #230)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from chainweaver import cli
+from chainweaver.cli import app
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLE_FLOW = _REPO_ROOT / "examples" / "double_add_format.flow.yaml"
+
+
+class _FakeServer:
+    """Stand-in FlowServer that records ``serve`` calls instead of blocking."""
+
+    def __init__(self) -> None:
+        self.registered_tool_names = ["double_add_format"]
+        self.served_transport: str | None = None
+
+    def serve(self, transport: str = "stdio") -> None:
+        self.served_transport = transport
+
+
+class TestServeCommandRegistration:
+    def test_serve_is_a_registered_command(self) -> None:
+        names = [c.name for c in app.registered_commands]
+        assert "serve" in names
+
+
+class TestBuildFlowServer:
+    def test_exposes_one_tool_per_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.syspath_prepend(str(_REPO_ROOT))
+        server = cli._build_flow_server(
+            _EXAMPLE_FLOW,
+            ["examples.simple_linear_flow"],
+            name="cw-test",
+            server_prefix="",
+        )
+        assert server.registered_tool_names == ["double_add_format"]
+
+    def test_prefix_namespaces_tool_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.syspath_prepend(str(_REPO_ROOT))
+        server = cli._build_flow_server(
+            _EXAMPLE_FLOW,
+            ["examples.simple_linear_flow"],
+            name="cw-test",
+            server_prefix="cw",
+        )
+        assert server.registered_tool_names == ["cw__double_add_format"]
+
+    def test_missing_flow_file_exits_2(self, tmp_path: Path) -> None:
+        exit_code = cli.main(["serve", str(tmp_path / "nope.flow.yaml")])
+        assert exit_code == 2
+
+    def test_missing_mcp_extra_exits_1(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        def _raise_missing_extra() -> type:
+            typer.echo(
+                "chainweaver: the 'serve' command requires the MCP extra. "
+                "Install with: pip install 'chainweaver[mcp]'.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        monkeypatch.setattr(cli, "_import_flow_server", _raise_missing_extra)
+        exit_code = cli.main(["serve", str(_EXAMPLE_FLOW)])
+        assert exit_code == 1
+        assert "requires the MCP extra" in capsys.readouterr().err
+
+
+class TestServeCommandWiring:
+    def test_serves_chosen_transport_and_banners_to_stderr(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fake = _FakeServer()
+        monkeypatch.setattr(cli, "_build_flow_server", lambda *a, **k: fake)
+        cli.serve_command(
+            flow_file=_EXAMPLE_FLOW,
+            tools=[],
+            transport=cli.ServeTransport.SSE,
+            name="chainweaver",
+            prefix="",
+        )
+        assert fake.served_transport == "sse"
+        err = capsys.readouterr().err
+        assert "double_add_format" in err
+        assert "over sse" in err


### PR DESCRIPTION
Finish the "ship + surface + submit" layer on top of the already-shipped
MCP FlowServer (#72) and framework recipes (#205, #206).

#230 — first-class MCP server:
- Add `chainweaver serve <flow_file> [--tools] [--transport] [--name]
  [--prefix]`: loads a flow file + tool modules (mirrors `run`) and exposes
  the compiled flow as MCP tools via FlowServer. The MCP SDK stays behind
  the `chainweaver[mcp]` extra through a guarded lazy import, so the base
  CLI is unaffected. Startup banner goes to stderr to keep stdio's stdout a
  clean MCP channel.
- New guide docs/mcp-server.md (one-command start + client config), a
  ready-to-submit MCP registry manifest (server.json, 2025-12-11 schema),
  and docs/distribution.md submission checklist.

#231 — ecosystem listings:
- New README "Integrations" section surfacing the MCP server, MCP adapter,
  and LangGraph / OpenAI Agents SDK / LangChain / LlamaIndex entry points.
- Verified recipes + server run against current versions (mcp 1.27.2,
  langgraph 1.2.4, openai-agents 0.17.4, langchain-core 1.4.0,
  llama-index-core 0.14.22), recorded in docs/distribution.md.

Docs nav, docs/cli.md `serve` reference, CHANGELOG, and tests added. The
external directory submissions (awesome-mcp-servers, MCP registry,
framework directories) are prepared as ready-to-submit artifacts; opening
those PRs in third-party repos remains a maintainer action.

https://claude.ai/code/session_0119KQ5znu2w4y2qPPyu1FbC