### PR TITLE
Automate release and distribution workflows

### DIFF
--- a/.github/actions/chainweaver/README.md
+++ b/.github/actions/chainweaver/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
         with:
           directory: flows/
 ```
@@ -29,7 +29,7 @@ jobs:
 | `directory` | `.` | Directory scanned recursively for flow files. |
 | `annotations` | `true` | Emit GitHub `::error` annotations for each invalid flow file. Annotations are file-scoped — the flow serializer reports structural errors per file without line numbers. |
 | `python-version` | `3.10` | Python version used to install and run `chainweaver`. Must be one of ChainWeaver's supported versions (3.10–3.14). |
-| `chainweaver-version` | `0.12.0` | Exact version of `chainweaver` to install from PyPI (passed through to `pip install "chainweaver==<version>"`). Pinned by default; pass an empty string for the latest published version. |
+| `chainweaver-version` | `0.12.1` | Exact version of `chainweaver` to install from PyPI (passed through to `pip install "chainweaver==<version>"`). Pinned by default; pass an empty string for the latest published version. |
 | `extra-args` | `""` | Additional arguments appended verbatim to the invocation (e.g. `--quiet`). |
 
 ### Outputs
@@ -51,7 +51,7 @@ summary. Set `annotations: false` to disable.
 ### Validate every flow under `flows/`
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
   with:
     directory: flows/
 ```
@@ -59,7 +59,7 @@ summary. Set `annotations: false` to disable.
 ### Forward the result to a downstream step
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
   id: cw
   continue-on-error: true
   with:
@@ -72,15 +72,15 @@ summary. Set `annotations: false` to disable.
 ### Pin to a specific ChainWeaver release
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
   with:
-    chainweaver-version: "0.12.0"
+    chainweaver-version: "0.12.1"
 ```
 
 ### Track the latest release instead
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
   with:
     chainweaver-version: ""  # falls through to ``pip install chainweaver``
 ```
@@ -89,9 +89,15 @@ summary. Set `annotations: false` to disable.
 
 This action lives inside the `dgenio/ChainWeaver` repository, so it is
 versioned with the package. Pin to a ChainWeaver release tag
-(`@v0.12.0`) rather than `@main` to avoid implicit upgrades.
+(`@v0.12.1`) rather than `@main` to avoid implicit upgrades.
 
 The `chainweaver-version` input default matches the action's tag — both
 are bumped in lockstep when a new ChainWeaver release ships. If you
 override `chainweaver-version`, the action will install whatever you ask
 for; it will not refuse a mismatch.
+
+ChainWeaver's own pre-publish smoke workflow passes an empty version so a
+release PR tests the action code against the latest package already available
+on PyPI. After publication, `distribution-check.yml` reruns the action with the
+exact just-published version. This keeps downstream defaults pinned without
+making release-day CI depend on a package that does not exist yet.

--- a/.github/actions/chainweaver/action.yml
+++ b/.github/actions/chainweaver/action.yml
@@ -27,7 +27,7 @@ inputs:
       Pinned by default to a known-good release; pass an empty string
       to install the latest published version.
     required: false
-    default: "0.12.0"
+    default: "0.12.1"
   extra-args:
     description: |
       Additional arguments appended verbatim to the ``chainweaver``

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -43,6 +43,10 @@ jobs:
         uses: ./.github/actions/chainweaver
         with:
           directory: examples
+          # Pre-publish CI exercises action code at HEAD against the latest
+          # already-published package. distribution-check.yml verifies the
+          # exact new pin after PyPI publication.
+          chainweaver-version: ""
       - name: Assert success
         run: test "${{ steps.cw.outputs.exit-code }}" = "0"
 
@@ -61,6 +65,7 @@ jobs:
         uses: ./.github/actions/chainweaver
         with:
           directory: ${{ runner.temp }}/flows
+          chainweaver-version: ""
       - name: Assert failure
         run: |
           test "${{ steps.cw.outcome }}" = "failure"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,16 +7,12 @@ name: Bench
 # History is stored in the repo's ``gh-pages`` branch (a one-off manual
 # init step; see ``benchmarks/README.md``).
 #
-# Regression contract: a compiled metric that grows by more than 25%
-# vs. the recorded baseline fails the build. ``customSmallerIsBetter``
-# means smaller values are better; the action emits a PR comment when
-# the threshold trips.
+# Regression contract: a compiled metric that grows beyond 2x the recorded
+# baseline alerts only when execution-sensitive files changed.
 #
-# The gate is enforced (fails the build) only on pushes to ``main``,
-# where the baseline is captured on a consistent runner. On PRs it is
-# advisory (comment-only): the sub-millisecond ``compiled`` overhead
-# metrics swing 50-170us on shared CI runners, which trips the 25%
-# alert on runner noise rather than a real regression.
+# The benchmark still runs on release/docs PRs so the normal check remains
+# present, but those changes cannot emit a noisy performance alert. The gate is
+# enforced only on pushes to ``main`` that touched the executor path.
 
 on:
   push:
@@ -46,6 +42,27 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect execution-sensitive changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          files="$(git diff --name-only "${base}" "${{ github.sha }}")"
+          echo "${files}"
+          if echo "${files}" | grep -Eq \
+            '^(chainweaver/(cache|checkpoint|compiler|contracts|decisions|events|executor|flow|middleware|registry|tools)\.py|benchmarks/.*|pyproject\.toml|\.github/workflows/bench\.yml)$'; then
+            echo "execution=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "execution=false" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Ensure gh-pages branch exists
         shell: bash
