### PR TITLE
fix(mcp): resolve [mcp] extra in registry manifest fresh-client launch (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `pydantic>=2.11` (was `>=2.0`). Removed the speculative `mcp<2` upper-bound
   cap (now `mcp>=1.0`), per the no-caps policy.
 
+### Fixed
+
+- **MCP registry manifest now resolves the `mcp` extra on a fresh launch**
+  (#250): `server.json` carries a `--from 'chainweaver[mcp]'` `uvx` runtime
+  argument so a fresh client installs `fastmcp`/`mcp` before running
+  `chainweaver serve <flow_file>`, instead of launching bare `chainweaver`
+  (which lacks the MCP dependencies). New `tests/test_server_manifest.py` guards
+  the manifest version alignment and the `[mcp]`-extra launch. Publishing
+  `chainweaver==0.11.0` to PyPI and running `mcp-publisher` remain external
+  prerequisites tracked in #250 / #230.
+
 ## [0.11.0] - 2026-05-29
 
 ### Added

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -37,14 +37,17 @@ conforming to the
 
 **Before submitting:**
 
+- [x] Finalize the package launch in the manifest so a fresh client can start a
+      working server: `server.json` now carries a `--from 'chainweaver[mcp]'`
+      `uvx` runtime argument (resolving the `mcp` extra) plus a required
+      `flow_file` positional. `tests/test_server_manifest.py` guards this.
+- [ ] Publish `chainweaver==0.11.0` (including the `mcp` extra) to PyPI so the
+      manifest `version` resolves to an installable release (currently PyPI's
+      latest is `0.1.0`; see [#250](https://github.com/dgenio/ChainWeaver/issues/250)).
 - [ ] Validate and publish with the official
       [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) tool —
-      it validates `server.json` against the live schema on publish.
-- [ ] Confirm the `version` field matches the published PyPI release.
-- [ ] Because `serve` needs a flow-file argument and the `mcp` extra, finalize the
-      package launch in the manifest (e.g. a `--from 'chainweaver[mcp]'` runtime
-      argument for `uvx`, plus the flow path as a templated `packageArguments`
-      value) so a fresh client can launch a working server.
+      it validates `server.json` against the live schema on publish. Confirm the
+      `version` field matches the published PyPI release first.
 
 ## awesome-* lists
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -41,9 +41,10 @@ conforming to the
       working server: `server.json` now carries a `--from 'chainweaver[mcp]'`
       `uvx` runtime argument (resolving the `mcp` extra) plus a required
       `flow_file` positional. `tests/test_server_manifest.py` guards this.
-- [ ] Publish `chainweaver==0.11.0` (including the `mcp` extra) to PyPI so the
-      manifest `version` resolves to an installable release (currently PyPI's
-      latest is `0.1.0`; see [#250](https://github.com/dgenio/ChainWeaver/issues/250)).
+- [ ] Publish the manifest's `version` (including the `mcp` extra) to PyPI so it
+      resolves to an installable release. Confirm the version is live on
+      [PyPI](https://pypi.org/project/chainweaver/) before publishing the
+      manifest; see [#250](https://github.com/dgenio/ChainWeaver/issues/250).
 - [ ] Validate and publish with the official
       [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) tool —
       it validates `server.json` against the live schema on publish. Confirm the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -84,6 +84,12 @@ full end-to-end demo that talks to the server with a real MCP client lives in
 ## Publishing to the MCP ecosystem
 
 A ready-to-submit MCP registry manifest ships at
-[`server.json`](https://github.com/dgenio/ChainWeaver/blob/main/server.json). See
-[Distribution & ecosystem listings](distribution.md) for the registry and
+[`server.json`](https://github.com/dgenio/ChainWeaver/blob/main/server.json). It
+launches the server with a fresh-client command that resolves the `mcp` extra:
+
+```bash
+uvx --from 'chainweaver[mcp]' chainweaver serve /abs/path/to/your.flow.yaml
+```
+
+See [Distribution & ecosystem listings](distribution.md) for the registry and
 awesome-list submission checklist.

--- a/server.json
+++ b/server.json
@@ -14,6 +14,14 @@
       "identifier": "chainweaver",
       "version": "0.11.0",
       "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "chainweaver[mcp]",
+          "description": "Resolve the MCP extra so a fresh client installs the fastmcp/mcp dependencies the serve command needs."
+        }
+      ],
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -42,16 +42,29 @@ class _BOut(BaseModel):
     b: int
 
 
-def _make_executor(*, sleep_a: float = 0.0) -> FlowExecutor:
+def _make_executor(
+    *,
+    sleep_a: float = 0.0,
+    gate: tuple[threading.Event, threading.Event] | None = None,
+) -> FlowExecutor:
     """A 2-step linear flow ``slow_then_fast`` and a 2-level DAG ``slow_dag``.
 
     ``step_a`` (the first linear step / the DAG root) sleeps ``sleep_a``
-    seconds so a deadline or a cross-thread cancel can land at the boundary
-    *after* it completes and *before* the second step runs.
+    seconds so a deadline can land at the boundary *after* it completes and
+    *before* the second step runs.
+
+    When ``gate`` is supplied, ``step_a`` instead sets the first event on entry
+    and blocks on the second before returning. This lets a test drive a
+    cross-thread cancel to land mid-step deterministically — no sleep race
+    (#244).
     """
 
     def _slow_a(inp: _NIn) -> dict[str, Any]:
-        if sleep_a:
+        if gate is not None:
+            entered, proceed = gate
+            entered.set()
+            proceed.wait(timeout=5.0)
+        elif sleep_a:
             time.sleep(sleep_a)
         return {"a": inp.n + 1}
 
@@ -163,16 +176,20 @@ class TestLinearCancellation:
         assert err.result.execution_log[0].outputs == {"a": 2}
 
     def test_token_cancel_between_steps(self) -> None:
-        executor = _make_executor(sleep_a=0.15)
+        entered = threading.Event()
+        proceed = threading.Event()
+        executor = _make_executor(gate=(entered, proceed))
         token = CancellationToken()
 
-        # Cancel partway through step 0 so the request is visible at the
-        # boundary before step 1.
-        def _cancel_soon() -> None:
-            time.sleep(0.05)
+        # Deterministic barrier (#244): cancel while step 0 is in-flight, then
+        # release it so the request is guaranteed visible at the boundary
+        # before step 1 — no reliance on thread scheduling.
+        def _cancel_in_step() -> None:
+            entered.wait(timeout=5.0)
             token.cancel()
+            proceed.set()
 
-        canceller = threading.Thread(target=_cancel_soon)
+        canceller = threading.Thread(target=_cancel_in_step)
         canceller.start()
         try:
             with pytest.raises(FlowCancelledError) as exc_info:

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -21,6 +21,11 @@ from chainweaver import (
 )
 from chainweaver.exceptions import FlowCancelledError
 
+# Upper bound for the deterministic cancel-barrier waits (#244). Generous enough
+# never to trip on a loaded CI runner, yet bounded so a logic error fails fast
+# instead of hanging the suite.
+_BARRIER_TIMEOUT_S = 5.0
+
 # ---------------------------------------------------------------------------
 # Schemas + tools
 # ---------------------------------------------------------------------------
@@ -63,7 +68,7 @@ def _make_executor(
         if gate is not None:
             entered, proceed = gate
             entered.set()
-            proceed.wait(timeout=5.0)
+            proceed.wait(timeout=_BARRIER_TIMEOUT_S)
         elif sleep_a:
             time.sleep(sleep_a)
         return {"a": inp.n + 1}
@@ -185,7 +190,7 @@ class TestLinearCancellation:
         # release it so the request is guaranteed visible at the boundary
         # before step 1 — no reliance on thread scheduling.
         def _cancel_in_step() -> None:
-            entered.wait(timeout=5.0)
+            entered.wait(timeout=_BARRIER_TIMEOUT_S)
             token.cancel()
             proceed.set()
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -382,17 +382,29 @@ class TestDagAndAsync:
 # ---------------------------------------------------------------------------
 
 
-def _slow_subflow_executor(*, sleep_a: float) -> FlowExecutor:
+def _slow_subflow_executor(
+    *,
+    sleep_a: float = 0.0,
+    gate: tuple[threading.Event, threading.Event] | None = None,
+) -> FlowExecutor:
     """Parent flows that compose a 2-step sub-flow whose first tool sleeps.
 
-    ``t_slow`` sleeps ``sleep_a`` seconds so a deadline or cross-thread cancel
-    lands at the boundary *inside* the sub-flow — after its first step, before
-    its second — which only the parent's forwarded ``deadline`` /
-    ``cancel_token`` can observe.
+    ``t_slow`` sleeps ``sleep_a`` seconds so a deadline lands at the boundary
+    *inside* the sub-flow — after its first step, before its second — which
+    only the parent's forwarded ``deadline`` / ``cancel_token`` can observe.
+
+    When ``gate`` is supplied, ``t_slow`` instead sets the first event on entry
+    and blocks on the second before returning, so a test can drive a
+    cross-thread cancel into the sub-flow deterministically — no sleep race
+    (#244).
     """
 
     def _slow_inc(inp: _NIn) -> dict[str, Any]:
-        if sleep_a:
+        if gate is not None:
+            entered, proceed = gate
+            entered.set()
+            proceed.wait(timeout=5.0)
+        elif sleep_a:
             time.sleep(sleep_a)
         return {"a": inp.n + 1}
 
@@ -470,14 +482,20 @@ class TestCompositionCancellation:
         assert composed.sub_result.execution_log[0].outputs == {"a": 2}
 
     def test_token_cancel_observed_in_subflow(self) -> None:
-        ex = _slow_subflow_executor(sleep_a=0.15)
+        entered = threading.Event()
+        proceed = threading.Event()
+        ex = _slow_subflow_executor(gate=(entered, proceed))
         token = CancellationToken()
 
-        def _cancel_soon() -> None:
-            time.sleep(0.05)
+        # Deterministic barrier (#244): cancel while the sub-flow's first step
+        # is in-flight, then release it so the request is guaranteed visible at
+        # the boundary before the sub-flow's second step.
+        def _cancel_in_step() -> None:
+            entered.wait(timeout=5.0)
             token.cancel()
+            proceed.set()
 
-        canceller = threading.Thread(target=_cancel_soon)
+        canceller = threading.Thread(target=_cancel_in_step)
         canceller.start()
         try:
             with pytest.raises(FlowCancelledError) as exc_info:

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -26,6 +26,11 @@ from chainweaver.exceptions import (
     FlowExecutionError,
 )
 
+# Upper bound for the deterministic cancel-barrier waits (#244). Generous enough
+# never to trip on a loaded CI runner, yet bounded so a logic error fails fast
+# instead of hanging the suite.
+_BARRIER_TIMEOUT_S = 5.0
+
 # ---------------------------------------------------------------------------
 # Schemas + tools
 # ---------------------------------------------------------------------------
@@ -403,7 +408,7 @@ def _slow_subflow_executor(
         if gate is not None:
             entered, proceed = gate
             entered.set()
-            proceed.wait(timeout=5.0)
+            proceed.wait(timeout=_BARRIER_TIMEOUT_S)
         elif sleep_a:
             time.sleep(sleep_a)
         return {"a": inp.n + 1}
@@ -491,7 +496,7 @@ class TestCompositionCancellation:
         # is in-flight, then release it so the request is guaranteed visible at
         # the boundary before the sub-flow's second step.
         def _cancel_in_step() -> None:
-            entered.wait(timeout=5.0)
+            entered.wait(timeout=_BARRIER_TIMEOUT_S)
             token.cancel()
             proceed.set()
 

--- a/tests/test_server_manifest.py
+++ b/tests/test_server_manifest.py
@@ -1,0 +1,66 @@
+"""Guard the MCP registry manifest (``server.json``) against regressions (#250).
+
+These checks encode the two in-repo registry-publish prerequisites:
+
+1. The declared ``version`` stays aligned with the package version, so the
+   manifest never advertises a release that does not match the code.
+2. A fresh ``uvx`` client launch resolves the ``[mcp]`` extra and is handed a
+   required flow file, so the served command can actually start.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import chainweaver
+
+_MANIFEST = Path(__file__).resolve().parents[1] / "server.json"
+
+
+def _load_manifest() -> dict[str, Any]:
+    manifest: dict[str, Any] = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    return manifest
+
+
+def _pypi_package(manifest: dict[str, Any]) -> dict[str, Any]:
+    pypi: list[dict[str, Any]] = [
+        pkg for pkg in manifest["packages"] if pkg.get("registryType") == "pypi"
+    ]
+    assert len(pypi) == 1, "Expected exactly one PyPI package entry in server.json."
+    return pypi[0]
+
+
+def test_manifest_is_valid_json() -> None:
+    manifest = _load_manifest()
+    assert manifest["name"] == "io.github.dgenio/chainweaver"
+
+
+def test_manifest_version_matches_package() -> None:
+    manifest = _load_manifest()
+    assert manifest["version"] == chainweaver.__version__
+    assert _pypi_package(manifest)["version"] == chainweaver.__version__
+
+
+def test_uvx_launch_resolves_mcp_extra() -> None:
+    """A fresh client must install ``chainweaver[mcp]``, not bare ``chainweaver``."""
+    package = _pypi_package(_load_manifest())
+    assert package["runtimeHint"] == "uvx"
+    runtime_args = package.get("runtimeArguments", [])
+    from_args = [
+        arg for arg in runtime_args if arg.get("type") == "named" and arg.get("name") == "--from"
+    ]
+    assert from_args, "server.json must pass '--from' so uvx resolves the [mcp] extra."
+    assert from_args[0]["value"] == "chainweaver[mcp]"
+
+
+def test_serve_command_takes_required_flow_file() -> None:
+    package = _pypi_package(_load_manifest())
+    package_args = package["packageArguments"]
+    assert package_args[0]["value"] == "serve"
+    required_positional = [
+        arg for arg in package_args if arg.get("type") == "positional" and arg.get("isRequired")
+    ]
+    assert required_positional, "server.json must require a flow-file positional."
+    assert required_positional[0]["valueHint"] == "flow_file"


### PR DESCRIPTION
## Summary

Two related changes:

1. **Fixes the in-repo MCP registry-publish blocker (#250).** `server.json` launched a fresh `uvx` client against **bare** `chainweaver`, so the optional `mcp`/`fastmcp` dependencies that `chainweaver serve` requires were never installed and the served command could not start. The manifest now resolves the `[mcp]` extra.
2. **De-flakes the cancellation timing tests (#244).** While this PR's CI ran, `test_token_cancel_observed_in_subflow` flaked on `macos-latest`/3.11 (`DID NOT RAISE FlowCancelledError`) — the same sleep-based scheduling race tracked in #244. Replaced the timing with a deterministic barrier.

The remaining work in the distribution cluster (#250 PyPI publish, #230 `mcp-publisher`/awesome-list submissions, #231 framework-directory listings) are external maintainer actions in other repos/registries that a PR here cannot perform.

## Changes

- **`server.json`** — add a package-level `runtimeArguments` entry `{"type":"named","name":"--from","value":"chainweaver[mcp]"}`, so the fresh-client launch is `uvx --from 'chainweaver[mcp]' chainweaver serve <flow_file>`. (Field structure verified against the `2025-12-11` server schema.)
- **`tests/test_server_manifest.py`** *(new)* — regression guard: manifest is valid JSON; `version` matches `chainweaver.__version__` (`0.11.0`); the `--from chainweaver[mcp]` uvx runtime arg is present; a required `flow_file` positional exists.
- **`tests/test_cancellation.py`, `tests/test_composition.py`** — replace the `sleep(0.05)`-then-cancel race in the two token-cancel tests with a `threading.Event` barrier: the first tool signals entry and blocks until the test issues `token.cancel()`, so the cancel is guaranteed visible at the between-steps boundary regardless of scheduling. Deadline tests are unchanged (a 0.15s step always exceeds a 0.05s deadline). **Closes #244.**
- **`docs/distribution.md`** — tick the manifest-launch checklist item; the PyPI publish + `mcp-publisher` steps remain external (worded to verify the release on PyPI rather than hard-coding a version, per review).
- **`docs/mcp-server.md`** — document the `uvx --from 'chainweaver[mcp]'` fresh-client command.
- **`CHANGELOG.md`** — `[Unreleased] → Fixed` entry for the manifest fix.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/` → All checks passed)
- [x] Formatting check passes (`ruff format --check …`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/` → no issues, 151 files)
- [x] All existing tests pass (`python -m pytest tests/` → **1370 passed, 1 skipped**, 92.07% coverage)
- [x] New manifest tests verified red-on-`main` (stashing `server.json` makes `test_uvx_launch_resolves_mcp_extra` fail) / green with the fix.
- [x] De-flake verified: the two token-cancel tests ran **30× consecutively with 0 failures**.

## Related Issues

- Fixes the in-repo blocker of #250 and **closes #244**.
- Unblocks the `mcp-publisher` step of #230.
- Distribution cluster also includes #231 (external submissions only).

## Tradeoffs / risks

- No runtime/source changes — executor invariants untouched. The de-flake is test-only (deterministic barrier; no production behavior change).
- The PyPI version mismatch (manifest `0.11.0` vs published `0.1.0`) is out of scope — it requires an external release. Manifest intentionally kept at the target `0.11.0`.
- The earlier Bench alert was sub-millisecond microbenchmark jitter, unrelated to this diff.

## Scope notes

Originally scoped to the #250 manifest fix; the #244 de-flake was added because that pre-existing flake surfaced in this PR's CI (maintainer-approved expansion). External submissions for #230/#231 remain maintainer actions documented in `docs/distribution.md`.

https://claude.ai/code/session_01WsccutaJtSQSeYnuGwC8LC