### PR TITLE
Include source context in loader errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ToolSafetyContract.requires_review` is retained as a deprecated alias for
   `requires_approval`; legacy serialized contracts are migrated on load.
 
+### Fixed
+
+- **Source-attributed loading errors** (#343): JSON/YAML flow loaders now carry
+  optional source context through `FlowSerializationError`, CLI/file-store
+  callers pass flow paths into deserialization, and skipped plugin entry-point
+  warnings include tracebacks for the underlying loader failure.
+
 ## [0.12.1] - 2026-06-08
 
 ### Fixed

--- a/chainweaver/cli.py
+++ b/chainweaver/cli.py
@@ -315,9 +315,9 @@ def _load_flow_file(path: Path) -> Flow | DAGFlow:
     name_lower = path.name.lower()
     text = path.read_text(encoding="utf-8")
     if name_lower.endswith(".flow.json"):
-        return flow_from_json(text)
+        return flow_from_json(text, source=str(path))
     if name_lower.endswith((".flow.yaml", ".flow.yml")):
-        return flow_from_yaml(text)
+        return flow_from_yaml(text, source=str(path))
     raise FlowSerializationError(
         f"Unrecognised extension; expected one of {_FLOW_FILE_SUFFIXES}",
         source=str(path),
@@ -1899,7 +1899,7 @@ _FLOW_PROMOTE_TARGET_OPTION = typer.Option(
 def _load_persisted_candidate(path: Path) -> Flow | DAGFlow:
     """Load a candidate flow file and surface a concise CLI error."""
     try:
-        return flow_from_yaml(path.read_text(encoding="utf-8"))
+        return flow_from_yaml(path.read_text(encoding="utf-8"), source=str(path))
     except (OSError, FlowSerializationError) as exc:
         detail = exc.detail if isinstance(exc, FlowSerializationError) else str(exc)
         raise ValueError(f"cannot read candidate '{path}': {detail}") from exc

--- a/chainweaver/flow.py
+++ b/chainweaver/flow.py
@@ -690,7 +690,7 @@ class Flow(BaseModel):
         return flow_to_yaml(self)
 
     @classmethod
-    def from_json(cls, data: str) -> Flow:
+    def from_json(cls, data: str, *, source: str | None = None) -> Flow:
         """Deserialize a :class:`Flow` from a JSON string (issue #14).
 
         Raises:
@@ -700,15 +700,16 @@ class Flow(BaseModel):
         """
         from chainweaver.serialization import flow_from_json
 
-        result = flow_from_json(data)
+        result = flow_from_json(data, source=source)
         if not isinstance(result, cls):
             raise FlowSerializationError(
-                f"Expected a Flow payload but got {type(result).__name__}"
+                f"Expected a Flow payload but got {type(result).__name__}",
+                source=source,
             )
         return result
 
     @classmethod
-    def from_yaml(cls, data: str) -> Flow:
+    def from_yaml(cls, data: str, *, source: str | None = None) -> Flow:
         """Deserialize a :class:`Flow` from a YAML string (issue #14).
 
         Requires ``pyyaml`` to be installed (``pip install chainweaver[yaml]``).
@@ -720,10 +721,11 @@ class Flow(BaseModel):
         """
         from chainweaver.serialization import flow_from_yaml
 
-        result = flow_from_yaml(data)
+        result = flow_from_yaml(data, source=source)
         if not isinstance(result, cls):
             raise FlowSerializationError(
-                f"Expected a Flow payload but got {type(result).__name__}"
+                f"Expected a Flow payload but got {type(result).__name__}",
+                source=source,
             )
         return result
 
@@ -1019,7 +1021,7 @@ class DAGFlow(BaseModel):
         return flow_to_yaml(self)
 
     @classmethod
-    def from_json(cls, data: str) -> DAGFlow:
+    def from_json(cls, data: str, *, source: str | None = None) -> DAGFlow:
         """Deserialize a :class:`DAGFlow` from a JSON string (issue #14).
 
         Raises:
@@ -1029,15 +1031,16 @@ class DAGFlow(BaseModel):
         """
         from chainweaver.serialization import flow_from_json
 
-        result = flow_from_json(data)
+        result = flow_from_json(data, source=source)
         if not isinstance(result, cls):
             raise FlowSerializationError(
-                f"Expected a DAGFlow payload but got {type(result).__name__}"
+                f"Expected a DAGFlow payload but got {type(result).__name__}",
+                source=source,
             )
         return result
 
     @classmethod
-    def from_yaml(cls, data: str) -> DAGFlow:
+    def from_yaml(cls, data: str, *, source: str | None = None) -> DAGFlow:
         """Deserialize a :class:`DAGFlow` from a YAML string (issue #14).
 
         Raises:
@@ -1046,10 +1049,11 @@ class DAGFlow(BaseModel):
         """
         from chainweaver.serialization import flow_from_yaml
 
-        result = flow_from_yaml(data)
+        result = flow_from_yaml(data, source=source)
         if not isinstance(result, cls):
             raise FlowSerializationError(
-                f"Expected a DAGFlow payload but got {type(result).__name__}"
+                f"Expected a DAGFlow payload but got {type(result).__name__}",
+                source=source,
             )
         return result
 

--- a/chainweaver/plugins.py
+++ b/chainweaver/plugins.py
@@ -97,16 +97,24 @@ def _load_one(
     """
     ep_id = _entry_point_id(ep)
 
-    def _fail(detail: str) -> list[Any]:
+    def _fail(detail: str, exc: Exception | None = None) -> list[Any]:
         if strict:
-            raise PluginDiscoveryError(ep_id, detail)
-        _logger.warning("Skipping plugin entry-point '%s': %s", ep_id, detail)
+            error = PluginDiscoveryError(ep_id, detail)
+            if exc is not None:
+                raise error from exc
+            raise error
+        _logger.warning(
+            "Skipping plugin entry-point '%s': %s",
+            ep_id,
+            detail,
+            exc_info=(type(exc), exc, exc.__traceback__) if exc is not None else None,
+        )
         return []
 
     try:
         loader = ep.load()
     except Exception as exc:
-        return _fail(f"could not import loader ({type(exc).__name__}: {exc})")
+        return _fail(f"could not import loader ({type(exc).__name__}: {exc})", exc)
 
     if not callable(loader):
         return _fail(f"entry point resolved to {type(loader).__name__}, expected a callable")
@@ -114,7 +122,7 @@ def _load_one(
     try:
         result = loader()
     except Exception as exc:
-        return _fail(f"loader raised {type(exc).__name__}: {exc}")
+        return _fail(f"loader raised {type(exc).__name__}: {exc}", exc)
 
     if not isinstance(result, list):
         return _fail(f"loader returned {type(result).__name__}, expected list[{expected_label}]")

--- a/chainweaver/serialization.py
+++ b/chainweaver/serialization.py
@@ -66,7 +66,7 @@ def flow_to_dict(flow: AnyFlow) -> dict[str, Any]:
     return payload
 
 
-def flow_from_dict(data: dict[str, Any]) -> AnyFlow:
+def flow_from_dict(data: dict[str, Any], *, source: str | None = None) -> AnyFlow:
     """Reconstruct a :class:`Flow` or :class:`DAGFlow` from a dict payload.
 
     The dict must contain a ``type`` key whose value is either ``"Flow"`` or
@@ -79,13 +79,15 @@ def flow_from_dict(data: dict[str, Any]) -> AnyFlow:
     """
     if not isinstance(data, dict):
         raise FlowSerializationError(
-            f"Expected a mapping at the top level, got {type(data).__name__}"
+            f"Expected a mapping at the top level, got {type(data).__name__}",
+            source=source,
         )
     flow_type = data.get(_TYPE_KEY)
     if flow_type not in (_FLOW_DISCRIMINATOR, _DAG_DISCRIMINATOR):
         raise FlowSerializationError(
             f"Missing or invalid 'type' discriminator (got {flow_type!r}); "
-            f"expected 'Flow' or 'DAGFlow'"
+            f"expected 'Flow' or 'DAGFlow'",
+            source=source,
         )
     payload = {k: v for k, v in data.items() if k != _TYPE_KEY}
     model: type[AnyFlow] = DAGFlow if flow_type == _DAG_DISCRIMINATOR else Flow
@@ -93,7 +95,8 @@ def flow_from_dict(data: dict[str, Any]) -> AnyFlow:
         return model.model_validate(payload)
     except Exception as exc:
         raise FlowSerializationError(
-            f"Validation failed while reconstructing {flow_type}: {exc}"
+            f"Validation failed while reconstructing {flow_type}: {exc}",
+            source=source,
         ) from exc
 
 
@@ -116,7 +119,7 @@ def flow_to_json(flow: AnyFlow, *, indent: int | None = 2) -> str:
     return json.dumps(flow_to_dict(flow), indent=indent, sort_keys=True)
 
 
-def flow_from_json(data: str) -> AnyFlow:
+def flow_from_json(data: str, *, source: str | None = None) -> AnyFlow:
     """Deserialize a JSON string produced by :func:`flow_to_json`.
 
     Raises:
@@ -127,8 +130,8 @@ def flow_from_json(data: str) -> AnyFlow:
     try:
         parsed = json.loads(data)
     except json.JSONDecodeError as exc:
-        raise FlowSerializationError(f"Invalid JSON: {exc}") from exc
-    return flow_from_dict(parsed)
+        raise FlowSerializationError(f"Invalid JSON: {exc}", source=source) from exc
+    return flow_from_dict(parsed, source=source)
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +172,7 @@ def flow_to_yaml(flow: AnyFlow) -> str:
     )
 
 
-def flow_from_yaml(data: str) -> AnyFlow:
+def flow_from_yaml(data: str, *, source: str | None = None) -> AnyFlow:
     """Deserialize a YAML string produced by :func:`flow_to_yaml`.
 
     Raises:
@@ -180,7 +183,7 @@ def flow_from_yaml(data: str) -> AnyFlow:
     try:
         parsed = yaml.safe_load(data)
     except yaml.YAMLError as exc:
-        raise FlowSerializationError(f"Invalid YAML: {exc}") from exc
+        raise FlowSerializationError(f"Invalid YAML: {exc}", source=source) from exc
     if parsed is None:
-        raise FlowSerializationError("YAML payload is empty")
-    return flow_from_dict(parsed)
+        raise FlowSerializationError("YAML payload is empty", source=source)
+    return flow_from_dict(parsed, source=source)

--- a/chainweaver/storage.py
+++ b/chainweaver/storage.py
@@ -201,7 +201,7 @@ class FileStore:
         if not path.exists():
             raise FlowNotFoundError(name, version=version)
         try:
-            return flow_from_json(path.read_text(encoding="utf-8"))
+            return flow_from_json(path.read_text(encoding="utf-8"), source=str(path))
         except FlowSerializationError as exc:
             # Re-raise with the file path for better diagnostics.
             raise FlowSerializationError(exc.detail, source=str(path)) from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,7 @@ class TestValidateCommand:
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "INVALID" in captured.err
+        assert str(bad) in captured.err
 
     def test_missing_file_returns_two(
         self,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -143,9 +143,9 @@ class TestDiscoverTools:
         with caplog.at_level(logging.WARNING, logger="chainweaver.plugins"):
             tools = discover_tools()
         assert [t.name for t in tools] == ["plugin_double", "plugin_add_ten"]
-        assert any(
-            "bad" in rec.message and "RuntimeError" in rec.message for rec in caplog.records
-        )
+        record = next(rec for rec in caplog.records if "bad" in rec.message)
+        assert "RuntimeError" in record.message
+        assert record.exc_info is not None
 
     def test_skips_loader_returning_wrong_type(
         self, patch_entry_points: Any, caplog: pytest.LogCaptureFixture
@@ -186,6 +186,7 @@ class TestDiscoverTools:
             discover_tools(strict=True)
         assert exc_info.value.entry_point.endswith(":bad")
         assert "RuntimeError" in exc_info.value.detail
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -391,9 +391,21 @@ class TestErrorPaths:
         with pytest.raises(FlowSerializationError, match="Invalid JSON"):
             flow_from_json("{not valid json")
 
+    def test_invalid_json_records_source_context(self) -> None:
+        with pytest.raises(FlowSerializationError, match=r"bad\.flow\.json") as exc_info:
+            flow_from_json("{not valid json", source="flows/bad.flow.json")
+        assert exc_info.value.source == "flows/bad.flow.json"
+        assert "Invalid JSON" in exc_info.value.detail
+
     def test_invalid_yaml_raises_serialization_error(self) -> None:
         with pytest.raises(FlowSerializationError, match="Invalid YAML"):
             flow_from_yaml("key: [unbalanced")
+
+    def test_invalid_yaml_records_source_context(self) -> None:
+        with pytest.raises(FlowSerializationError, match=r"bad\.flow\.yaml") as exc_info:
+            flow_from_yaml("key: [unbalanced", source="flows/bad.flow.yaml")
+        assert exc_info.value.source == "flows/bad.flow.yaml"
+        assert "Invalid YAML" in exc_info.value.detail
 
     def test_empty_yaml_raises_serialization_error(self) -> None:
         with pytest.raises(FlowSerializationError, match="empty"):
@@ -427,6 +439,12 @@ class TestErrorPaths:
         flow = _make_linear()
         with pytest.raises(FlowSerializationError, match="DAGFlow"):
             DAGFlow.from_json(flow.to_json())
+
+    def test_from_json_classmethod_preserves_source_on_type_mismatch(self) -> None:
+        flow = _make_linear()
+        with pytest.raises(FlowSerializationError, match=r"flow\.json") as exc_info:
+            DAGFlow.from_json(flow.to_json(), source="flows/flow.json")
+        assert exc_info.value.source == "flows/flow.json"
 
     def test_from_json_dag_payload_to_flow_class_fails(self) -> None:
         flow = _make_dag()


### PR DESCRIPTION
## Summary
- thread optional `source` context through JSON/YAML/dict flow deserialization and Flow/DAGFlow classmethods
- pass file paths from CLI and file-store loaders so malformed flow errors identify the source artifact
- include traceback context for skipped plugin entry-point failures and chain strict-mode plugin exceptions
- add regression coverage and changelog entry

## Tests
- `git diff --check`
- `PYTHONPATH=. uvx --with '.[dev]' ruff format --check chainweaver/serialization.py chainweaver/flow.py chainweaver/cli.py chainweaver/storage.py chainweaver/plugins.py tests/test_serialization.py tests/test_plugins.py tests/test_cli.py`
- `PYTHONPATH=. uvx --with '.[dev]' ruff check chainweaver/serialization.py chainweaver/flow.py chainweaver/cli.py chainweaver/storage.py chainweaver/plugins.py tests/test_serialization.py tests/test_plugins.py tests/test_cli.py`
- `PYTHONPATH=. uvx --with '.[dev]' pytest --no-cov tests/test_serialization.py tests/test_plugins.py tests/test_cli.py -q`
- `PYTHONPATH=. uvx --with '.[dev]' pytest --no-cov -q`
- `PYTHONPATH=. uvx --with '.[dev]' mypy chainweaver/serialization.py chainweaver/flow.py chainweaver/cli.py chainweaver/storage.py chainweaver/plugins.py`
- `python3 -m compileall chainweaver tests`

Closes dgenio/ChainWeaver#343