### PR TITLE
feat(mcp): migrate FlowServer to standalone fastmcp 3.x (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,8 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MCPToolAdapter` still imports `mcp.ClientSession`, and `fastmcp` re-uses
   `mcp.types.ToolAnnotations`. `FlowServer`'s public API is unchanged
   (constructor, `serve()`/`serve_async()`, `.fastmcp`, `.registered_tool_names`);
-  `.fastmcp` now returns a `fastmcp.FastMCP` instance. The base install is
-  unaffected.
+  `.fastmcp` now returns a `fastmcp.FastMCP` instance. Rationale (#243): the
+  FastMCP bundled in the `mcp` SDK is effectively frozen, while the standalone
+  [`fastmcp`](https://github.com/jlowin/fastmcp) (3.x) is where active
+  development continues — so this is a maintenance/longevity move that resolves
+  the #243 evaluation in favour of switching. The added dependency and its
+  transitive footprint land only in the opt-in `[mcp]`/`[dev]` extras; the base
+  install is unaffected.
 - **Weaver Stack types are now the upstream `weaver-contracts` dataclasses**
   (#233, breaking): the previous internal Pydantic mirror types
   (`SelectableItem`, `RoutingDecision`, `CapabilityToken`) are replaced by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP server now runs on standalone `fastmcp`** (#243, breaking for the
+  `[mcp]` extra): `chainweaver.mcp.FlowServer` migrated from the SDK-bundled
+  `mcp.server.fastmcp.FastMCP` to the standalone
+  [`fastmcp`](https://github.com/jlowin/fastmcp) package (3.x). The `[mcp]`
+  extra now installs `fastmcp>=3.4` alongside `mcp>=1.0` — the inbound
+  `MCPToolAdapter` still imports `mcp.ClientSession`, and `fastmcp` re-uses
+  `mcp.types.ToolAnnotations`. `FlowServer`'s public API is unchanged
+  (constructor, `serve()`/`serve_async()`, `.fastmcp`, `.registered_tool_names`);
+  `.fastmcp` now returns a `fastmcp.FastMCP` instance. The base install is
+  unaffected.
 - **Weaver Stack types are now the upstream `weaver-contracts` dataclasses**
   (#233, breaking): the previous internal Pydantic mirror types
   (`SelectableItem`, `RoutingDecision`, `CapabilityToken`) are replaced by the

--- a/chainweaver/mcp/server.py
+++ b/chainweaver/mcp/server.py
@@ -23,7 +23,10 @@ Each exposed flow advertises:
 Optional extra
 --------------
 
-Requires the official MCP SDK::
+Runs on the standalone `fastmcp <https://github.com/jlowin/fastmcp>`_
+package (issue #243).  The official ``mcp`` SDK is also pulled in by the
+extra for the inbound :mod:`chainweaver.mcp.adapter` (``mcp.ClientSession``)
+and for :class:`mcp.types.ToolAnnotations`, which ``fastmcp`` re-uses::
 
     pip install 'chainweaver[mcp]'
 
@@ -43,11 +46,12 @@ from chainweaver.exceptions import FlowExecutionError
 from chainweaver.flow import DAGFlow, Flow
 
 try:  # Optional dependency.
-    from mcp.server.fastmcp import FastMCP
+    from fastmcp import FastMCP
+    from fastmcp.tools import Tool as _FastMCPTool
     from mcp.types import ToolAnnotations
 except ImportError as exc:  # pragma: no cover — depends on install layout
     raise ImportError(
-        "chainweaver.mcp.server requires the 'mcp' Python SDK. "
+        "chainweaver.mcp.server requires the 'fastmcp' package and the 'mcp' SDK. "
         "Install with: pip install 'chainweaver[mcp]'."
     ) from exc
 
@@ -167,13 +171,20 @@ class FlowServer:
             idempotentHint=getattr(flow, "deterministic", False),
         )
 
-        self._mcp.add_tool(
+        # fastmcp 3.x takes a pre-built ``Tool`` rather than ``add_tool``
+        # keyword arguments.  Passing ``output_schema`` as a JSON-Schema dict
+        # enables structured output; ``None`` disables it (the result then
+        # lands in the content text block as JSON) — matching the behaviour of
+        # the old ``structured_output`` flag.
+        out_schema = output_schema.model_json_schema() if output_schema is not None else None
+        tool = _FastMCPTool.from_function(
             flow_tool,
             name=mcp_name,
             description=flow.description or f"ChainWeaver flow '{flow.name}'.",
             annotations=annotations,
-            structured_output=output_schema is not None,
+            output_schema=out_schema,
         )
+        self._mcp.add_tool(tool)
         self._registered_tool_names.append(mcp_name)
 
     def serve(self, transport: TransportName = "stdio") -> None:
@@ -185,30 +196,26 @@ class FlowServer:
                 or ``"streamable-http"``.
 
         This delegates to :meth:`FastMCP.run` and blocks the calling
-        thread for the lifetime of the server.  For programmatic
-        embedding inside an existing event loop, see :meth:`serve_async`.
+        thread for the lifetime of the server.  ``show_banner`` is
+        disabled so nothing is written to stdout — a banner there would
+        corrupt the stdio MCP framing.  For programmatic embedding inside
+        an existing event loop, see :meth:`serve_async`.
         """
-        self._mcp.run(transport=transport)
+        self._mcp.run(transport=transport, show_banner=False)
 
     async def serve_async(self, transport: TransportName = "stdio") -> None:
         """Async variant of :meth:`serve`.
 
-        Picks the right FastMCP coroutine based on *transport*.  Use
-        this from inside an existing ``asyncio`` event loop (e.g. when
-        embedding the MCP server in a larger async application).
+        Delegates to :meth:`FastMCP.run_async`, which dispatches on
+        *transport* internally.  Use this from inside an existing
+        ``asyncio`` event loop (e.g. when embedding the MCP server in a
+        larger async application).
 
         Args:
             transport: One of ``"stdio"``, ``"sse"``, or
                 ``"streamable-http"``.
         """
-        if transport == "stdio":
-            await self._mcp.run_stdio_async()
-        elif transport == "sse":
-            await self._mcp.run_sse_async()
-        elif transport == "streamable-http":
-            await self._mcp.run_streamable_http_async()
-        else:  # pragma: no cover — Literal type prevents this at type-check time
-            raise ValueError(f"Unsupported transport '{transport}'.")
+        await self._mcp.run_async(transport=transport, show_banner=False)
 
 
 def _safe_identifier(raw: str) -> str:

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,7 +19,7 @@ Recipes and the MCP server are verified runnable against these versions
 
 | Integration | Entry point | Verified against |
 |---|---|---|
-| MCP server (outbound) | `chainweaver serve` / `chainweaver.mcp.FlowServer` | `mcp` 1.27.2 |
+| MCP server (outbound) | `chainweaver serve` / `chainweaver.mcp.FlowServer` | `fastmcp` 3.4.0 (+ `mcp` 1.27.2 for the inbound adapter) |
 | LangGraph node | `examples/integrations/langgraph_node.py`, [recipe](cookbook/langgraph-node.md) | `langgraph` 1.2.4 |
 | OpenAI Agents SDK tool | `examples/integrations/openai_agents_tool.py`, [recipe](cookbook/openai-agents-tool.md) | `openai-agents` 0.17.4 |
 | LangChain bridge | `chainweaver.integrations.langchain` | `langchain-core` 1.4.0 |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,8 +12,10 @@ ChainWeaver is MCP-native in **both directions**:
 This page covers the **outbound** direction: turning ChainWeaver into an MCP server.
 
 !!! note "Requires the `mcp` extra"
-    The MCP server builds on the official [`mcp`](https://pypi.org/project/mcp/)
-    Python SDK (FastMCP):
+    The MCP server builds on the standalone
+    [`fastmcp`](https://github.com/jlowin/fastmcp) package; the official
+    [`mcp`](https://pypi.org/project/mcp/) SDK is pulled in by the same extra
+    for the inbound adapter:
 
     ```bash
     pip install 'chainweaver[mcp]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,11 @@ openai-agents = [
     "openai-agents>=0.1",
 ]
 mcp = [
+    # ``FlowServer`` (outbound) runs on the standalone ``fastmcp`` package
+    # (issue #243); the inbound ``MCPToolAdapter`` still imports
+    # ``mcp.ClientSession`` from the official SDK, so both are required.
     "mcp>=1.0",
+    "fastmcp>=3.4",
 ]
 weaver-stack = [
     # Real Weaver Stack interop (issue #233).  ``weaver-contracts`` is the
@@ -126,6 +130,7 @@ dev = [
     "langgraph>=0.2",
     "openai-agents>=0.1",
     "mcp>=1.0",
+    "fastmcp>=3.4",
     # Weaver Stack interop (issue #233): the conformance + adapter suites import
     # the real weaver-contracts types, so CI's ``.[dev]`` install must carry them.
     "weaver-contracts>=0.6,<1.0",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -90,6 +90,14 @@ class TestFlowServerRegistration:
         server = FlowServer(executor_with_flow, name="cw-test")
         assert server.fastmcp.name == "cw-test"
 
+    def test_backed_by_standalone_fastmcp(self, executor_with_flow: FlowExecutor) -> None:
+        # Migration guard (issue #243): the server runs on the standalone
+        # ``fastmcp`` package, not the SDK-bundled ``mcp.server.fastmcp``.
+        from fastmcp import FastMCP
+
+        server = FlowServer(executor_with_flow, name="cw-test")
+        assert isinstance(server.fastmcp, FastMCP)
+
 
 class TestFlowServerOverMCP:
     def test_client_sees_advertised_flow(self, executor_with_flow: FlowExecutor) -> None:


### PR DESCRIPTION
Migrate chainweaver.mcp.FlowServer from the SDK-bundled
mcp.server.fastmcp.FastMCP to the standalone fastmcp package. The [mcp]
extra now installs fastmcp>=3.4 alongside mcp>=1.0 — the inbound
MCPToolAdapter still imports mcp.ClientSession and fastmcp re-uses
mcp.types.ToolAnnotations, so adapter.py is untouched.

FlowServer's public API is preserved (constructor, serve()/serve_async(),
.fastmcp, .registered_tool_names). Internals updated for the 3.x API:
tools are built via Tool.from_function(...) then add_tool(tool), and
serve()/serve_async() delegate to FastMCP.run/run_async(transport=...,
show_banner=False) so stdio framing stays clean. Refresh docs +
CHANGELOG and add a migration-guard test.

https://claude.ai/code/session_01WgHy1iQwVhRtNDU4DPLPFy