### PR TITLE
feat(playground): interactive zero-install Streamlit playground (#81)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,10 @@ examples/
 ├── coding_agent_*.py        Coding-agent workflow templates (#173): PR review, changelog, debug-log triage
 ├── cookbook/                Paired scripts for docs/cookbook/ recipes (#146)
 └── (other domain-specific demos)
+playground/                  Streamlit zero-install onboarding playground (#81); outside the package, not lint/type-gated
+├── app.py                   Thin Streamlit UI shell
+├── core.py                  Streamlit-free flow builders + headless runner + Mermaid + share codec (tests/test_playground.py)
+└── requirements.txt         streamlit + streamlit-mermaid + chainweaver
 docs/
 ├── index.md                 Hosted-site landing page
 ├── boundaries.md            Fit / non-fit guidance (#169)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Interactive web playground — zero-install onboarding** (#81): a new
+  `playground/` directory with a Streamlit app (`playground/app.py`) that lets
+  visitors pick a pre-loaded flow, edit its JSON input, run it, and inspect the
+  step-by-step LLM-free trace and a Mermaid execution diagram — driven by the
+  real `FlowExecutor`. Ships three example flows (arithmetic, a data pipeline,
+  an MCP-style search), stateless `?share=<token>` links that round-trip a run
+  through the URL, and deploy instructions for Streamlit Community Cloud. All
+  flow-building/execution/diagram/share logic lives in a Streamlit-free
+  `playground/core.py` covered by `tests/test_playground.py`; the app shell is a
+  thin UI layer. Linked from the README.
+
 - **`trace_to_lesson_candidate()` — runtime failures to reviewable lessons** (#210):
   a new `chainweaver.lessons` module exposing `trace_to_lesson_candidate()` plus
   `LessonCandidate`, `LessonEvidenceStep`, and the `LessonReview` outcome enum.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `playground/` directory with a Streamlit app (`playground/app.py`) that lets
   visitors pick a pre-loaded flow, edit its JSON input, run it, and inspect the
   step-by-step LLM-free trace and a Mermaid execution diagram — driven by the
-  real `FlowExecutor`. Ships three example flows (arithmetic, a data pipeline,
+  real `FlowExecutor`. Ships three example flows (arithmetic, a data flow,
   an MCP-style search), stateless `?share=<token>` links that round-trip a run
   through the URL, and deploy instructions for Streamlit Community Cloud. All
   flow-building/execution/diagram/share logic lives in a Streamlit-free

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ result = executor.execute_flow("calc", {"number": 5})
 
 > See the [full example](#quick-start) below or run `python examples/simple_linear_flow.py`
 
-**[Installation](#installation) · [Why ChainWeaver?](#why-chainweaver) · [Is this for me?](#is-this-for-me) · [Quick Start](#quick-start) · [Architecture](#architecture) · [Docs site](https://chainweaver.readthedocs.io/) · [Roadmap](#roadmap)**
+**[Installation](#installation) · [Why ChainWeaver?](#why-chainweaver) · [Is this for me?](#is-this-for-me) · [Quick Start](#quick-start) · [Playground](#interactive-playground) · [Architecture](#architecture) · [Docs site](https://chainweaver.readthedocs.io/) · [Roadmap](#roadmap)**
 
 ---
 
@@ -522,6 +522,27 @@ flow = (
 - **`.with_trigger(conditions)`** — optional free-form trigger metadata.
 - **`.build()`** — returns a validated `Flow`; raises `FlowBuilderError` if
   `name` or `description` is missing.
+
+---
+
+## Interactive playground
+
+Want to try ChainWeaver without installing anything locally? The
+[`playground/`](playground/) directory ships a Streamlit app that lets you pick
+a pre-loaded flow, edit its JSON input, run it, and watch the step-by-step,
+**LLM-free** execution trace with a Mermaid diagram — the same `FlowExecutor`
+the library ships.
+
+```bash
+pip install -r playground/requirements.txt
+streamlit run playground/app.py
+```
+
+It ships three example flows (arithmetic, a data pipeline, and an MCP-style
+search), produces shareable `?share=<token>` links that round-trip a run through
+the URL, and is fully stateless so it deploys to Streamlit Community Cloud with
+no backend. See [`playground/README.md`](playground/README.md) for local-run and
+deployment instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ pip install -r playground/requirements.txt
 streamlit run playground/app.py
 ```
 
-It ships three example flows (arithmetic, a data pipeline, and an MCP-style
+It ships three example flows (arithmetic, a data flow, and an MCP-style
 search), produces shareable `?share=<token>` links that round-trip a run through
 the URL, and is fully stateless so it deploys to Streamlit Community Cloud with
 no backend. See [`playground/README.md`](playground/README.md) for local-run and

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,62 @@
+# ChainWeaver Playground
+
+A zero-install, interactive playground for ChainWeaver (issue
+[#81](https://github.com/dgenio/ChainWeaver/issues/81)). Pick a pre-loaded
+flow, edit its initial input as JSON, run it, and watch the step-by-step,
+**LLM-free** execution trace — the same `FlowExecutor` the library ships.
+
+## Features
+
+- **Three pre-loaded example flows** — arithmetic (`double → add_ten → format`),
+  a data pipeline (`extract → filter_positive → summarize`), and an MCP-style
+  flow (`search → extract_facts → format_answer`). All deterministic, no I/O,
+  no randomness.
+- **Editable JSON input** — change the input and re-run to see results change.
+- **Step-by-step trace** — per-step tool, success, duration, and outputs.
+- **Mermaid visualization** — the flow graph and a per-run execution diagram
+  with success/failure markers (links to the `chainweaver.viz` renderers).
+- **Share links** — every run produces a `?share=<token>` query string that
+  encodes the flow + input so a run round-trips through the URL. No server-side
+  state.
+
+## Run locally
+
+```bash
+pip install -r playground/requirements.txt
+streamlit run playground/app.py
+```
+
+The app opens at <http://localhost:8501>. To run it against local, unreleased
+ChainWeaver changes instead of the released package, install the repo in
+editable mode first:
+
+```bash
+pip install -e .
+pip install streamlit streamlit-mermaid
+streamlit run playground/app.py
+```
+
+## Deploy (Streamlit Community Cloud)
+
+1. Push this repository to GitHub (already done for this repo).
+2. On [share.streamlit.io](https://share.streamlit.io), create a new app
+   pointing at this repository.
+3. Set **Main file path** to `playground/app.py` and the **requirements file**
+   to `playground/requirements.txt`.
+4. Deploy. The app is stateless, so no secrets or persistent storage are
+   required. The shareable `?share=<token>` links work on the deployed URL.
+
+## Architecture
+
+```text
+playground/
+├── app.py            Thin Streamlit UI (imports core; no flow logic here)
+├── core.py           Streamlit-free flow builders, runner, diagrams, share codec
+├── requirements.txt  streamlit + streamlit-mermaid + chainweaver
+└── README.md         this file
+```
+
+All flow-building and execution logic lives in `core.py`, which imports **no
+Streamlit** and is unit-tested in
+[`tests/test_playground.py`](../tests/test_playground.py). `app.py` is a thin
+presentation layer.

--- a/playground/README.md
+++ b/playground/README.md
@@ -8,7 +8,7 @@ flow, edit its initial input as JSON, run it, and watch the step-by-step,
 ## Features
 
 - **Three pre-loaded example flows** — arithmetic (`double → add_ten → format`),
-  a data pipeline (`extract → filter_positive → summarize`), and an MCP-style
+  a data flow (`extract → filter_positive → summarize`), and an MCP-style
   flow (`search → extract_facts → format_answer`). All deterministic, no I/O,
   no randomness.
 - **Editable JSON input** — change the input and re-run to see results change.
@@ -18,6 +18,15 @@ flow, edit its initial input as JSON, run it, and watch the step-by-step,
 - **Share links** — every run produces a `?share=<token>` query string that
   encodes the flow + input so a run round-trips through the URL. No server-side
   state.
+
+## Scope
+
+The playground demonstrates **deterministic, LLM-free execution** with an
+editable **input**. Editing tool *functions* live (arbitrary user-supplied
+Python) is intentionally out of scope: the hosted app runs untrusted input, so
+executing user code would be a security risk and would break the determinism the
+playground exists to show. To author your own tools and flows, use the library
+directly — see the top-level [README](../README.md).
 
 ## Run locally
 

--- a/playground/app.py
+++ b/playground/app.py
@@ -20,8 +20,11 @@ import streamlit as st
 
 # ``streamlit run`` executes this file as a script, so the sibling ``core``
 # module is not importable as ``playground.core`` without help.  Add this
-# directory to the path and import it as a top-level module.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+# directory to the path and import it as a top-level module.  Streamlit reruns
+# this script on most UI interactions, so guard the insertion to keep
+# ``sys.path`` free of accumulating duplicate entries.
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import core
 
@@ -55,8 +58,15 @@ def main() -> None:
     shared_name: str | None = None
     shared_input: dict[str, object] | None = None
     if "share" in params:
+        share_param = params["share"]
+        # ``st.query_params`` returns a single string in the current API, but a
+        # repeated ``?share=a&share=b`` (or the legacy list-valued API) can hand
+        # back a list — normalize to the last value before decoding so a stray
+        # list never reaches ``decode_share`` and raises an uncaught error.
+        if isinstance(share_param, (list, tuple)):
+            share_param = share_param[-1] if share_param else ""
         try:
-            shared_name, shared_input = core.decode_share(params["share"])
+            shared_name, shared_input = core.decode_share(share_param)
         except ValueError as exc:
             st.warning(f"Ignoring invalid share link: {exc}")
 

--- a/playground/app.py
+++ b/playground/app.py
@@ -1,0 +1,115 @@
+"""Streamlit shell for the ChainWeaver interactive playground (issue #81).
+
+Run locally::
+
+    pip install -r playground/requirements.txt
+    streamlit run playground/app.py
+
+All flow-building, execution, diagram, and share logic lives in
+``playground/core.py`` (Streamlit-free, unit-tested).  This file is only the
+thin UI layer, so it is intentionally outside the linted/typed package scope.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+# ``streamlit run`` executes this file as a script, so the sibling ``core``
+# module is not importable as ``playground.core`` without help.  Add this
+# directory to the path and import it as a top-level module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import core
+
+try:  # Optional: render Mermaid diagrams inline when the helper is installed.
+    from streamlit_mermaid import st_mermaid
+except ImportError:  # pragma: no cover - exercised only without the extra
+    st_mermaid = None
+
+
+def _render_mermaid(diagram: str, *, key: str) -> None:
+    if st_mermaid is not None:
+        st_mermaid(diagram, key=key)
+    else:
+        st.caption(
+            "Install `streamlit-mermaid` to render this inline, or paste it into mermaid.live:"
+        )
+        st.code(diagram, language="mermaid")
+
+
+def main() -> None:
+    st.set_page_config(page_title="ChainWeaver Playground", page_icon="🧵", layout="wide")
+    st.title("🧵 ChainWeaver Playground")
+    st.write(
+        "Pick a pre-loaded flow, edit its input, and run it — deterministically, "
+        "with **zero LLM calls between steps**. This is the same `FlowExecutor` "
+        "the library ships."
+    )
+
+    # Restore a shared selection from the URL (?share=<token>) if present.
+    params = st.query_params
+    shared_name: str | None = None
+    shared_input: dict[str, object] | None = None
+    if "share" in params:
+        try:
+            shared_name, shared_input = core.decode_share(params["share"])
+        except ValueError as exc:
+            st.warning(f"Ignoring invalid share link: {exc}")
+
+    names = list(core.EXAMPLES)
+    default_index = names.index(shared_name) if shared_name in core.EXAMPLES else 0
+    name = st.sidebar.selectbox("Example flow", names, index=default_index)
+    example = core.EXAMPLES[name]
+    st.sidebar.write(example.description)
+
+    if shared_name == name and shared_input is not None:
+        default_input = shared_input
+    else:
+        default_input = example.default_input
+    input_text = st.text_area(
+        "Initial input (JSON)",
+        value=json.dumps(default_input, indent=2),
+        height=160,
+    )
+
+    st.subheader("Flow")
+    _, flow = core.build_executor(example)
+    _render_mermaid(core.flow_diagram(flow), key=f"flow-{name}")
+
+    if st.button("▶ Run flow", type="primary"):
+        try:
+            initial_input = json.loads(input_text)
+        except json.JSONDecodeError as exc:
+            st.error(f"Initial input is not valid JSON: {exc}")
+            return
+        if not isinstance(initial_input, dict):
+            st.error("Initial input must be a JSON object.")
+            return
+
+        result = core.run_example(name, initial_input)
+
+        st.subheader("Result")
+        if result.success:
+            st.success(f"Flow `{result.flow_name}` succeeded in {result.total_duration_ms:.2f} ms")
+        else:
+            st.error(f"Flow `{result.flow_name}` failed")
+        st.json(result.final_output)
+
+        st.subheader("Step trace")
+        st.dataframe(core.trace_rows(result), use_container_width=True)
+
+        st.subheader("Execution diagram")
+        _render_mermaid(core.result_diagram(result), key=f"result-{name}")
+
+        token = core.encode_share(name, initial_input)
+        st.subheader("Share this run")
+        st.code(f"?share={token}", language="text")
+        st.caption("Append the query string above to the playground URL to reproduce this run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/playground/core.py
+++ b/playground/core.py
@@ -331,6 +331,7 @@ def trace_rows(result: ExecutionResult) -> list[dict[str, Any]]:
             "tool": record.tool_name,
             "success": record.success,
             "duration_ms": round(record.duration_ms, 3),
+            "inputs": record.inputs,
             "outputs": record.outputs,
             "error": record.error_message,
         }

--- a/playground/core.py
+++ b/playground/core.py
@@ -1,0 +1,382 @@
+"""Pure-Python core for the ChainWeaver interactive playground (issue #81).
+
+This module deliberately imports **no Streamlit** so it can be unit-tested and
+reused headless.  ``playground/app.py`` is the thin Streamlit shell that wraps
+the functions defined here.
+
+It ships three pre-loaded example flows, a headless runner that returns a real
+``ExecutionResult``, helpers that turn that result into display rows and Mermaid
+diagrams, and a tiny URL-safe share codec so a flow selection + initial input
+can round-trip through a query string.
+
+Everything is deterministic and LLM-free — the playground demonstrates exactly
+the property ChainWeaver enforces.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from chainweaver import (
+    ExecutionResult,
+    Flow,
+    FlowExecutor,
+    FlowRegistry,
+    FlowStep,
+    Tool,
+)
+from chainweaver.viz import flow_to_ascii, flow_to_mermaid, result_to_mermaid
+
+# ---------------------------------------------------------------------------
+# Example 1 — arithmetic: double → add_ten → format_result
+# ---------------------------------------------------------------------------
+
+
+class _NumberInput(BaseModel):
+    number: int
+
+
+class _ValueOutput(BaseModel):
+    value: int
+
+
+class _ValueInput(BaseModel):
+    value: int
+
+
+class _FormattedOutput(BaseModel):
+    result: str
+
+
+def _double_fn(inp: _NumberInput) -> dict[str, Any]:
+    return {"value": inp.number * 2}
+
+
+def _add_ten_fn(inp: _ValueInput) -> dict[str, Any]:
+    return {"value": inp.value + 10}
+
+
+def _format_result_fn(inp: _ValueInput) -> dict[str, Any]:
+    return {"result": f"Final value: {inp.value}"}
+
+
+def _build_arithmetic() -> tuple[Flow, list[Tool]]:
+    tools = [
+        Tool(
+            name="double",
+            description="Doubles a number.",
+            input_schema=_NumberInput,
+            output_schema=_ValueOutput,
+            fn=_double_fn,
+        ),
+        Tool(
+            name="add_ten",
+            description="Adds ten to a value.",
+            input_schema=_ValueInput,
+            output_schema=_ValueOutput,
+            fn=_add_ten_fn,
+        ),
+        Tool(
+            name="format_result",
+            description="Formats a numeric value into a human-readable string.",
+            input_schema=_ValueInput,
+            output_schema=_FormattedOutput,
+            fn=_format_result_fn,
+        ),
+    ]
+    flow = Flow(
+        name="double_add_format",
+        description="Doubles a number, adds 10, and formats the result.",
+        steps=[
+            FlowStep(tool_name="double", input_mapping={"number": "number"}),
+            FlowStep(tool_name="add_ten", input_mapping={"value": "value"}),
+            FlowStep(tool_name="format_result", input_mapping={"value": "value"}),
+        ],
+    )
+    return flow, tools
+
+
+# ---------------------------------------------------------------------------
+# Example 2 — data pipeline: extract → filter_positive → summarize
+# ---------------------------------------------------------------------------
+
+
+class _SourceInput(BaseModel):
+    source: str
+
+
+class _RecordsOutput(BaseModel):
+    numbers: list[int]
+
+
+class _NumbersInput(BaseModel):
+    numbers: list[int]
+
+
+class _SummaryOutput(BaseModel):
+    count: int
+    total: int
+
+
+def _extract_fn(inp: _SourceInput) -> dict[str, Any]:
+    # Deterministic mock "extraction": derive numbers from the source label so
+    # the same source always yields the same records — no I/O, no RNG.
+    seed = sum(ord(char) for char in inp.source) % 7
+    return {"numbers": [seed - 3, seed, -seed, seed + 2, 0]}
+
+
+def _filter_positive_fn(inp: _NumbersInput) -> dict[str, Any]:
+    return {"numbers": [n for n in inp.numbers if n > 0]}
+
+
+def _summarize_fn(inp: _NumbersInput) -> dict[str, Any]:
+    return {"count": len(inp.numbers), "total": sum(inp.numbers)}
+
+
+def _build_data_pipeline() -> tuple[Flow, list[Tool]]:
+    tools = [
+        Tool(
+            name="extract",
+            description="Deterministically derive a list of numbers from a source label.",
+            input_schema=_SourceInput,
+            output_schema=_RecordsOutput,
+            fn=_extract_fn,
+        ),
+        Tool(
+            name="filter_positive",
+            description="Keep only the positive numbers.",
+            input_schema=_NumbersInput,
+            output_schema=_RecordsOutput,
+            fn=_filter_positive_fn,
+        ),
+        Tool(
+            name="summarize",
+            description="Count and sum the remaining numbers.",
+            input_schema=_NumbersInput,
+            output_schema=_SummaryOutput,
+            fn=_summarize_fn,
+        ),
+    ]
+    flow = Flow(
+        name="data_pipeline",
+        description="Extract numbers from a source, drop non-positives, and summarize.",
+        steps=[
+            FlowStep(tool_name="extract", input_mapping={"source": "source"}),
+            FlowStep(tool_name="filter_positive", input_mapping={"numbers": "numbers"}),
+            FlowStep(tool_name="summarize", input_mapping={"numbers": "numbers"}),
+        ],
+    )
+    return flow, tools
+
+
+# ---------------------------------------------------------------------------
+# Example 3 — MCP-style: search → extract → format
+# ---------------------------------------------------------------------------
+
+
+class _QueryInput(BaseModel):
+    query: str
+
+
+class _HitsOutput(BaseModel):
+    hits: list[str]
+
+
+class _HitsInput(BaseModel):
+    hits: list[str]
+
+
+class _FactsOutput(BaseModel):
+    facts: list[str]
+
+
+class _FactsInput(BaseModel):
+    facts: list[str]
+
+
+class _AnswerOutput(BaseModel):
+    answer: str
+
+
+def _search_fn(inp: _QueryInput) -> dict[str, Any]:
+    return {"hits": [f"{inp.query} result {i}" for i in range(1, 4)]}
+
+
+def _extract_facts_fn(inp: _HitsInput) -> dict[str, Any]:
+    return {"facts": [hit.upper() for hit in inp.hits]}
+
+
+def _format_answer_fn(inp: _FactsInput) -> dict[str, Any]:
+    return {"answer": " | ".join(inp.facts)}
+
+
+def _build_mcp_search() -> tuple[Flow, list[Tool]]:
+    tools = [
+        Tool(
+            name="search",
+            description="Mock search returning deterministic hits for a query.",
+            input_schema=_QueryInput,
+            output_schema=_HitsOutput,
+            fn=_search_fn,
+        ),
+        Tool(
+            name="extract_facts",
+            description="Extract facts from the search hits.",
+            input_schema=_HitsInput,
+            output_schema=_FactsOutput,
+            fn=_extract_facts_fn,
+        ),
+        Tool(
+            name="format_answer",
+            description="Format the facts into a single answer string.",
+            input_schema=_FactsInput,
+            output_schema=_AnswerOutput,
+            fn=_format_answer_fn,
+        ),
+    ]
+    flow = Flow(
+        name="mcp_search",
+        description="MCP-style search, then extract facts, then format the answer.",
+        steps=[
+            FlowStep(tool_name="search", input_mapping={"query": "query"}),
+            FlowStep(tool_name="extract_facts", input_mapping={"hits": "hits"}),
+            FlowStep(tool_name="format_answer", input_mapping={"facts": "facts"}),
+        ],
+    )
+    return flow, tools
+
+
+# ---------------------------------------------------------------------------
+# Example registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Example:
+    """A pre-loaded playground example.
+
+    ``builder`` returns a fresh ``(Flow, tools)`` pair on every call so a run
+    never mutates shared state, and ``default_input`` is the initial input the
+    UI pre-fills for a first execution.
+    """
+
+    name: str
+    description: str
+    builder: Callable[[], tuple[Flow, list[Tool]]]
+    default_input: dict[str, Any]
+
+
+EXAMPLES: dict[str, Example] = {
+    "double_add_format": Example(
+        name="double_add_format",
+        description="Arithmetic: double a number, add ten, format the result.",
+        builder=_build_arithmetic,
+        default_input={"number": 5},
+    ),
+    "data_pipeline": Example(
+        name="data_pipeline",
+        description="Data pipeline: extract numbers, drop non-positives, summarize.",
+        builder=_build_data_pipeline,
+        default_input={"source": "sales"},
+    ),
+    "mcp_search": Example(
+        name="mcp_search",
+        description="MCP-style: search, extract facts, format the answer.",
+        builder=_build_mcp_search,
+        default_input={"query": "chainweaver"},
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Headless execution + display helpers
+# ---------------------------------------------------------------------------
+
+
+def build_executor(example: Example) -> tuple[FlowExecutor, Flow]:
+    """Build a fresh registry + executor wired with *example*'s flow and tools."""
+    flow, tools = example.builder()
+    registry = FlowRegistry()
+    registry.register_flow(flow)
+    executor = FlowExecutor(registry=registry)
+    for tool in tools:
+        executor.register_tool(tool)
+    return executor, flow
+
+
+def run_example(name: str, initial_input: dict[str, Any]) -> ExecutionResult:
+    """Run the named example with *initial_input* and return the result.
+
+    Raises:
+        KeyError: when *name* is not a known example.
+    """
+    if name not in EXAMPLES:
+        raise KeyError(f"Unknown example '{name}'.")
+    executor, flow = build_executor(EXAMPLES[name])
+    return executor.execute_flow(flow.name, initial_input)
+
+
+def trace_rows(result: ExecutionResult) -> list[dict[str, Any]]:
+    """Flatten an ``ExecutionResult`` into per-step rows for tabular display."""
+    return [
+        {
+            "step": record.step_index,
+            "tool": record.tool_name,
+            "success": record.success,
+            "duration_ms": round(record.duration_ms, 3),
+            "outputs": record.outputs,
+            "error": record.error_message,
+        }
+        for record in result.execution_log
+    ]
+
+
+def flow_diagram(flow: Flow, *, fmt: str = "mermaid") -> str:
+    """Render *flow* as a Mermaid graph (``fmt="mermaid"``) or ASCII art."""
+    if fmt == "ascii":
+        return flow_to_ascii(flow)
+    return flow_to_mermaid(flow)
+
+
+def result_diagram(result: ExecutionResult) -> str:
+    """Render an ``ExecutionResult`` as a Mermaid graph with per-step markers."""
+    return result_to_mermaid(result)
+
+
+# ---------------------------------------------------------------------------
+# Share codec — encode a (flow, input) selection into a URL-safe token
+# ---------------------------------------------------------------------------
+
+
+def encode_share(name: str, initial_input: dict[str, Any]) -> str:
+    """Encode a flow name + initial input into a URL-safe base64 token."""
+    payload = json.dumps({"flow": name, "input": initial_input}, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
+
+
+def decode_share(token: str) -> tuple[str, dict[str, Any]]:
+    """Decode a share token back into ``(flow_name, initial_input)``.
+
+    Raises:
+        ValueError: when the token is not valid base64 / JSON or is missing the
+            expected ``flow`` / ``input`` fields.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        data = json.loads(raw.decode("utf-8"))
+    except (binascii.Error, ValueError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Malformed share token: {exc}") from exc
+    if not isinstance(data, dict) or "flow" not in data or "input" not in data:
+        raise ValueError("Share token is missing the 'flow' or 'input' field.")
+    flow_name = data["flow"]
+    initial_input = data["input"]
+    if not isinstance(flow_name, str) or not isinstance(initial_input, dict):
+        raise ValueError("Share token has the wrong types for 'flow' / 'input'.")
+    return flow_name, initial_input

--- a/playground/core.py
+++ b/playground/core.py
@@ -104,7 +104,7 @@ def _build_arithmetic() -> tuple[Flow, list[Tool]]:
 
 
 # ---------------------------------------------------------------------------
-# Example 2 — data pipeline: extract → filter_positive → summarize
+# Example 2 — data flow: extract → filter_positive → summarize
 # ---------------------------------------------------------------------------
 
 
@@ -140,7 +140,7 @@ def _summarize_fn(inp: _NumbersInput) -> dict[str, Any]:
     return {"count": len(inp.numbers), "total": sum(inp.numbers)}
 
 
-def _build_data_pipeline() -> tuple[Flow, list[Tool]]:
+def _build_data_flow() -> tuple[Flow, list[Tool]]:
     tools = [
         Tool(
             name="extract",
@@ -165,7 +165,7 @@ def _build_data_pipeline() -> tuple[Flow, list[Tool]]:
         ),
     ]
     flow = Flow(
-        name="data_pipeline",
+        name="data_flow",
         description="Extract numbers from a source, drop non-positives, and summarize.",
         steps=[
             FlowStep(tool_name="extract", input_mapping={"source": "source"}),
@@ -280,10 +280,10 @@ EXAMPLES: dict[str, Example] = {
         builder=_build_arithmetic,
         default_input={"number": 5},
     ),
-    "data_pipeline": Example(
-        name="data_pipeline",
-        description="Data pipeline: extract numbers, drop non-positives, summarize.",
-        builder=_build_data_pipeline,
+    "data_flow": Example(
+        name="data_flow",
+        description="Data flow: extract numbers, drop non-positives, summarize.",
+        builder=_build_data_flow,
         default_input={"source": "sales"},
     ),
     "mcp_search": Example(
@@ -354,6 +354,12 @@ def result_diagram(result: ExecutionResult) -> str:
 # Share codec — encode a (flow, input) selection into a URL-safe token
 # ---------------------------------------------------------------------------
 
+# Cap the size of a share token we are willing to decode. The token base64-
+# encodes a small JSON ``{"flow", "input"}`` payload, so a few KB is generous;
+# the cap stops an accidental or malicious huge query string from forcing a
+# large base64 + JSON parse on a shared deployment.
+_MAX_SHARE_TOKEN_LEN = 4096
+
 
 def encode_share(name: str, initial_input: dict[str, Any]) -> str:
     """Encode a flow name + initial input into a URL-safe base64 token."""
@@ -365,9 +371,13 @@ def decode_share(token: str) -> tuple[str, dict[str, Any]]:
     """Decode a share token back into ``(flow_name, initial_input)``.
 
     Raises:
-        ValueError: when the token is not valid base64 / JSON or is missing the
-            expected ``flow`` / ``input`` fields.
+        ValueError: when the token is too long, is not valid base64 / JSON, or
+            is missing the expected ``flow`` / ``input`` fields.
     """
+    if len(token) > _MAX_SHARE_TOKEN_LEN:
+        raise ValueError(
+            f"Share token is too long ({len(token)} > {_MAX_SHARE_TOKEN_LEN} characters)."
+        )
     try:
         raw = base64.urlsafe_b64decode(token.encode("ascii"))
         data = json.loads(raw.decode("utf-8"))

--- a/playground/requirements.txt
+++ b/playground/requirements.txt
@@ -1,0 +1,13 @@
+# Dependencies for the ChainWeaver interactive playground (issue #81).
+#
+# Run locally:
+#   pip install -r playground/requirements.txt
+#   streamlit run playground/app.py
+#
+# For Streamlit Community Cloud, point the app at playground/app.py and this
+# file as the requirements path. Replace the released package below with
+# `-e .` (an editable install of this repo) to run the playground against
+# local, unreleased changes.
+streamlit>=1.40
+streamlit-mermaid>=0.3.0
+chainweaver

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,143 @@
+"""Regression tests for the interactive playground core (issue #81).
+
+The playground lives outside the package (``playground/``) and follows the
+standalone-script convention, so we load its Streamlit-free ``core`` module by
+file path — the same approach ``test_coding_agent_examples.py`` uses for the
+``examples/`` scripts.  ``playground/app.py`` (the Streamlit shell) is not
+imported here; only the headless ``core`` logic is exercised.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PLAYGROUND_DIR = Path(__file__).resolve().parent.parent / "playground"
+
+
+def _load_core() -> ModuleType:
+    path = PLAYGROUND_DIR / "core.py"
+    module_name = "_playground_core"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the frozen ``Example`` dataclass can resolve its
+    # stringized annotations (``from __future__ import annotations``).
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def core() -> ModuleType:
+    return _load_core()
+
+
+# ---------------------------------------------------------------------------
+# Examples registry
+# ---------------------------------------------------------------------------
+
+
+def test_at_least_three_examples(core: ModuleType) -> None:
+    assert len(core.EXAMPLES) >= 3
+    # Every registered example's key matches its declared name.
+    for key, example in core.EXAMPLES.items():
+        assert key == example.name
+
+
+def test_every_example_runs_on_its_default_input(core: ModuleType) -> None:
+    for name, example in core.EXAMPLES.items():
+        result = core.run_example(name, example.default_input)
+        assert result.success is True, name
+        assert result.final_output is not None
+        rows = core.trace_rows(result)
+        assert len(rows) == 3
+        assert all(row["success"] for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# Specific example outputs (tight assertions)
+# ---------------------------------------------------------------------------
+
+
+def test_arithmetic_example_exact_output(core: ModuleType) -> None:
+    result = core.run_example("double_add_format", {"number": 5})
+    assert result.final_output == {"number": 5, "value": 20, "result": "Final value: 20"}
+
+
+def test_data_pipeline_drops_non_positive(core: ModuleType) -> None:
+    result = core.run_example("data_pipeline", {"source": "sales"})
+    # "sales" → seed = sum(ord) % 7 = 4 → [1, 4, -4, 6, 0] → positives [1, 4, 6].
+    assert result.final_output == {
+        "source": "sales",
+        "numbers": [1, 4, 6],
+        "count": 3,
+        "total": 11,
+    }
+
+
+def test_mcp_search_example_formats_answer(core: ModuleType) -> None:
+    result = core.run_example("mcp_search", {"query": "cw"})
+    assert result.final_output is not None
+    assert result.final_output["answer"] == "CW RESULT 1 | CW RESULT 2 | CW RESULT 3"
+
+
+# ---------------------------------------------------------------------------
+# Error path
+# ---------------------------------------------------------------------------
+
+
+def test_run_unknown_example_raises(core: ModuleType) -> None:
+    with pytest.raises(KeyError, match="Unknown example"):
+        core.run_example("does_not_exist", {})
+
+
+# ---------------------------------------------------------------------------
+# Diagrams
+# ---------------------------------------------------------------------------
+
+
+def test_flow_diagram_mermaid_and_ascii(core: ModuleType) -> None:
+    _, flow = core.build_executor(core.EXAMPLES["double_add_format"])
+    mermaid = core.flow_diagram(flow)
+    assert mermaid.startswith("graph LR")
+    assert "double" in mermaid
+    ascii_art = core.flow_diagram(flow, fmt="ascii")
+    assert "double" in ascii_art
+
+
+def test_result_diagram_marks_steps(core: ModuleType) -> None:
+    result = core.run_example("double_add_format", {"number": 5})
+    diagram = core.result_diagram(result)
+    assert diagram.startswith("graph LR")
+    assert "✓" in diagram
+
+
+# ---------------------------------------------------------------------------
+# Share codec
+# ---------------------------------------------------------------------------
+
+
+def test_share_roundtrip(core: ModuleType) -> None:
+    token = core.encode_share("data_pipeline", {"source": "demo"})
+    name, initial_input = core.decode_share(token)
+    assert name == "data_pipeline"
+    assert initial_input == {"source": "demo"}
+
+
+def test_decode_rejects_malformed_token(core: ModuleType) -> None:
+    with pytest.raises(ValueError, match="Malformed share token"):
+        core.decode_share("!!!not-base64!!!")
+
+
+def test_decode_rejects_token_missing_fields(core: ModuleType) -> None:
+    import base64
+    import json
+
+    token = base64.urlsafe_b64encode(json.dumps({"flow": "x"}).encode()).decode()
+    with pytest.raises(ValueError, match="missing the 'flow' or 'input' field"):
+        core.decode_share(token)

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -57,6 +57,9 @@ def test_every_example_runs_on_its_default_input(core: ModuleType) -> None:
         rows = core.trace_rows(result)
         assert len(rows) == 3
         assert all(row["success"] for row in rows)
+        # Issue #81 acceptance: the trace exposes inputs *and* outputs per step.
+        assert all("inputs" in row and "outputs" in row for row in rows), name
+        assert all(row["inputs"] is not None for row in rows), name
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +135,12 @@ def test_share_roundtrip(core: ModuleType) -> None:
 def test_decode_rejects_malformed_token(core: ModuleType) -> None:
     with pytest.raises(ValueError, match="Malformed share token"):
         core.decode_share("!!!not-base64!!!")
+
+
+def test_decode_rejects_oversized_token(core: ModuleType) -> None:
+    oversized = "A" * (core._MAX_SHARE_TOKEN_LEN + 1)
+    with pytest.raises(ValueError, match="too long"):
+        core.decode_share(oversized)
 
 
 def test_decode_rejects_token_missing_fields(core: ModuleType) -> None:

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -69,8 +69,8 @@ def test_arithmetic_example_exact_output(core: ModuleType) -> None:
     assert result.final_output == {"number": 5, "value": 20, "result": "Final value: 20"}
 
 
-def test_data_pipeline_drops_non_positive(core: ModuleType) -> None:
-    result = core.run_example("data_pipeline", {"source": "sales"})
+def test_data_flow_drops_non_positive(core: ModuleType) -> None:
+    result = core.run_example("data_flow", {"source": "sales"})
     # "sales" → seed = sum(ord) % 7 = 4 → [1, 4, -4, 6, 0] → positives [1, 4, 6].
     assert result.final_output == {
         "source": "sales",
@@ -123,9 +123,9 @@ def test_result_diagram_marks_steps(core: ModuleType) -> None:
 
 
 def test_share_roundtrip(core: ModuleType) -> None:
-    token = core.encode_share("data_pipeline", {"source": "demo"})
+    token = core.encode_share("data_flow", {"source": "demo"})
     name, initial_input = core.decode_share(token)
-    assert name == "data_pipeline"
+    assert name == "data_flow"
     assert initial_input == {"source": "demo"}
 
 


### PR DESCRIPTION
## Summary

Implements the interactive web playground (#81) for zero-install onboarding: pick a pre-loaded flow, edit its JSON input, run it, and inspect the step-by-step **LLM-free** trace plus a Mermaid execution diagram — driven by the real `FlowExecutor`.

This PR opened against "all open issues". Of the four open issues, **only #81 had an unimplemented in-repo deliverable** — the others' in-repo work already landed in prior triage PRs and their remainder is external-only (see *Related issues* below).

## Changes

- **`playground/core.py`** — Streamlit-free core: three example flow builders (arithmetic `double→add_ten→format`, data pipeline `extract→filter_positive→summarize`, MCP-style `search→extract_facts→format_answer`), a headless `run_example` runner, `trace_rows`/`flow_diagram`/`result_diagram` display helpers over `chainweaver.viz`, and a URL-safe `encode_share`/`decode_share` codec. Deterministic, no I/O, no randomness.
- **`playground/app.py`** — thin Streamlit UI shell over `core` (example picker, editable JSON input, run button, trace table, Mermaid diagrams, share link). Optional inline Mermaid via `streamlit-mermaid` with a graceful fallback.
- **`playground/requirements.txt`** + **`playground/README.md`** — local-run and Streamlit Community Cloud deploy instructions; the app is stateless (no backend).
- **`tests/test_playground.py`** — loads `core` by file path (matching the `examples/` test convention) and covers every example run, exact outputs, the unknown-example error path, both diagram renderers, and share encode/decode roundtrip incl. malformed/missing-field tokens.
- **README / CHANGELOG / AGENTS.md** — Playground section + nav link in README, Unreleased changelog entry, repo-map entry in AGENTS.md.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/` — also ran with `playground/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/` — also `playground/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/ playground/core.py` — no errors in the new files; remaining repo errors are pre-existing missing-optional-dep noise resolved by CI's `.[dev]` install)
- [x] New tests pass (`pytest tests/test_playground.py` — 11 passed; `test_readme_smoke.py`, `test_readme_assets.py`, `test_cli_docs.py` also green)
- [x] New tests added for new functionality

The Streamlit shell (`app.py`) is intentionally outside the lint/type-gated package scope (matching `playground/`'s placement); it is byte-compiled-clean and its logic is fully delegated to the unit-tested `core.py`.

## Related issues

- Closes #81.
- #230 (MCP server), #231 (framework directories), #250 (MCP registry prereqs): their **in-repo** deliverables already shipped (`docs/mcp-server.md`, `docs/distribution.md`, the `server.json` `--from 'chainweaver[mcp]'` manifest fix, verified recipes, README Integrations section). Their only remaining work is **external maintainer submissions** (running `mcp-publisher`, opening PRs against `awesome-mcp-servers` / LangGraph / OpenAI Agents directories) — actions in other repos that require credentials and cannot be performed from an automated sandbox. Left open and not bundled here.

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented (no `chainweaver` public-API changes; playground is a standalone app)
- [x] No secrets or credentials included

---
_Generated by [Claude Code](https://claude.ai/code/session_014vi7nbCWqXnqipDFM8KyMC)_