@@ -103,15 +120,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only archive results from main; PR-triggered runs would pollute
           # gh-pages with PR-branch data points and skew the alert baseline.
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.changes.outputs.execution == 'true' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-          # Fail the PR if any compiled metric regresses > 25% vs. the
-          # historical baseline on the same branch / gh-pages page.
-          alert-threshold: "125%"
-          # Enforce the gate only on main; PR runs stay advisory so
-          # sub-millisecond microbenchmark variance on shared runners does
-          # not fail PRs. ``comment-on-alert`` still surfaces a heads-up.
-          fail-on-alert: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          comment-on-alert: true
+          # Sub-millisecond measurements vary substantially on shared runners.
+          # A 2x threshold catches major regressions without treating 50-170us
+          # jitter as a release failure.
+          alert-threshold: "200%"
+          # Only execution-sensitive changes can alert or fail. PR runs remain
+          # advisory; the matching main push enforces the gate.
+          fail-on-alert: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.changes.outputs.execution == 'true' }}
+          comment-on-alert: ${{ github.event_name == 'pull_request' && steps.changes.outputs.execution == 'true' }}
           alert-comment-cc-users: "@dgenio"

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -1,0 +1,107 @@
+name: Distribution check
+
+# Verify public release surfaces only after Publish to PyPI finishes. The
+# workflow_run trigger executes from the default branch, then checks out the
+# exact release SHA reported by the publication run.
+
+on:
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to verify (X.Y.Z)."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify published distribution
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      MCP_PUBLISHER_VERSION: "1.7.9"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Resolve and verify release version
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="$(python scripts/release.py version)"
+          fi
+          python scripts/release.py check --expected-version "${version}"
+          git fetch --force origin "refs/tags/v${version}:refs/tags/v${version}"
+          test "$(git rev-list -n 1 "v${version}")" = "$(git rev-parse HEAD)"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for exact PyPI version
+        run: >-
+          python scripts/release.py verify-pypi
+          "${{ steps.release.outputs.version }}"
+          --attempts 12
+          --delay 10
+
+      - name: Install official MCP publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/mcp-publisher.tar.gz"
+          checksums="${RUNNER_TEMP}/registry-checksums.txt"
+          curl --fail --location --show-error \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            --output "${archive}"
+          curl --fail --location --show-error \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/registry_${MCP_PUBLISHER_VERSION}_checksums.txt" \
+            --output "${checksums}"
+          (
+            cd "${RUNNER_TEMP}"
+            grep ' mcp-publisher_linux_amd64.tar.gz$' "${checksums}" \
+              | sha256sum --check -
+          )
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" mcp-publisher
+          chmod +x "${RUNNER_TEMP}/mcp-publisher"
+
+      - name: Validate MCP registry manifest
+        run: "${RUNNER_TEMP}/mcp-publisher validate server.json"
+
+      - name: Smoke-test released action and package
+        id: action-smoke
+        uses: ./.github/actions/chainweaver
+        with:
+          directory: examples
+          chainweaver-version: ${{ steps.release.outputs.version }}
+
+      - name: Assert action success
+        run: test "${{ steps.action-smoke.outputs.exit-code }}" = "0"
+
+      - name: Write release summary
+        shell: bash
+        run: |
+          python scripts/release.py status \
+            --expected-version "${{ steps.release.outputs.version }}" \
+            >> "${GITHUB_STEP_SUMMARY}"
+          {
+            echo
+            echo "- PyPI version resolved: ${{ steps.release.outputs.version }}"
+            echo "- MCP manifest validated with mcp-publisher ${MCP_PUBLISHER_VERSION}"
+            echo "- Released composite action smoke test passed"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: publish-${{ inputs.version || github.ref_name }}
+  group: publish-${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,6 +103,10 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # A rerun may follow a failure after PyPI accepted the files but
+          # before the GitHub Release or distribution checks completed.
+          skip-existing: true
 
   github-release:
     needs: [release, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,53 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing tagged version to publish (X.Y.Z)."
+        required: true
+        type: string
+
+concurrency:
+  group: publish-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  release:
+    name: validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate tag and metadata
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          python scripts/release.py check --expected-version "${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
   test:
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -23,10 +64,12 @@ jobs:
         run: python -m pytest tests/ -v
 
   build:
-    needs: test
+    needs: [release, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -62,14 +105,17 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   github-release:
-    needs: publish
+    needs: [release, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          tag_name: v${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,142 @@
+name: Prepare release
+
+# Release PRs are generated from the authoritative package version and merged
+# through the normal branch-protection path. A successful main-branch CI run
+# creates a tag on the exact verified merge commit, then explicitly dispatches
+# publish.yml because tag pushes made with GITHUB_TOKEN do not trigger another
+# workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version in X.Y.Z format."
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: open release PR
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Prepare release metadata
+        run: python scripts/release.py prepare "${{ inputs.version }}"
+
+      - name: Verify release metadata
+        run: python scripts/release.py check --expected-version "${{ inputs.version }}"
+
+      - name: Generate release status
+        run: python scripts/release.py status > "${RUNNER_TEMP}/release-status.md"
+
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          # Required because GitHub suppresses pull_request workflow events
+          # created with GITHUB_TOKEN. Use a fine-grained PAT or App token.
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          branch: release/v${{ inputs.version }}
+          base: main
+          commit-message: "release: prepare v${{ inputs.version }}"
+          title: "Release v${{ inputs.version }}"
+          body-path: ${{ runner.temp }}/release-status.md
+          labels: release
+          delete-branch: true
+          add-paths: |
+            chainweaver/__init__.py
+            server.json
+            .github/actions/chainweaver/action.yml
+            .github/actions/chainweaver/README.md
+            docs/github-action.md
+            CHANGELOG.md
+
+  tag:
+    name: tag verified merge commit
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MERGE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Find merged release PR
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          head_ref="$(
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${MERGE_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and (.head.ref | startswith("release/v")))] | if length == 1 then .[0].head.ref else "" end'
+          )"
+          if [ -z "${head_ref}" ]; then
+            echo "release=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "release=true" >> "${GITHUB_OUTPUT}"
+          echo "version=${head_ref#release/v}" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@v6
+        if: steps.release.outputs.release == 'true'
+        with:
+          ref: ${{ env.MERGE_SHA }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        if: steps.release.outputs.release == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Verify merged release metadata
+        if: steps.release.outputs.release == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          python scripts/release.py check --expected-version "${VERSION}"
+
+      - name: Create release tag
+        id: tag
+        if: steps.release.outputs.release == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          remote_sha="$(git ls-remote origin "refs/tags/${tag}" | cut -f1)"
+          if [ -n "${remote_sha}" ]; then
+            test "${remote_sha}" = "${MERGE_SHA}"
+            echo "created=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          git tag "${tag}" "${MERGE_SHA}"
+          git push origin "${tag}"
+          echo "created=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch publication
+        if: steps.tag.outputs.created == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: gh workflow run publish.yml --ref "v${VERSION}" -f version="${VERSION}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,9 @@ mkdocs.yml                   MkDocs Material site config (#133)
 .readthedocs.yaml            Read the Docs build config (#133)
 pytest_chainweaver.py        Top-level pytest plugin module (#132); registered via [project.entry-points.pytest11]. Deliberately outside the chainweaver/ package so pytest's entry-point loader does not transitively import chainweaver before pytest-cov starts coverage measurement.
 pyproject.toml               Ruff, mypy, pytest config (source of truth for tooling)
-scripts/                     Maintenance scripts run from CI, not shipped in the package — refresh_prices.py keeps cost.py PROVIDER_PRICES fresh (#156)
+scripts/                     Maintenance scripts run from CI, not shipped in the package — release.py prepares/verifies releases (#304–#309); refresh_prices.py keeps cost.py PROVIDER_PRICES fresh (#156)
 benchmarks/                  Standalone benchmark scripts (not coverage-gated): bench_naive_vs_compiled.py (#29), bench_correctness.py (#103), report.py (#207); results/ holds generated latest.{json,md}
-.github/workflows/           CI (ci.yml), docs (docs.yml), bench (bench.yml), publish (publish.yml), and update-prices.yml (#156) workflows
+.github/workflows/           CI/docs/bench plus PR-first release, publish, post-publish distribution verification, and update-prices workflows
 ```
 
 ### Key entry points
@@ -338,10 +338,10 @@ installs the minimum declared dependency versions
 (`uv pip install --resolution lowest-direct`) and runs the full suite on
 Python 3.10, and a weekly scheduled `latest-deps` job runs the suite
 against the newest (incl. pre-release) dependencies on Python 3.14
-(issue #236). A separate `bench.yml` workflow runs
-the naive-vs-compiled benchmark on `ubuntu-22.04` and fails PRs whose
-median `total_duration_ms` regresses beyond 125 % of the `gh-pages`
-baseline (see [benchmarks/README.md](benchmarks/README.md)).
+(issue #236). A separate `bench.yml` workflow runs the naive-vs-compiled
+benchmark on `ubuntu-22.04`; executor-sensitive changes alert when a compiled
+metric exceeds 200 % of the `gh-pages` baseline, while release/docs changes
+cannot emit performance alerts (see [benchmarks/README.md](benchmarks/README.md)).
 
 For full CI, PR, branch, and commit conventions, see
 [workflows.md](docs/agent-context/workflows.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PR-first release and distribution automation** (#304, #305, #306, #307,
+  #308, #309): make `chainweaver.__version__` authoritative, add one-command
+  release preparation and consistency checks, create and tag reviewed release
+  PRs, verify PyPI/MCP/Action surfaces after publication, decouple pre-publish
+  Action smoke tests from unreleased pins, and restrict 2x benchmark alerts to
+  execution-sensitive changes.
 - **Governed macro-flow lifecycle and safe MCP exposure** (#259, #268, #294):
   flows now carry serializable `FlowGovernance` metadata with explicit
   `observed → suggested → draft → reviewed → active` promotion states plus

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -109,9 +109,11 @@ for debugging or for generating a local diff against `baseline.json`.
 
 ## CI bench guard (`.github/workflows/bench.yml`)
 
-The bench workflow runs the default sweep on every PR and push to
-`main`, uploads the result via `benchmark-action/github-action-benchmark`,
-and stores the history on the repo's `gh-pages` branch.
+The bench workflow runs the default sweep on every PR and push to `main`,
+uploads the result via `benchmark-action/github-action-benchmark`, and stores
+the history on the repo's `gh-pages` branch. Every PR still gets the benchmark
+check, including release PRs, but alerts are enabled only when the diff touches
+execution-sensitive modules or benchmark configuration.
 
 | Setting | Value |
 |---|---|
@@ -119,8 +121,15 @@ and stores the history on the repo's `gh-pages` branch.
 | Python | 3.10 |
 | Repeats | 5 (median reporting) |
 | Tool | `customSmallerIsBetter` |
-| Alert threshold | `125 %` — fail the PR if any compiled metric regresses > 25 % |
-| Comment | Posted on PR when the threshold trips |
+| Alert threshold | `200 %` — flag a compiled metric only when it exceeds 2x its baseline |
+| Alert scope | Executor-path and benchmark changes only |
+| Enforcement | Advisory comment on matching PRs; failure on the matching `main` push |
+
+The broader threshold is intentional. Compiled overhead is normally below one
+millisecond, where a 50-170 microsecond shared-runner swing can exceed a 25%
+ratio without a meaningful code regression. A 2x gate still catches major
+executor regressions while version-only and documentation releases cannot emit
+alerts.
 
 ### `gh-pages` branch
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -36,8 +36,38 @@ python -m pytest tests/ -v
 |----------|---------|-------|
 | `ci.yml` | Push/PR to `main` (+ weekly `schedule`) | Ruff lint + format `chainweaver/ tests/ examples/` + mypy `chainweaver/ tests/` (Python 3.10 on `ubuntu-latest` only); pytest across the OS × Python matrix `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12, 3.13, 3.14}`; `nbmake` runs `notebooks/` on the `ubuntu-latest` / 3.12 lane (issue #229); `floor-deps` runs the full suite against minimum declared dependency versions on 3.10 (`uv pip install --resolution lowest-direct`), and a weekly `latest-deps` job runs it against newest/pre-release deps on 3.14 (issue #236) |
 | `docs.yml` | Push/PR to `main` | `mkdocs build --strict` |
-| `publish.yml` | `v*` tags | Test → build → PyPI publish → GitHub Release |
-| `bench.yml` | Push/PR to `main` | Naive-vs-compiled benchmark on `ubuntu-22.04`; fails PRs whose median `total_duration_ms` regresses beyond 125 % of `gh-pages` baseline |
+| `release.yml` | Manual version input; successful `main` CI run | Prepare release metadata and open a PR; after merge CI passes, tag the exact verified merge commit and explicitly dispatch publication |
+| `publish.yml` | `v*` tags or explicit release dispatch | Validate tag metadata → test → build → PyPI publish → GitHub Release |
+| `distribution-check.yml` | Successful `publish.yml` run or manual dispatch | Verify PyPI propagation, tag/SHA, manifest, action pin, and released Action smoke |
+| `action-smoke.yml` | Action/workflow changes | Exercise action code against the latest already-published package before release |
+| `bench.yml` | Push/PR to `main` | Run the benchmark for every change; alert at 200% only when executor-path or benchmark files changed |
+
+---
+
+## Release process
+
+1. Dispatch **Prepare release** with an `X.Y.Z` version.
+2. `scripts/release.py prepare` updates the authoritative
+   `chainweaver.__version__`, `server.json`, Action pin and docs, and promotes
+   the current Unreleased changelog body.
+3. Review and merge the generated `release/vX.Y.Z` PR after its normal required
+   checks pass.
+4. The merge commit runs `CI` on `main`. After that run succeeds, `release.yml`
+   associates the SHA with the merged release PR, verifies its metadata,
+   creates `vX.Y.Z` on that exact commit, and explicitly dispatches
+   `publish.yml`.
+5. After trusted PyPI publication and GitHub Release creation,
+   `distribution-check.yml` verifies every automatable public surface.
+
+Set an Actions secret named `RELEASE_PR_TOKEN` to a fine-grained PAT or GitHub
+App token with contents and pull-request write access. The secret is required:
+GitHub suppresses `pull_request` workflow events when a PR is created with the
+built-in `GITHUB_TOKEN`, so using it would bypass the checks this process is
+designed to enforce.
+
+Publication retries are manual: dispatch **Publish to PyPI** with the existing
+tag's version. Release preparation never pushes directly to `main`, and reruns
+never move an existing release tag.
 
 ---
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -66,8 +66,10 @@ built-in `GITHUB_TOKEN`, so using it would bypass the checks this process is
 designed to enforce.
 
 Publication retries are manual: dispatch **Publish to PyPI** with the existing
-tag's version. Release preparation never pushes directly to `main`, and reruns
-never move an existing release tag.
+tag's version. The publisher skips files already present for that immutable
+version, allowing a run that failed after upload to complete its GitHub Release
+and distribution checks. Release preparation never pushes directly to `main`,
+and reruns never move an existing release tag.
 
 ---
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -2,15 +2,54 @@
 
 ChainWeaver's discovery strategy is **passive reach**: be listed where its exact
 audience already looks — the MCP ecosystem and the major agent-framework
-integration directories. This page is the operational checklist for those
-submissions, plus the prepared copy to paste into each one.
+integration directories. This page records what CI verifies and which external
+submissions remain maintainer-owned.
 
 The in-repo artifacts (the [`serve` command](cli.md#serve), the
-[MCP server guide](mcp-server.md), the [`server.json`](#mcp-registry) manifest, and
-the verified recipes below) are maintained here. The external submissions are
-maintainer actions in *other* projects' repos and are tracked by
-[#230](https://github.com/dgenio/ChainWeaver/issues/230) and
-[#231](https://github.com/dgenio/ChainWeaver/issues/231).
+[MCP server guide](mcp-server.md), the [`server.json`](#mcp-registry) manifest,
+and the verified recipes below) are maintained here. Release metadata is
+prepared by `scripts/release.py` and verified after publication by
+`.github/workflows/distribution-check.yml`.
+
+## Automated via CI
+
+| Check | Automation | Failure behavior |
+|---|---|---|
+| Version consistency | `python scripts/release.py check` | Release preparation and publication stop on drift. |
+| PyPI publication | `publish.yml` with trusted publishing | Publication must succeed before distribution verification starts. |
+| PyPI propagation | `release.py verify-pypi` with bounded retries | Distribution check fails if the exact version never resolves. |
+| MCP manifest | Official `mcp-publisher validate server.json` | Live registry-schema or semantic validation failures are reported. |
+| GitHub Action default | Release consistency check | The default must match the package and manifest version. |
+| Released Action smoke | Local action at the release SHA with the exact published version | Invalid installation or flow validation fails the distribution check. |
+
+The pre-publish `action-smoke.yml` workflow deliberately passes an empty
+`chainweaver-version`, so it tests action changes against the latest package
+already available on PyPI. The exact new pin is tested only after publication.
+
+## Manual / asynchronous
+
+External repositories and marketplaces require maintainer identity, review, or
+interactive publication. CI reports these items but does not impersonate a
+maintainer.
+
+| Item | Status | Tracker |
+|---|---|---|
+| Publish the MCP Registry entry and submit awesome-list PRs | Manual | [#325](https://github.com/dgenio/ChainWeaver/issues/325) |
+| Submit LangGraph/LangChain, OpenAI Agents SDK, and LlamaIndex listings | Manual | [#231](https://github.com/dgenio/ChainWeaver/issues/231) |
+| Publish the validation Action in GitHub Marketplace | Manual | [#325](https://github.com/dgenio/ChainWeaver/issues/325) |
+
+## Post-release status
+
+Generate the status block included in release PRs and workflow summaries:
+
+```bash
+python scripts/release.py status
+```
+
+The output records the current version, governed-reference consistency,
+configured automation, and tracker links for every manual item. The
+post-publish workflow appends live PyPI, manifest, and Action results to the
+GitHub Actions job summary.
 
 ## Verified integration matrix
 
@@ -35,23 +74,13 @@ A draft manifest ships at the repo root as
 conforming to the
 [`2025-12-11` server schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).
 
-**Before submitting:**
-
-- [x] Finalize the package launch in the manifest so a fresh client can start a
-      working server: `server.json` now carries a `--from 'chainweaver[mcp]'`
-      `uvx` runtime argument (resolving the `mcp` extra) plus a required
-      `flow_file` positional. `tests/test_server_manifest.py` guards this.
-- [x] Add the required PyPI ownership marker
-      `<!-- mcp-name: io.github.dgenio/chainweaver -->` to `README.md`.
-- [ ] Publish the manifest's `version` (including the README marker and `mcp`
-      extra) to PyPI so it
-      resolves to an installable release. Confirm the version is live on
-      [PyPI](https://pypi.org/project/chainweaver/) before publishing the
-      manifest.
-- [ ] Validate and publish with the official
-      [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) tool —
-      it validates `server.json` against the live schema on publish. Confirm the
-      `version` field matches the published PyPI release first.
+`server.json` carries a `--from 'chainweaver[mcp]'` `uvx` runtime argument plus
+a required `flow_file` positional. `tests/test_server_manifest.py` guards the
+launch contract, and `README.md` carries the required PyPI ownership marker.
+The post-release workflow confirms the exact package is live on
+[PyPI](https://pypi.org/project/chainweaver/) and validates the manifest with
+the official [`mcp-publisher`](https://github.com/modelcontextprotocol/registry)
+tool before a maintainer performs the tracked registry submission.
 
 Fresh-client verification command:
 
@@ -68,22 +97,27 @@ Open a PR adding ChainWeaver to each list. Suggested entry:
 > orchestration layer for MCP agents. Compiles tool sequences into schema-validated
 > flows and exposes each flow as a single MCP tool — no LLM at build or run time.
 
-- [ ] [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)
-- [ ] `awesome-ai-agents`
-- [ ] `awesome-llm-apps`
+Targets:
+
+- [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers)
+- `awesome-ai-agents`
+- `awesome-llm-apps`
+
+Submission status is tracked in [#325](https://github.com/dgenio/ChainWeaver/issues/325).
 
 ## Framework ecosystem directories
 
 For each framework, verify the recipe against the current version (table above),
 then submit to its community/integration surface:
 
-- [ ] **LangGraph / LangChain** — community/ecosystem integration listing, linking
-      [the LangGraph node recipe](cookbook/langgraph-node.md).
-- [ ] **OpenAI Agents SDK** — community/showcase resources, linking
-      [the OpenAI Agents tool recipe](cookbook/openai-agents-tool.md).
-- [ ] **LlamaIndex** — integrations/community listing, linking the LlamaIndex
-      bridge.
+- **LangGraph / LangChain** — community/ecosystem integration listing, linking
+  [the LangGraph node recipe](cookbook/langgraph-node.md).
+- **OpenAI Agents SDK** — community/showcase resources, linking
+  [the OpenAI Agents tool recipe](cookbook/openai-agents-tool.md).
+- **LlamaIndex** — integrations/community listing, linking the LlamaIndex
+  bridge.
 
+Progress is tracked in [#231](https://github.com/dgenio/ChainWeaver/issues/231).
 Once a listing is accepted, link it from the README **Integrations** section.
 
 ## GitHub Marketplace (validation Action)
@@ -95,12 +129,8 @@ inline PR annotations (see the [GitHub Action guide](github-action.md)). It is a
 distribution surface in its own right: a single `uses:` line lets other repos
 adopt flow validation.
 
-**Before submitting:**
-
-- [ ] Confirm the action's `chainweaver-version` default matches the published
-      PyPI release.
-- [ ] Tag the release so `uses: dgenio/ChainWeaver/.github/actions/chainweaver@<tag>`
-      resolves.
-- [ ] Publish the Action to the
-      [GitHub Marketplace](https://docs.github.com/actions/creating-actions/publishing-actions-in-github-marketplace)
-      from the tagged release.
+CI confirms the action's default matches the published version and that the
+release tag resolves to the tested merge commit. Marketplace publication is a
+manual maintainer action tracked in [#325](https://github.com/dgenio/ChainWeaver/issues/325);
+publish from the tagged release through
+[GitHub Marketplace](https://docs.github.com/actions/creating-actions/publishing-actions-in-github-marketplace).

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
         with:
           directory: flows/
 ```
@@ -51,7 +51,7 @@ structural errors per file, not per line.
 | `directory` | `.` | Directory scanned recursively for flow files. |
 | `annotations` | `true` | Emit `::error` annotations for invalid files. Set `false` to disable. |
 | `python-version` | `3.10` | Python used to install and run `chainweaver` (3.10–3.14). |
-| `chainweaver-version` | `0.12.0` | Exact PyPI version to install. Pass `""` for the latest published release. |
+| `chainweaver-version` | `0.12.1` | Exact PyPI version to install. Pass `""` for the latest published release. |
 | `extra-args` | `""` | Extra args appended verbatim (e.g. `--quiet`). |
 
 ## Outputs
@@ -64,7 +64,7 @@ To branch on the result without failing the job, set `continue-on-error: true`
 on the action step and inspect `exit-code`:
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.12.1
   id: cw
   continue-on-error: true
   with:
@@ -76,9 +76,14 @@ on the action step and inspect `exit-code`:
 
 ## Versioning
 
-Pin to a ChainWeaver release tag (`@v0.12.0`) rather than `@main` to avoid
+Pin to a ChainWeaver release tag (`@v0.12.1`) rather than `@main` to avoid
 implicit upgrades. The `chainweaver-version` input default tracks the action's
 tag; both move in lockstep on each release.
+
+The repository's pre-publish smoke test overrides the input with `""`, testing
+the action implementation against the latest package already on PyPI. The
+post-publish distribution workflow then tests the exact newly published
+version. Downstream users continue to receive the pinned default.
 
 See also the [action's README](https://github.com/dgenio/ChainWeaver/tree/main/.github/actions/chainweaver)
 and the [distribution checklist](distribution.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chainweaver"
-version = "0.12.1"
+dynamic = ["version"]
 description = "Deterministic orchestration layer for MCP-based agents."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -216,3 +216,6 @@ include = ["chainweaver*"]
 # the module docstring of ``pytest_chainweaver.py`` for details.
 [tool.setuptools]
 py-modules = ["pytest_chainweaver"]
+
+[tool.setuptools.dynamic]
+version = { attr = "chainweaver.__version__" }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,367 @@
+"""Prepare and verify ChainWeaver releases.
+
+The package version in ``chainweaver.__init__`` is authoritative. This script
+updates the small set of release artifacts that cannot read it dynamically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+_VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+_SOURCE_VERSION_RE = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
+_RELEASE_HEADING_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+_PYPI_URL = "https://pypi.org/pypi/chainweaver/{version}/json"
+
+_VERSIONED_DOCS = (
+    Path(".github/actions/chainweaver/README.md"),
+    Path("docs/github-action.md"),
+)
+
+_MANUAL_DISTRIBUTION = (
+    (
+        "MCP Registry publication and awesome-list submissions",
+        "Tracked in #325",
+        "https://github.com/dgenio/ChainWeaver/issues/325",
+    ),
+    (
+        "Framework ecosystem listings",
+        "Tracked in #231",
+        "https://github.com/dgenio/ChainWeaver/issues/231",
+    ),
+    (
+        "GitHub Marketplace publication",
+        "Tracked in #325",
+        "https://github.com/dgenio/ChainWeaver/issues/325",
+    ),
+)
+
+FetchJson = Callable[[str], dict[str, Any]]
+Sleep = Callable[[float], None]
+
+
+def _parse_version(value: str) -> tuple[int, int, int]:
+    match = _VERSION_RE.fullmatch(value)
+    if match is None:
+        raise ValueError(f"Version '{value}' must use X.Y.Z semantic-version format.")
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def source_version(root: Path) -> str:
+    """Return the authoritative package version."""
+    source = (root / "chainweaver/__init__.py").read_text(encoding="utf-8")
+    match = _SOURCE_VERSION_RE.search(source)
+    if match is None:
+        raise ValueError("chainweaver/__init__.py has no literal __version__ assignment.")
+    return match.group(1)
+
+
+def _replace_once(text: str, old: str, new: str, *, path: Path) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise ValueError(f"Expected one occurrence of {old!r} in '{path}', found {count}.")
+    return text.replace(old, new, 1)
+
+
+def _update_source_version(root: Path, current: str, target: str) -> None:
+    path = root / "chainweaver/__init__.py"
+    text = path.read_text(encoding="utf-8")
+    old = f'__version__ = "{current}"'
+    updated = _replace_once(text, old, f'__version__ = "{target}"', path=path)
+    path.write_text(updated, encoding="utf-8")
+
+
+def _update_manifest(root: Path, target: str) -> None:
+    path = root / "server.json"
+    manifest: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    manifest["version"] = target
+    packages = manifest.get("packages", [])
+    pypi_packages = [item for item in packages if item.get("registryType") == "pypi"]
+    if len(pypi_packages) != 1:
+        raise ValueError("server.json must contain exactly one PyPI package entry.")
+    pypi_packages[0]["version"] = target
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def _action_version(text: str, *, path: Path) -> str:
+    start = text.find("  chainweaver-version:")
+    end = text.find("\n  extra-args:", start)
+    if start < 0 or end < 0:
+        raise ValueError(f"Could not locate the chainweaver-version input in '{path}'.")
+    block = text[start:end]
+    match = re.search(r'^    default: "([^"]+)"$', block, re.MULTILINE)
+    if match is None:
+        raise ValueError(f"Could not locate the chainweaver-version default in '{path}'.")
+    return match.group(1)
+
+
+def _update_action_version(root: Path, current: str, target: str) -> None:
+    path = root / ".github/actions/chainweaver/action.yml"
+    text = path.read_text(encoding="utf-8")
+    actual = _action_version(text, path=path)
+    if actual != current:
+        raise ValueError(
+            f"Action version drift: expected '{current}' before bump, found '{actual}'."
+        )
+    start = text.index("  chainweaver-version:")
+    end = text.index("\n  extra-args:", start)
+    block = text[start:end]
+    updated = _replace_once(
+        block,
+        f'    default: "{current}"',
+        f'    default: "{target}"',
+        path=path,
+    )
+    path.write_text(text[:start] + updated + text[end:], encoding="utf-8")
+
+
+def _update_versioned_docs(root: Path, current: str, target: str) -> None:
+    for relative in _VERSIONED_DOCS:
+        path = root / relative
+        text = path.read_text(encoding="utf-8")
+        if current not in text:
+            raise ValueError(f"Expected release version '{current}' in '{path}'.")
+        path.write_text(text.replace(current, target), encoding="utf-8")
+
+
+def _promote_changelog(root: Path, current: str, target: str, release_date: str) -> None:
+    path = root / "CHANGELOG.md"
+    text = path.read_text(encoding="utf-8")
+    heading = "## [Unreleased]\n"
+    replacement = f"## [Unreleased]\n\n## [{target}] - {release_date}\n"
+    text = _replace_once(text, heading, replacement, path=path)
+    old_link = f"[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v{current}...HEAD"
+    new_links = (
+        f"[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v{target}...HEAD\n"
+        f"[{target}]: https://github.com/dgenio/ChainWeaver/compare/v{current}...v{target}"
+    )
+    path.write_text(_replace_once(text, old_link, new_links, path=path), encoding="utf-8")
+
+
+def prepare_release(root: Path, target: str, release_date: str) -> None:
+    """Update all release-derived references for ``target``."""
+    target_parts = _parse_version(target)
+    current = source_version(root)
+    current_parts = _parse_version(current)
+    if target_parts <= current_parts:
+        raise ValueError(f"Release version '{target}' must be greater than current '{current}'.")
+    try:
+        date.fromisoformat(release_date)
+    except ValueError as exc:
+        raise ValueError(f"Release date '{release_date}' must use YYYY-MM-DD format.") from exc
+
+    existing_issues = release_issues(root, expected_version=current)
+    if existing_issues:
+        raise ValueError("Current release metadata is inconsistent: " + "; ".join(existing_issues))
+
+    _update_source_version(root, current, target)
+    _update_manifest(root, target)
+    _update_action_version(root, current, target)
+    _update_versioned_docs(root, current, target)
+    _promote_changelog(root, current, target, release_date)
+
+
+def release_issues(root: Path, *, expected_version: str | None = None) -> list[str]:
+    """Return release-metadata consistency problems."""
+    version = source_version(root)
+    issues: list[str] = []
+    if expected_version is not None and version != expected_version:
+        issues.append(f"source version is {version}, expected {expected_version}")
+
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    if 'dynamic = ["version"]' not in pyproject:
+        issues.append("pyproject.toml does not declare version as dynamic")
+    if 'version = { attr = "chainweaver.__version__" }' not in pyproject:
+        issues.append("pyproject.toml does not read chainweaver.__version__")
+
+    manifest: dict[str, Any] = json.loads((root / "server.json").read_text(encoding="utf-8"))
+    if manifest.get("version") != version:
+        issues.append(f"server.json version is {manifest.get('version')}, expected {version}")
+    pypi_versions = [
+        item.get("version")
+        for item in manifest.get("packages", [])
+        if item.get("registryType") == "pypi"
+    ]
+    if pypi_versions != [version]:
+        issues.append(f"server.json PyPI versions are {pypi_versions}, expected [{version!r}]")
+
+    action_path = root / ".github/actions/chainweaver/action.yml"
+    action_version = _action_version(
+        action_path.read_text(encoding="utf-8"),
+        path=action_path,
+    )
+    if action_version != version:
+        issues.append(f"action default is {action_version}, expected {version}")
+
+    for relative in _VERSIONED_DOCS:
+        text = (root / relative).read_text(encoding="utf-8")
+        if f"v{version}" not in text:
+            issues.append(f"{relative.as_posix()} does not reference release tag v{version}")
+
+    for relative in (
+        Path(".github/workflows/release.yml"),
+        Path(".github/workflows/distribution-check.yml"),
+    ):
+        if not (root / relative).is_file():
+            issues.append(f"{relative.as_posix()} is missing")
+
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    heading = _RELEASE_HEADING_RE.search(changelog)
+    if heading is None or heading.group(1) != version:
+        actual = heading.group(1) if heading is not None else "missing"
+        issues.append(f"CHANGELOG.md top release is {actual}, expected {version}")
+    return issues
+
+
+def release_status(
+    root: Path,
+    *,
+    expected_version: str | None = None,
+    generated_on: str | None = None,
+) -> str:
+    """Render release status as Markdown."""
+    version = source_version(root)
+    issues = release_issues(root, expected_version=expected_version)
+    consistency = "PASS" if not issues else "FAIL"
+    details = "All governed references agree." if not issues else "; ".join(issues)
+    status_date = generated_on or date.today().isoformat()
+    rows = [
+        ("Package version", "READY", version),
+        ("Release metadata consistency", consistency, details),
+        (
+            "Release PR automation",
+            "CONFIGURED",
+            "`.github/workflows/release.yml`",
+        ),
+        (
+            "Post-publish verification",
+            "CONFIGURED",
+            "`.github/workflows/distribution-check.yml`",
+        ),
+    ]
+    lines = [
+        "## Release status",
+        "",
+        f"Generated: {status_date}",
+        "",
+        "| Check | Status | Detail |",
+        "|---|---|---|",
+    ]
+    lines.extend(f"| {name} | {status} | {detail} |" for name, status, detail in rows)
+    lines.extend(
+        [
+            "",
+            "### Manual / asynchronous distribution",
+            "",
+            "| Item | Status | Completed | Tracker |",
+            "|---|---|---|---|",
+        ]
+    )
+    lines.extend(
+        f"| {item} | MANUAL | Not completed | [{status}]({url}) |"
+        for item, status, url in _MANUAL_DISTRIBUTION
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": "chainweaver-release-check"})
+    with urllib.request.urlopen(request, timeout=15) as response:
+        payload: dict[str, Any] = json.load(response)
+    return payload
+
+
+def verify_pypi(
+    version: str,
+    *,
+    attempts: int = 12,
+    delay: float = 10.0,
+    fetch: FetchJson = _fetch_json,
+    sleep: Sleep = time.sleep,
+) -> None:
+    """Wait for an exact ChainWeaver version to resolve from PyPI."""
+    _parse_version(version)
+    if attempts < 1:
+        raise ValueError("PyPI verification attempts must be at least 1.")
+    url = _PYPI_URL.format(version=version)
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            payload = fetch(url)
+            actual = payload.get("info", {}).get("version")
+            if actual != version:
+                raise ValueError(f"PyPI returned version '{actual}', expected '{version}'.")
+            return
+        except (OSError, ValueError, urllib.error.HTTPError) as exc:
+            last_error = exc
+            if attempt < attempts:
+                sleep(delay)
+    raise RuntimeError(
+        f"PyPI version '{version}' did not resolve after {attempts} attempts: {last_error}"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare", help="Prepare a release version.")
+    prepare.add_argument("version")
+    prepare.add_argument("--date", default=date.today().isoformat())
+
+    check = subparsers.add_parser("check", help="Check release metadata for drift.")
+    check.add_argument("--expected-version")
+
+    status = subparsers.add_parser("status", help="Render release status Markdown.")
+    status.add_argument("--expected-version")
+
+    subparsers.add_parser("version", help="Print the authoritative package version.")
+
+    pypi = subparsers.add_parser("verify-pypi", help="Wait for a version to resolve on PyPI.")
+    pypi.add_argument("version")
+    pypi.add_argument("--attempts", type=int, default=12)
+    pypi.add_argument("--delay", type=float, default=10.0)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the release command-line interface."""
+    args = _parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        if args.command == "prepare":
+            prepare_release(root, args.version, args.date)
+            problems = release_issues(root, expected_version=args.version)
+            if problems:
+                raise RuntimeError("; ".join(problems))
+        elif args.command == "check":
+            problems = release_issues(root, expected_version=args.expected_version)
+            if problems:
+                raise RuntimeError("; ".join(problems))
+        elif args.command == "status":
+            print(release_status(root, expected_version=args.expected_version), end="")
+            problems = release_issues(root, expected_version=args.expected_version)
+            return 1 if problems else 0
+        elif args.command == "version":
+            print(source_version(root))
+        elif args.command == "verify-pypi":
+            verify_pypi(args.version, attempts=args.attempts, delay=args.delay)
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"release error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_metadata_consistency.py
+++ b/tests/test_metadata_consistency.py
@@ -1,9 +1,9 @@
 """Package metadata anti-drift (#203, #209).
 
-These tests fail when the three version sources fall out of sync:
+These tests fail when release metadata falls out of sync:
 
-- ``pyproject.toml`` ``[project]`` ``version``
-- ``chainweaver.__version__`` at runtime
+- ``chainweaver.__version__`` (the authoritative package version)
+- ``pyproject.toml`` dynamic setuptools configuration
 - the latest released heading in ``CHANGELOG.md`` (``## [x.y.z] - YYYY-MM-DD``)
 
 Historical drift example: ``pyproject.toml`` was bumped to 0.10.0 in the
@@ -20,7 +20,7 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -46,10 +46,20 @@ def _pyproject_table() -> dict[str, Any]:
             return tomllib.load(handle)
     # Fallback: read just the keys we need.
     text = _PYPROJECT.read_text(encoding="utf-8")
-    table: dict[str, Any] = {"project": {}, "urls": {}}
-    version_match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
-    if version_match:
-        table["project"]["version"] = version_match.group(1)
+    table: dict[str, Any] = {
+        "project": {},
+        "urls": {},
+        "tool": {"setuptools": {"dynamic": {}}},
+    }
+    if 'dynamic = ["version"]' in text:
+        table["project"]["dynamic"] = ["version"]
+    attr_match = re.search(
+        r'^version\s*=\s*\{\s*attr\s*=\s*"([^"]+)"\s*\}',
+        text,
+        re.MULTILINE,
+    )
+    if attr_match:
+        table["tool"]["setuptools"]["dynamic"]["version"] = {"attr": attr_match.group(1)}
     urls_block = re.search(
         r"^\[project\.urls\]\n(.*?)(?=^\[|\Z)",
         text,
@@ -62,10 +72,6 @@ def _pyproject_table() -> dict[str, Any]:
                 table["urls"][entry.group(1)] = entry.group(2)
     table["project"]["urls"] = table["urls"]
     return table
-
-
-def _pyproject_version() -> str:
-    return cast(str, _pyproject_table()["project"]["version"])
 
 
 def _latest_changelog_version() -> str:
@@ -81,12 +87,14 @@ def _latest_changelog_version() -> str:
     pytest.fail(f"No released version heading found in {_CHANGELOG}")
 
 
-def test_pyproject_version_matches_runtime_version() -> None:
-    """``pyproject.toml`` and ``chainweaver.__version__`` must agree."""
-    assert _pyproject_version() == chainweaver.__version__, (
-        f"version drift: pyproject.toml={_pyproject_version()!r} "
-        f"but chainweaver.__version__={chainweaver.__version__!r}"
-    )
+def test_pyproject_reads_authoritative_runtime_version() -> None:
+    """Build metadata must read the single literal runtime version."""
+    metadata = _pyproject_table()
+    assert metadata["project"]["dynamic"] == ["version"]
+    assert "version" not in metadata["project"]
+    assert metadata["tool"]["setuptools"]["dynamic"]["version"] == {
+        "attr": "chainweaver.__version__"
+    }
 
 
 def test_changelog_top_release_matches_runtime_version() -> None:

--- a/tests/test_release_tooling.py
+++ b/tests/test_release_tooling.py
@@ -1,0 +1,150 @@
+"""Release automation tests (#304, #307, #308, #309)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts/release.py"
+_RELEASE_FILES = (
+    Path("pyproject.toml"),
+    Path("chainweaver/__init__.py"),
+    Path("server.json"),
+    Path(".github/actions/chainweaver/action.yml"),
+    Path(".github/actions/chainweaver/README.md"),
+    Path(".github/workflows/release.yml"),
+    Path(".github/workflows/distribution-check.yml"),
+    Path("docs/github-action.md"),
+    Path("CHANGELOG.md"),
+)
+
+
+def _load_release_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("chainweaver_release", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def release_module() -> ModuleType:
+    return _load_release_module()
+
+
+@pytest.fixture()
+def release_tree() -> Iterator[Path]:
+    root = _REPO_ROOT / "build" / f"release-test-{uuid4().hex}"
+    root.mkdir(parents=True)
+    try:
+        for relative in _RELEASE_FILES:
+            source = _REPO_ROOT / relative
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        yield root
+    finally:
+        shutil.rmtree(root)
+
+
+def test_prepare_release_updates_all_governed_references(
+    release_module: ModuleType,
+    release_tree: Path,
+) -> None:
+    release_module.prepare_release(release_tree, "0.12.2", "2026-06-09")
+
+    assert release_module.source_version(release_tree) == "0.12.2"
+    assert release_module.release_issues(release_tree, expected_version="0.12.2") == []
+
+    manifest = json.loads((release_tree / "server.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.12.2"
+    assert manifest["packages"][0]["version"] == "0.12.2"
+
+    changelog = (release_tree / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [Unreleased]\n\n## [0.12.2] - 2026-06-09" in changelog
+    assert "[0.12.2]: https://github.com/dgenio/ChainWeaver/compare/v0.12.1...v0.12.2" in changelog
+
+
+@pytest.mark.parametrize("target", ["0.12.1", "0.12.0", "v0.12.2", "0.12"])
+def test_prepare_release_rejects_invalid_or_non_increasing_versions(
+    release_module: ModuleType,
+    release_tree: Path,
+    target: str,
+) -> None:
+    with pytest.raises(ValueError):
+        release_module.prepare_release(release_tree, target, "2026-06-09")
+
+
+def test_release_status_reports_manual_trackers(
+    release_module: ModuleType,
+    release_tree: Path,
+) -> None:
+    action = release_tree / ".github/actions/chainweaver/action.yml"
+    action.write_text(
+        action.read_text(encoding="utf-8").replace(
+            '    default: "0.12.1"',
+            '    default: "0.12.0"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    status = release_module.release_status(
+        release_tree,
+        expected_version="0.12.1",
+        generated_on="2026-06-08",
+    )
+
+    assert "Generated: 2026-06-08" in status
+    assert "| Release metadata consistency | FAIL |" in status
+    assert "action default is 0.12.0, expected 0.12.1" in status
+    assert "[Tracked in #325](https://github.com/dgenio/ChainWeaver/issues/325)" in status
+    assert "[Tracked in #231](https://github.com/dgenio/ChainWeaver/issues/231)" in status
+    assert "| MANUAL | Not completed |" in status
+
+
+def test_verify_pypi_retries_until_exact_version(release_module: ModuleType) -> None:
+    responses: list[dict[str, Any] | Exception] = [
+        OSError("not propagated yet"),
+        {"info": {"version": "0.12.2"}},
+    ]
+    sleeps: list[float] = []
+
+    def fetch(_url: str) -> dict[str, Any]:
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    release_module.verify_pypi(
+        "0.12.2",
+        attempts=2,
+        delay=0.25,
+        fetch=fetch,
+        sleep=sleeps.append,
+    )
+
+    assert sleeps == [0.25]
+
+
+def test_verify_pypi_fails_after_bounded_attempts(release_module: ModuleType) -> None:
+    def fetch(_url: str) -> dict[str, Any]:
+        raise OSError("still missing")
+
+    with pytest.raises(RuntimeError, match="did not resolve after 2 attempts"):
+        release_module.verify_pypi(
+            "0.12.2",
+            attempts=2,
+            delay=0,
+            fetch=fetch,
+            sleep=lambda _delay: None,
+        )

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,92 @@
+"""Structural checks for release and performance workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOWS = _ROOT / ".github/workflows"
+
+
+def _workflow(name: str) -> str:
+    return (_WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "release.yml",
+        "publish.yml",
+        "distribution-check.yml",
+        "action-smoke.yml",
+        "bench.yml",
+    ],
+)
+def test_changed_workflow_is_valid_yaml(name: str) -> None:
+    document = yaml.load(_workflow(name), Loader=yaml.BaseLoader)
+
+    assert isinstance(document, dict)
+    assert "jobs" in document
+
+
+def test_release_workflow_tags_the_merged_release_pr_commit() -> None:
+    workflow = _workflow("release.yml")
+
+    assert "workflow_dispatch:" in workflow
+    assert 'workflows: ["CI"]' in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.head_sha" in workflow
+    assert 'startswith("release/v")' in workflow
+    assert "commits/${MERGE_SHA}/pulls" in workflow
+    assert "token: ${{ secrets.RELEASE_PR_TOKEN }}" in workflow
+    assert "secrets.RELEASE_PR_TOKEN || github.token" not in workflow
+    assert 'python scripts/release.py check --expected-version "${VERSION}"' in workflow
+    assert 'gh workflow run publish.yml --ref "v${VERSION}"' in workflow
+
+
+def test_publish_workflow_accepts_tag_push_or_explicit_dispatch() -> None:
+    workflow = _workflow("publish.yml")
+
+    assert 'tags:\n      - "v*"' in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "python scripts/release.py check --expected-version" in workflow
+    assert "ref: v${{ needs.release.outputs.version }}" in workflow
+    assert "tag_name: v${{ needs.release.outputs.version }}" in workflow
+
+
+def test_distribution_check_runs_after_successful_publication() -> None:
+    workflow = _workflow("distribution-check.yml")
+
+    assert 'workflows: ["Publish to PyPI"]' in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "python scripts/release.py verify-pypi" in workflow
+    assert "mcp-publisher validate server.json" in workflow
+    assert "sha256sum --check -" in workflow
+    assert "uses: ./.github/actions/chainweaver" in workflow
+    assert "chainweaver-version: ${{ steps.release.outputs.version }}" in workflow
+
+
+def test_pre_publish_action_smoke_uses_latest_published_package() -> None:
+    workflow = _workflow("action-smoke.yml")
+
+    assert workflow.count('chainweaver-version: ""') == 2
+
+
+def test_benchmark_alerts_only_for_execution_sensitive_changes() -> None:
+    workflow = _workflow("bench.yml")
+
+    assert "chainweaver/(cache|checkpoint|compiler|contracts|decisions|events|executor" in workflow
+    assert "benchmarks/.*" in workflow
+    assert "pyproject\\.toml" in workflow
+    assert 'alert-threshold: "200%"' in workflow
+    assert "steps.changes.outputs.execution == 'true'" in workflow
+    assert "auto-push:" in workflow
+
+
+def test_distribution_document_has_no_untracked_checkboxes() -> None:
+    document = (_ROOT / "docs/distribution.md").read_text(encoding="utf-8")
+
+    assert "- [ ]" not in document

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -58,6 +58,7 @@ def test_publish_workflow_accepts_tag_push_or_explicit_dispatch() -> None:
     ) in workflow
     assert "python scripts/release.py check --expected-version" in workflow
     assert "ref: v${{ needs.release.outputs.version }}" in workflow
+    assert "skip-existing: true" in workflow
     assert "tag_name: v${{ needs.release.outputs.version }}" in workflow
 
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -52,6 +52,10 @@ def test_publish_workflow_accepts_tag_push_or_explicit_dispatch() -> None:
 
     assert 'tags:\n      - "v*"' in workflow
     assert "workflow_dispatch:" in workflow
+    assert (
+        "group: publish-${{ github.event_name == 'workflow_dispatch' "
+        "&& format('v{0}', inputs.version) || github.ref_name }}"
+    ) in workflow
     assert "python scripts/release.py check --expected-version" in workflow
     assert "ref: v${{ needs.release.outputs.version }}" in workflow
     assert "tag_name: v${{ needs.release.outputs.version }}" in workflow


### PR DESCRIPTION
## Summary

Automates the PR-first release path, makes the package version single-source, verifies post-publish distribution surfaces, and limits benchmark alerts to execution-sensitive changes. This combines the approved release-engineering issues into one coherent PR without changing runtime executor behavior.

## Changes

- Added `scripts/release.py` to prepare releases, validate metadata consistency, render release status, expose the authoritative version, and verify exact PyPI publication.
- Changed `pyproject.toml` to derive package metadata from `chainweaver.__version__`.
- Added `.github/workflows/release.yml` for release PR creation and tagging the exact main-branch commit that passed CI.
- Updated `.github/workflows/publish.yml` and added `.github/workflows/distribution-check.yml` for explicit tagged publication and post-publish PyPI, MCP manifest, and composite-action verification.
- Updated action smoke tests and benchmark gating so release/docs-only changes cannot produce benchmark alerts or baseline updates.
- Added release-tooling and workflow-structure tests, plus updated release, action, benchmark, and agent documentation.
- Created #325 to track the remaining manual ecosystem submissions rather than representing them as completed automation.

## Why

The previous release process duplicated version values and mixed automated checks with manual distribution tasks. The new flow keeps release mutations reviewable in a normal PR, waits for main CI before tagging, dispatches publication explicitly, and reports asynchronous/manual work through durable issue trackers.

## How verified

- `ruff check chainweaver/ tests/ examples/` - all checks passed.
- `ruff format --check chainweaver/ tests/ examples/` - 190 files already formatted.
- `python -m mypy chainweaver/ tests/` - no issues in 154 source files.
- `python -m pytest tests/ -v` - 1443 passed, 1 skipped; 92.11% total coverage.
- `python -m mkdocs build --strict --site-dir site` - completed successfully (existing informational warnings only).
- `python -m build` and `twine check dist/*` - built the 0.12.1 wheel/sdist and all checked artifacts passed.
- `python scripts/release.py check` - release metadata consistency passed.

`actionlint` was not executed locally because downloading and executing the external binary was blocked. PyYAML parsing and repository-specific structural tests cover the changed workflow syntax and required job wiring.

## Tradeoffs / risks

- Automated release PR creation requires the repository secret `RELEASE_PR_TOKEN`; `GITHUB_TOKEN` cannot trigger the normal PR workflow chain.
- Live PyPI, MCP publisher, and released-action verification only execute after an actual publication.
- The benchmark alert threshold remains intentionally broad at 200%, so smaller regressions remain visible in artifacts but do not fail CI.

## Scope notes

Mode B scope combines issues #304-#309 because they share one release lifecycle and must agree on version metadata, tagging, publication, distribution verification, and benchmark behavior. No runtime public API or executor semantics are changed.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`)
- [x] New tests added for new functionality

## Related Issues

Closes #304
Closes #305
Closes #306
Closes #307
Closes #308
Closes #309

Related: #325

## Checklist

- [x] Code follows project conventions (see `AGENTS.md`)
- [x] Public API changes are documented (N/A: no runtime public API changes; release behavior is documented)
- [x] No secrets, credentials, or PII in code or tests