### PR TITLE
[codex] Fix MCP registry publication prerequisites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,7 @@ Full checklist: [review-checklist.md](docs/agent-context/review-checklist.md).
 | [review-checklist.md](docs/agent-context/review-checklist.md) | Definition-of-done, review gates | Before submitting a PR, during code review |
 | [versioning-policy.md](docs/versioning-policy.md) | SemVer policy, public-API scope, deprecation process | Adding / removing / renaming public symbols, planning a release |
 | [flow-as-capability.md](docs/agent-context/flow-as-capability.md) | Treating a flow as a Weaver Stack capability (#90); `Flow.capability_id`; `flow_to_selectable_item` exporter | Setting capability identity on a flow, exporting to contextweaver |
-| [SPEC_COMPAT.md](docs/SPEC_COMPAT.md) | Declared `weaver-contracts` 0.6.0 compatibility (#91, #233); conformance test + CI gate | Bumping the pinned contract version, changing the weaver_spec adapters |
+| [SPEC_COMPAT.md](docs/SPEC_COMPAT.md) | Declared `weaver-contracts>=0.6,<1.0` compatibility (#91, #233); conformance test + CI gates | Changing the supported contract range or weaver_spec adapters |
 | [v1-release-criteria.md](docs/v1-release-criteria.md) | Measurable v1.0.0 release bar | Before tagging a release, when scoping issues against the v1.0 milestone |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.12.1] - 2026-06-08
+
+### Fixed
+
+- **MCP registry publication prerequisites** (#230): add the exact PyPI
+  ownership marker for `io.github.dgenio/chainweaver`, shorten the manifest
+  description to the official schema's 100-character limit, and declare the
+  required flow file as a `filepath` while keeping `--tools` optional and
+  repeatable.
+- **Fresh `uvx` tool-module imports** (#230): installed console-script launches
+  now import `--tools` modules from the client's current working directory, so
+  `uvx --from "chainweaver[mcp]" chainweaver serve <flow_file> --tools
+  <tools_module>` works outside an editable repository install.
+
 ## [0.12.0] - 2026-06-08
 
 ### Added
@@ -966,6 +980,10 @@ flow.input_schema   # → MyInput (resolves the ref lazily)
 This file starts at 0.4.0.  See the git history for the contents of the
 0.1.0 and 0.2.0 releases.
 
+[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/dgenio/ChainWeaver/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/dgenio/ChainWeaver/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/dgenio/ChainWeaver/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/dgenio/ChainWeaver/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/dgenio/ChainWeaver/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/dgenio/ChainWeaver/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ _No changes yet._
   now import `--tools` modules from the client's current working directory, so
   `uvx --from "chainweaver[mcp]" chainweaver serve <flow_file> --tools
   <tools_module>` works outside an editable repository install.
+- **Floor-dependency conformance** (#311): validate the installed
+  `weaver-contracts` version against the declared `>=0.6,<1.0` range instead
+  of requiring the compatibility document to name one exact installed release.
 
 ## [0.12.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ChainWeaver
 
+<!-- mcp-name: io.github.dgenio/chainweaver -->
+
 **Observe the tool paths your agent repeats. Compile them into typed, deterministic flows. Replace the LLM-in-the-loop with governed, auditable execution.**
 
 [![PyPI](https://img.shields.io/pypi/v/chainweaver)](https://pypi.org/project/chainweaver/)

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -208,7 +208,7 @@ ExecutionSnapshot.model_rebuild(_types_namespace=_forward_namespace)
 # applications can configure logging centrally without interference.
 logging.getLogger("chainweaver").addHandler(logging.NullHandler())
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "BUILTIN_PROPERTIES",

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -447,8 +447,10 @@ def _import_tools_from(module_name: str) -> list[Tool]:
     """Import *module_name* and return every :class:`Tool` found at top level.
 
     Args:
-        module_name: A Python import path (e.g. ``"my_pkg.tools"``).  The
-            module must be importable from the current ``sys.path``.
+        module_name: A Python import path (e.g. ``"my_pkg.tools"``). Modules
+            in the current working directory are importable, matching normal
+            ``python -m`` behavior even when ChainWeaver runs as an installed
+            console script.
 
     Returns:
         A list of :class:`Tool` instances, in the order they appear in
@@ -461,6 +463,12 @@ def _import_tools_from(module_name: str) -> list[Tool]:
             with a clear stderr message; exit code is ``2`` (module is treated
             like a missing file, consistent with the CLI's exit-code contract).
     """
+    cwd = str(Path.cwd())
+    # Installed console scripts put their own scripts directory at sys.path[0],
+    # so explicitly preserve the documented ability to import local tool modules.
+    if "" not in sys.path and cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
     try:
         module: ModuleType = importlib.import_module(module_name)
     except (ImportError, ModuleNotFoundError) as exc:

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -463,11 +463,10 @@ def _import_tools_from(module_name: str) -> list[Tool]:
             with a clear stderr message; exit code is ``2`` (module is treated
             like a missing file, consistent with the CLI's exit-code contract).
     """
-    cwd = str(Path.cwd())
     # Installed console scripts put their own scripts directory at sys.path[0],
     # so explicitly preserve the documented ability to import local tool modules.
-    if "" not in sys.path and cwd not in sys.path:
-        sys.path.insert(0, cwd)
+    if "" not in sys.path:
+        sys.path.insert(0, "")
 
     try:
         module: ModuleType = importlib.import_module(module_name)

--- a/chainweaver/integrations/weaver_spec.py
+++ b/chainweaver/integrations/weaver_spec.py
@@ -22,9 +22,9 @@ and `agent-kernel` (capability execution).  Four concerns sit here:
    resolves a routing decision to a registered flow so a Weaver router
    can hand a verdict straight to ChainWeaver for execution.
 4. **Conformance signal** — :data:`WEAVER_SPEC_VERSION` mirrors the
-   installed contract version (issue #91).  The conformance test suite
-   (``tests/test_weaver_spec_conformance.py``) verifies the declaration
-   matches ``docs/SPEC_COMPAT.md``.
+   installed contract version (issue #91). The conformance test suite
+   (``tests/test_weaver_spec_conformance.py``) verifies that version is
+   inside the supported range documented in ``docs/SPEC_COMPAT.md``.
 
 No agent-kernel or contextweaver imports live in
 :mod:`chainweaver.executor` — per the Weaver Stack guardrail
@@ -73,9 +73,8 @@ if TYPE_CHECKING:
 
 #: Version string of the ``weaver-contracts`` package ChainWeaver
 #: consumes.  Sourced from the installed distribution so the declaration
-#: cannot drift from what is actually importable.  The conformance test
-#: in ``tests/test_weaver_spec_conformance.py`` keeps
-#: ``docs/SPEC_COMPAT.md`` and this constant in sync.
+#: cannot drift from what is actually importable. The conformance test
+#: verifies this version satisfies the package's supported dependency range.
 WEAVER_SPEC_VERSION = _CONTRACT_VERSION
 
 

--- a/docs/SPEC_COMPAT.md
+++ b/docs/SPEC_COMPAT.md
@@ -1,33 +1,32 @@
 # Weaver-spec compatibility
 
-ChainWeaver consumes a specific revision of the
+ChainWeaver consumes a supported range of the
 [weaver-spec](https://github.com/dgenio/weaver-spec) contract, published
 to PyPI as the [`weaver-contracts`](https://pypi.org/project/weaver-contracts/)
-distribution.  The declared version lives in source so CI fails any
-change that bumps the contract without also touching this document.
+distribution. The dependency range lives in `pyproject.toml`;
+`WEAVER_SPEC_VERSION` reports the version installed at runtime.
 
 ## Declared compatibility
 
-- **weaver-contracts version:** `0.7.0`
-- **Source of truth:**
+- **Supported `weaver-contracts` range:** `>=0.6,<1.0`
+- **Minimum version tested in CI:** `0.6.0`
+- **Runtime version signal:**
   `chainweaver.integrations.weaver_spec.WEAVER_SPEC_VERSION`
   (read from the installed `weaver_contracts.version.CONTRACT_VERSION`)
 - **Optional extra:** `pip install 'chainweaver[weaver-stack]'`
 - **Conformance test suite:**
   `tests/test_weaver_spec_conformance.py`
 - **CI gate:**
-  `.github/workflows/ci.yml` — the
-  `conformance` job runs `pytest -m conformance` on the canonical
-  Python 3.10 / `ubuntu-latest` lane.
+  `.github/workflows/ci.yml` — the `conformance` job validates the normally
+  resolved dependency, while `floor-deps` validates the declared minimum.
 
-The version above must match
-`WEAVER_SPEC_VERSION`
-verbatim.  The conformance test asserts this — bumping the package
-without updating this document, or vice versa, breaks CI.
+The conformance test asserts that the installed `WEAVER_SPEC_VERSION`
+satisfies the package metadata's declared range and that this document
+lists the same lower and upper bounds.
 
 ## Supported invariants
 
-ChainWeaver consumes `weaver-contracts` 0.7.0's three core routing /
+ChainWeaver consumes `weaver-contracts>=0.6,<1.0`'s three core routing /
 execution invariants directly (no internal mirror types):
 
 | Invariant | What it requires | Where it lives in ChainWeaver |
@@ -37,12 +36,12 @@ execution invariants directly (no internal mirror types):
 | **I-07 — `CapabilityToken`** | Capability execution is delegated to a kernel via a scoped bearer token. | `CapabilityToken` is the upstream type; `KernelBackedExecutor` dispatches `step_type="capability"` steps through a `KernelProtocol`, gating each call against the token's `scope`. |
 
 ChainWeaver consumes the upstream dataclasses directly, so there is no
-mirror-vs-spec drift to police — the only seam is the declared version
+mirror-vs-spec drift to police — the only seam is the declared range
 above.  Importing `chainweaver.integrations.weaver_spec` (or the
 `contextweaver` / `agent_kernel` adapters that build on it) requires the
 `weaver-stack` extra; the base install is unaffected.
 
-## How to bump the declared version
+## How to change the supported range
 
 1. Install the new `weaver-contracts` release and review its changelog
    for shape changes to `SelectableItem` / `RoutingDecision` /
@@ -51,8 +50,8 @@ above.  Importing `chainweaver.integrations.weaver_spec` (or the
    `chainweaver/integrations/weaver_spec.py`,
    `contextweaver.py`, and `agent_kernel.py` if any consumed field
    changed.
-3. Bump the pin in `pyproject.toml` (`weaver-stack` extra and `dev`).
-   `WEAVER_SPEC_VERSION` tracks the installed package automatically.
+3. Update the range in `pyproject.toml` (`weaver-stack` extra and `dev`).
+   `WEAVER_SPEC_VERSION` continues to track the installed package.
 4. Update this document — the "Declared compatibility" section *and*
    any invariant rows that changed.
 5. Update `tests/test_weaver_spec_conformance.py` to cover any new

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -195,5 +195,5 @@ standalone; the only seams that reach into integrations are:
 - The `_execute_capability_step` hook — overridden by
   `KernelBackedExecutor`, not by the base class.
 
-`docs/SPEC_COMPAT.md` declares the targeted weaver-spec version; bumping it
+`docs/SPEC_COMPAT.md` declares the supported weaver-spec range; changing it
 follows the procedure documented there.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -41,14 +41,24 @@ conforming to the
       working server: `server.json` now carries a `--from 'chainweaver[mcp]'`
       `uvx` runtime argument (resolving the `mcp` extra) plus a required
       `flow_file` positional. `tests/test_server_manifest.py` guards this.
-- [ ] Publish the manifest's `version` (including the `mcp` extra) to PyPI so it
+- [x] Add the required PyPI ownership marker
+      `<!-- mcp-name: io.github.dgenio/chainweaver -->` to `README.md`.
+- [ ] Publish the manifest's `version` (including the README marker and `mcp`
+      extra) to PyPI so it
       resolves to an installable release. Confirm the version is live on
       [PyPI](https://pypi.org/project/chainweaver/) before publishing the
-      manifest; see [#250](https://github.com/dgenio/ChainWeaver/issues/250).
+      manifest.
 - [ ] Validate and publish with the official
       [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) tool —
       it validates `server.json` against the live schema on publish. Confirm the
       `version` field matches the published PyPI release first.
+
+Fresh-client verification command:
+
+```bash
+uvx --from 'chainweaver[mcp]==<VERSION>' chainweaver serve \
+  examples/double_add_format.flow.yaml --tools examples.simple_linear_flow
+```
 
 ## awesome-* lists
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -88,7 +88,8 @@ A ready-to-submit MCP registry manifest ships at
 launches the server with a fresh-client command that resolves the `mcp` extra:
 
 ```bash
-uvx --from 'chainweaver[mcp]' chainweaver serve /abs/path/to/your.flow.yaml
+uvx --from 'chainweaver[mcp]' chainweaver serve /abs/path/to/your.flow.yaml \
+  --tools your_package.tools
 ```
 
 See [Distribution & ecosystem listings](distribution.md) for the registry and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chainweaver"
-version = "0.12.0"
+version = "0.12.1"
 description = "Deterministic orchestration layer for MCP-based agents."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dgenio/chainweaver",
-  "description": "Deterministic orchestration layer for MCP agents. Compiles tool sequences into schema-validated flows and exposes each flow as a single MCP tool — no LLM at build or run time.",
-  "version": "0.12.0",
+  "title": "ChainWeaver",
+  "description": "Expose deterministic ChainWeaver flows as MCP tools without LLM calls between steps.",
+  "version": "0.12.1",
   "repository": {
     "url": "https://github.com/dgenio/ChainWeaver",
     "source": "github"
@@ -12,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "chainweaver",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {
@@ -34,12 +35,15 @@
           "type": "positional",
           "valueHint": "flow_file",
           "description": "Path to a .flow.yaml/.flow.json file to expose as MCP tools.",
+          "format": "filepath",
           "isRequired": true
         },
         {
           "type": "named",
           "name": "--tools",
           "description": "Python module path exposing Tool instances at top level. Repeatable.",
+          "placeholder": "your_package.tools",
+          "isRequired": false,
           "isRepeated": true
         }
       ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -489,6 +490,23 @@ def _module_sys_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 class TestRunCommand:
+    def test_imports_tools_module_from_current_working_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        module_name = _write_tools_module(tmp_path, name="cwd_double")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "path",
+            [entry for entry in sys.path if entry not in {"", str(tmp_path)}],
+        )
+
+        imported = cli._import_tools_from(module_name)
+
+        assert [tool.name for tool in imported] == ["cwd_double"]
+
     def test_happy_path_table_output(
         self,
         _module_sys_path: Path,

--- a/tests/test_server_manifest.py
+++ b/tests/test_server_manifest.py
@@ -17,6 +17,8 @@ from typing import Any
 import chainweaver
 
 _MANIFEST = Path(__file__).resolve().parents[1] / "server.json"
+_README = Path(__file__).resolve().parents[1] / "README.md"
+_MCP_NAME_MARKER = "<!-- mcp-name: io.github.dgenio/chainweaver -->"
 
 
 def _load_manifest() -> dict[str, Any]:
@@ -34,7 +36,11 @@ def _pypi_package(manifest: dict[str, Any]) -> dict[str, Any]:
 
 def test_manifest_is_valid_json() -> None:
     manifest = _load_manifest()
+    assert manifest["$schema"] == (
+        "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    )
     assert manifest["name"] == "io.github.dgenio/chainweaver"
+    assert len(manifest["description"]) <= 100
 
 
 def test_manifest_version_matches_package() -> None:
@@ -46,7 +52,10 @@ def test_manifest_version_matches_package() -> None:
 def test_uvx_launch_resolves_mcp_extra() -> None:
     """A fresh client must install ``chainweaver[mcp]``, not bare ``chainweaver``."""
     package = _pypi_package(_load_manifest())
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == "chainweaver"
     assert package["runtimeHint"] == "uvx"
+    assert package["transport"] == {"type": "stdio"}
     runtime_args = package.get("runtimeArguments", [])
     from_args = [
         arg for arg in runtime_args if arg.get("type") == "named" and arg.get("name") == "--from"
@@ -64,3 +73,20 @@ def test_serve_command_takes_required_flow_file() -> None:
     ]
     assert required_positional, "server.json must require a flow-file positional."
     assert required_positional[0]["valueHint"] == "flow_file"
+    assert required_positional[0]["format"] == "filepath"
+
+
+def test_tools_module_argument_is_optional_and_repeatable() -> None:
+    package_args = _pypi_package(_load_manifest())["packageArguments"]
+    tools_args = [
+        arg for arg in package_args if arg.get("type") == "named" and arg.get("name") == "--tools"
+    ]
+    assert len(tools_args) == 1
+    assert tools_args[0]["isRepeated"] is True
+    assert tools_args[0]["isRequired"] is False
+    assert "value" not in tools_args[0]
+
+
+def test_pypi_readme_contains_registry_ownership_marker() -> None:
+    readme = _README.read_text(encoding="utf-8")
+    assert readme.count(_MCP_NAME_MARKER) == 1

--- a/tests/test_weaver_spec_conformance.py
+++ b/tests/test_weaver_spec_conformance.py
@@ -1,10 +1,10 @@
 """Weaver-spec conformance gate (issues #91, #233).
 
 This module is the CI conformance signal for ChainWeaver's declared
-weaver-spec compatibility.  It is collected by the default ``pytest``
+weaver-spec compatibility. It is collected by the default ``pytest``
 run *and* by the dedicated CI job in ``.github/workflows/ci.yml`` so
-drift between :data:`chainweaver.integrations.weaver_spec.WEAVER_SPEC_VERSION`
-and ``docs/SPEC_COMPAT.md`` fails the build.
+drift between the package metadata and ``docs/SPEC_COMPAT.md`` fails
+the build.
 
 The tests are intentionally narrow:
 
@@ -15,18 +15,21 @@ The tests are intentionally narrow:
   :mod:`chainweaver.integrations.weaver_spec` are the upstream
   dataclasses and that the exporter/resolvers are at their documented
   paths.
-- They cross-check the declared version against
-  ``docs/SPEC_COMPAT.md`` so the compat statement and the code stay
-  in sync.
+- They cross-check the declared dependency range against the installed
+  version and ``docs/SPEC_COMPAT.md``.
 """
 
 from __future__ import annotations
 
 import dataclasses
 import json
+from importlib.metadata import requires as distribution_requires
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 pytest.importorskip("weaver_contracts")
 
@@ -44,6 +47,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SPEC_COMPAT_PATH = REPO_ROOT / "docs" / "SPEC_COMPAT.md"
 
 
+def _declared_weaver_specifier() -> SpecifierSet:
+    """Return the unique weaver-contracts range from package metadata."""
+    specifiers = {
+        str(requirement.specifier)
+        for raw_requirement in distribution_requires("chainweaver") or ()
+        if (requirement := Requirement(raw_requirement)).name == "weaver-contracts"
+    }
+    assert len(specifiers) == 1, (
+        "Expected one consistent weaver-contracts range in package metadata; "
+        f"got {sorted(specifiers)!r}."
+    )
+    return SpecifierSet(specifiers.pop())
+
+
 @pytest.mark.conformance
 def test_weaver_spec_version_format() -> None:
     """The declared version is a PEP 440-style ``major.minor.patch`` string."""
@@ -59,19 +76,20 @@ def test_declared_version_matches_installed_contract() -> None:
     from weaver_contracts.version import CONTRACT_VERSION
 
     assert WEAVER_SPEC_VERSION == CONTRACT_VERSION
+    assert Version(WEAVER_SPEC_VERSION) in _declared_weaver_specifier()
     assert is_compatible(WEAVER_SPEC_VERSION) is True
 
 
 @pytest.mark.conformance
-def test_spec_compat_doc_references_declared_version() -> None:
-    """``docs/SPEC_COMPAT.md`` must mention the declared spec version."""
+def test_spec_compat_doc_references_declared_range() -> None:
+    """``docs/SPEC_COMPAT.md`` must mention every declared range bound."""
     assert SPEC_COMPAT_PATH.is_file(), f"Missing {SPEC_COMPAT_PATH}"
     text = SPEC_COMPAT_PATH.read_text(encoding="utf-8")
-    assert WEAVER_SPEC_VERSION in text, (
-        f"docs/SPEC_COMPAT.md does not reference declared "
-        f"WEAVER_SPEC_VERSION={WEAVER_SPEC_VERSION!r}. "
-        f"Update the doc or bump the constant in lock-step."
-    )
+    for bound in _declared_weaver_specifier():
+        assert str(bound) in text, (
+            f"docs/SPEC_COMPAT.md does not reference declared "
+            f"weaver-contracts bound {str(bound)!r}."
+        )
 
 
 @pytest.mark.conformance


### PR DESCRIPTION
## Summary

- bump ChainWeaver and `server.json` to `0.12.1`, the first releasable version whose PyPI description can carry the required MCP ownership marker
- align `server.json` with the current official schema, including its description limit, required `filepath` flow argument, and optional repeatable `--tools` argument
- make installed console-script launches import tool modules from the client's current working directory, so the documented `uvx` command works outside an editable checkout
- model Weaver contract compatibility as the declared `>=0.6,<1.0` range, allowing both normal and floor-dependency conformance lanes to validate the installed version correctly
- add regression coverage and update the existing release and compatibility documentation

## Why

PyPI `0.12.0` is live, but its immutable package description does not contain `<!-- mcp-name: io.github.dgenio/chainweaver -->`. Publishing that manifest would fail registry ownership verification. The published CLI also could not import `examples.simple_linear_flow` from a fresh client's working directory because an installed console script does not place that directory on `sys.path`.

The floor-dependencies lane exposed a separate modeling contradiction: package metadata supports `weaver-contracts>=0.6,<1.0`, but the compatibility document and test required one exact installed version. The conformance test now derives the range from package metadata and verifies both the installed version and documented bounds.

## Validation

- `mcp-publisher v1.7.9 validate server.json`
- `ruff check chainweaver/ tests/ examples/`
- `ruff format --check chainweaver/ tests/ examples/`
- `python -m mypy chainweaver/ tests/`
- `python -m pytest tests/ -v` (`1385 passed, 1 skipped`, 92.12% coverage)
- isolated Python 3.10 with `weaver-contracts==0.6.0`: all 11 conformance tests passed
- built wheel and sdist; `twine check` passed for both
- verified wheel metadata version `0.12.1` and the MCP ownership marker in both release artifacts
- isolated local-wheel smoke: `uvx --from "chainweaver[mcp] @ file:///.../chainweaver-0.12.1-py3-none-any.whl" chainweaver --help`
- isolated local-wheel MCP smoke: `chainweaver serve examples/double_add_format.flow.yaml --tools examples.simple_linear_flow` started one flow tool over stdio

## Release and publication gate

After merge, tag `v0.12.1` and wait for the existing publish workflow to put `chainweaver[mcp]==0.12.1` on PyPI. Only then should the maintainer run the pinned `uvx` verification, `mcp-publisher login github`, and `mcp-publisher publish`. The official registry currently returns no ChainWeaver entry.

Progresses #230.
Fixes #311.