### PR TITLE
fix: validate fallback inputs against fallback schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,7 +316,7 @@ integration.
 
 | Field | Type | Meaning |
 |-------|------|---------|
-| `trace_schema_version` | `str` | Library-stamped version of the trace *shape* (#393), e.g. `"1"`. Lets long-lived trace consumers detect shape evolution; distinct from `flow_version`. See [docs/versioning-policy.md](docs/versioning-policy.md#artifact-schema-versions). |
+| `trace_schema_version` | `str` | Library-stamped version of the trace *shape* (#393), currently `"1.1"`. Lets long-lived trace consumers detect shape evolution; distinct from `flow_version`. See [docs/versioning-policy.md](docs/versioning-policy.md#artifact-schema-versions). |
 | `flow_name` | `str` | Name of the executed flow. |
 | `success` | `bool` | `True` when all steps completed without error. |
 | `final_output` | `dict \| None` | Merged execution context, or `None` on failure. |
@@ -332,7 +332,7 @@ integration.
 | Field | Type | Meaning |
 |-------|------|---------|
 | `step_index` | `int` | Zero-based position (`-1` = flow-input validation, `len(steps)` = flow-output validation). |
-| `tool_name` | `str` | Tool invoked (or flow name for validation records). |
+| `tool_name` | `str` | Configured primary tool for the step (or flow name for validation records). Remains the primary name when a fallback runs so step identity is stable across traces. |
 | `inputs` | `dict` | Validated inputs passed to the tool. |
 | `outputs` | `dict \| None` | Validated outputs, or `None` on failure. |
 | `error_type` | `str \| None` | Exception class name (e.g. `"FlowExecutionError"`) when the step failed; `None` on success. |
@@ -342,6 +342,8 @@ integration.
 | `started_at` | `datetime` | UTC timestamp when the step began. |
 | `ended_at` | `datetime` | UTC timestamp when the step finished. |
 | `duration_ms` | `float` | Wall-clock duration in ms (via `time.perf_counter`). |
+| `fallback_used` | `bool` | `True` when `on_error="fallback:<tool_name>"` attempted recovery, including missing or failing fallbacks. |
+| `fallback_tool_name` | `str \| None` | The configured fallback target when `fallback_used=True`; `None` otherwise. |
 | `approval` | `ApprovalRecord \| None` | The decision for a step gated by an execution-time approval callback (#356); `None` when no approval was required. |
 
 > **Serialization:** `ExecutionResult` and `StepRecord` are Pydantic models;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fallback input-schema validation and attribution** (#338): sync and async
+  fallback tools continue to validate the primary step's resolved inputs
+  against their own input schemas, but validation failures now name the
+  fallback tool instead of the primary. `StepRecord` keeps the stable primary
+  `tool_name` and adds `fallback_tool_name`; the additive trace shape bumps
+  `TRACE_SCHEMA_VERSION` to `"1.1"`. `compile_flow()` now rejects missing
+  fallback tools and incompatible fallback mappings, required fields, or
+  types before execution.
+
 ## [0.13.0] - 2026-06-15
 
 ### Added

--- a/chainweaver/_versions.py
+++ b/chainweaver/_versions.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 # only for a breaking shape change (removed/renamed/retyped field); bump MINOR
 # for additive fields older readers can ignore. See docs/versioning-policy.md.
 FLOW_FORMAT_VERSION = "1"
-TRACE_SCHEMA_VERSION = "1"
+TRACE_SCHEMA_VERSION = "1.1"
 SNAPSHOT_VERSION = "1"
 
 # How an absent version field is interpreted on read (pre-versioning artifact).

--- a/chainweaver/compiler.py
+++ b/chainweaver/compiler.py
@@ -8,6 +8,7 @@ catching wiring errors (missing tools, unmapped keys, type mismatches) at
 from __future__ import annotations
 
 import types
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Union, get_args, get_origin
 
@@ -129,6 +130,78 @@ def _get_model_fields(model: type[BaseModel]) -> dict[str, FieldInfo]:
     return model.model_fields
 
 
+def _validate_fallback_inputs(
+    *,
+    step_index: int,
+    fallback_tool: Tool,
+    input_mapping: Mapping[str, object],
+    context_fields: dict[str, type | None],
+) -> list[CompilationError]:
+    """Validate the primary step's resolved inputs against its fallback tool."""
+    errors: list[CompilationError] = []
+    fallback_fields = _get_model_fields(fallback_tool.input_schema)
+
+    if input_mapping:
+        for target_key, source in input_mapping.items():
+            target_field = fallback_fields.get(target_key)
+            if target_field is None:
+                errors.append(
+                    CompilationError(
+                        step_index=step_index,
+                        tool_name=fallback_tool.name,
+                        field_name=target_key,
+                        issue_type="fallback_unknown_target_key",
+                        detail=(
+                            f"Step {step_index} fallback tool ('{fallback_tool.name}'): "
+                            f"input key '{target_key}' is not a declared input field "
+                            f"{set(fallback_fields.keys())}."
+                        ),
+                    )
+                )
+            elif isinstance(source, str) and source in context_fields:
+                source_type = context_fields[source]
+                target_type = _get_field_type(target_field)
+                if not _types_compatible(source_type, target_type):
+                    errors.append(
+                        CompilationError(
+                            step_index=step_index,
+                            tool_name=fallback_tool.name,
+                            field_name=target_key,
+                            issue_type="fallback_type_mismatch",
+                            detail=(
+                                f"Step {step_index} fallback tool ('{fallback_tool.name}'): "
+                                f"field '{target_key}' expects "
+                                f"{target_type.__name__ if target_type else 'unknown'}, got "
+                                f"{source_type.__name__ if source_type else 'unknown'} "
+                                f"from '{source}'."
+                            ),
+                        )
+                    )
+
+    for field_name, finfo in fallback_fields.items():
+        if not finfo.is_required():
+            continue
+        if input_mapping:
+            if field_name in input_mapping:
+                continue
+        elif field_name in context_fields:
+            continue
+        errors.append(
+            CompilationError(
+                step_index=step_index,
+                tool_name=fallback_tool.name,
+                field_name=field_name,
+                issue_type="fallback_missing_required_input",
+                detail=(
+                    f"Step {step_index} fallback tool ('{fallback_tool.name}'): required "
+                    f"input field '{field_name}' is not satisfied by input_mapping or "
+                    f"the accumulated context."
+                ),
+            )
+        )
+    return errors
+
+
 def compile_flow(flow: Flow, tools: dict[str, Tool]) -> CompilationResult:
     """Perform static validation of a flow's step sequence.
 
@@ -142,7 +215,9 @@ def compile_flow(flow: Flow, tools: dict[str, Tool]) -> CompilationResult:
     5. Required input coverage — every required tool input field is supplied
        either by an explicit mapping or, when ``input_mapping`` is empty, by
        the accumulated context.
-    6. Output coverage — if the flow has an output_schema, the accumulated
+    6. Fallback compatibility — ``fallback:<tool_name>`` targets exist and
+       accept the same resolved inputs as the primary tool.
+    7. Output coverage — if the flow has an output_schema, the accumulated
        context satisfies it.
 
     Args:
@@ -183,6 +258,20 @@ def compile_flow(flow: Flow, tools: dict[str, Tool]) -> CompilationResult:
 
         tool = tools[step.tool_name]
         tool_input_fields = _get_model_fields(tool.input_schema)
+        fallback_tool: Tool | None = None
+        if step.on_error.startswith("fallback:"):
+            fallback_name = step.on_error[len("fallback:") :]
+            fallback_tool = tools.get(fallback_name)
+            if fallback_tool is None:
+                errors.append(
+                    CompilationError(
+                        step_index=idx,
+                        tool_name=fallback_name,
+                        field_name=None,
+                        issue_type="missing_fallback_tool",
+                        detail=f"Fallback tool '{fallback_name}' is not registered.",
+                    )
+                )
 
         # 2. + 3. Input mapping resolution and target validity.
         if step.input_mapping:
@@ -278,6 +367,16 @@ def compile_flow(flow: Flow, tools: dict[str, Tool]) -> CompilationResult:
                         f"'{field_name}' is not satisfied by input_mapping or "
                         f"the accumulated context."
                     ),
+                )
+            )
+
+        if fallback_tool is not None:
+            errors.extend(
+                _validate_fallback_inputs(
+                    step_index=idx,
+                    fallback_tool=fallback_tool,
+                    input_mapping=step.input_mapping,
+                    context_fields=context_fields,
                 )
             )
 

--- a/chainweaver/executor.py
+++ b/chainweaver/executor.py
@@ -430,6 +430,10 @@ class StepRecord(BaseModel):
             fallback tool (issue #176).  Set regardless of whether the
             fallback itself succeeded or failed; ``False`` for normal
             execution, retry-success, ``skip``, and ``fail`` paths.
+        fallback_tool_name: Name of the fallback target when
+            ``fallback_used=True``; ``None`` otherwise.  ``tool_name`` keeps
+            identifying the configured primary step so traces remain stable
+            across runs that do and do not need recovery (issue #338).
         flow_name: For a composed sub-flow step (issue #75), the name of the
             sub-flow that was executed; ``None`` for ordinary tool steps.
             When set, ``tool_name`` mirrors it so existing trace consumers
@@ -461,6 +465,7 @@ class StepRecord(BaseModel):
     skipped: bool = False
     cached: bool = False
     fallback_used: bool = False
+    fallback_tool_name: str | None = None
     flow_name: str | None = None
     sub_result: ExecutionResult | None = None
     approval: ApprovalRecord | None = None
@@ -488,7 +493,7 @@ class ExecutionResult(BaseModel):
 
     Attributes:
         trace_schema_version: Library-stamped version of the trace *shape*
-            (issue #393), e.g. ``"1"``.  Lets long-lived trace consumers
+            (issue #393), currently ``"1.1"``.  Lets long-lived trace consumers
             (``chainweaver profile`` / ``diff``, external trace stores, OTel
             export) detect and adapt to trace-shape evolution instead of
             sniffing field presence.  Distinct from ``flow_version``, which
@@ -2165,6 +2170,7 @@ class FlowExecutor:
             skipped: bool,
             retry_errors: list[str],
             fallback_used: bool = False,
+            fallback_tool_name: str | None = None,
         ) -> StepRecord:
             err_type, err_msg = (None, None) if error is None else _exc_to_strings(error)
             retry_count = max(0, tool_attempts[0] - 1)
@@ -2184,6 +2190,7 @@ class FlowExecutor:
                 skipped=skipped,
                 cached=False,
                 fallback_used=fallback_used,
+                fallback_tool_name=fallback_tool_name,
                 approval=approval_record,
             )
 
@@ -2402,12 +2409,13 @@ class FlowExecutor:
                     skipped=False,
                     retry_errors=retry_errors,
                     fallback_used=True,
+                    fallback_tool_name=fb_name,
                 )
             try:
                 outputs = await fb_tool.run_async(inputs)
             except Exception as exc:
                 retry_errors.append(f"fallback '{fb_name}' failed: {exc}")
-                wrapped_fb = self._wrap_tool_exception(step, step_index, exc)
+                wrapped_fb = self._wrap_tool_exception(step, step_index, exc, tool_name=fb_name)
                 return make_record(
                     inputs=inputs,
                     outputs=None,
@@ -2416,6 +2424,7 @@ class FlowExecutor:
                     skipped=False,
                     retry_errors=retry_errors,
                     fallback_used=True,
+                    fallback_tool_name=fb_name,
                 )
             return make_record(
                 inputs=inputs,
@@ -2425,6 +2434,7 @@ class FlowExecutor:
                 skipped=False,
                 retry_errors=retry_errors,
                 fallback_used=True,
+                fallback_tool_name=fb_name,
             )
         # Unrecognised on_error → treat as fail.
         return make_record(
@@ -3537,6 +3547,7 @@ class FlowExecutor:
             retry_errors: list[str],
             cached: bool = False,
             fallback_used: bool = False,
+            fallback_tool_name: str | None = None,
         ) -> StepRecord:
             err_type, err_msg = (None, None) if error is None else _exc_to_strings(error)
             # ``retry_count`` = retries beyond the initial invocation.
@@ -3560,6 +3571,7 @@ class FlowExecutor:
                 skipped=skipped,
                 cached=cached,
                 fallback_used=fallback_used,
+                fallback_tool_name=fallback_tool_name,
                 approval=approval_record,
             )
 
@@ -4052,6 +4064,8 @@ class FlowExecutor:
         step: FlowStep,
         step_index: int,
         exc: Exception,
+        *,
+        tool_name: str | None = None,
     ) -> Exception:
         """Convert a tool-side exception into the right ChainWeaver type.
 
@@ -4060,11 +4074,12 @@ class FlowExecutor:
           through (their ``error_type`` is preserved on the StepRecord).
         - Any other exception → :class:`FlowExecutionError`.
         """
+        attributed_tool = tool_name or step.display_name
         if isinstance(exc, ValidationError):
-            return SchemaValidationError(step.display_name, step_index, str(exc))
+            return SchemaValidationError(attributed_tool, step_index, str(exc))
         if isinstance(exc, (ToolTimeoutError, ToolOutputSizeError)):
             return exc
-        return FlowExecutionError(step.display_name, step_index, str(exc))
+        return FlowExecutionError(attributed_tool, step_index, str(exc))
 
     def _apply_on_error(
         self,
@@ -4123,12 +4138,15 @@ class FlowExecutor:
                 skipped=False,
                 retry_errors=[*retry_errors, str(wrapped_error)],
                 fallback_used=True,
+                fallback_tool_name=fallback_name,
             )
 
         try:
             outputs = fallback_tool.run(inputs)
         except Exception as fallback_exc:
-            wrapped = self._wrap_tool_exception(step, step_index, fallback_exc)
+            wrapped = self._wrap_tool_exception(
+                step, step_index, fallback_exc, tool_name=fallback_name
+            )
             return make_record(
                 inputs=inputs,
                 outputs=None,
@@ -4137,6 +4155,7 @@ class FlowExecutor:
                 skipped=False,
                 retry_errors=[*retry_errors, str(wrapped_error)],
                 fallback_used=True,
+                fallback_tool_name=fallback_name,
             )
 
         return make_record(
@@ -4147,6 +4166,7 @@ class FlowExecutor:
             skipped=False,
             retry_errors=[*retry_errors, str(wrapped_error)],
             fallback_used=True,
+            fallback_tool_name=fallback_name,
         )
 
     # ------------------------------------------------------------------

--- a/docs/concepts/execution-trace.md
+++ b/docs/concepts/execution-trace.md
@@ -21,7 +21,7 @@ across releases.
 | Field | Type | Meaning |
 |---|---|---|
 | `step_index` | `int` | Zero-based position (`-1` for input-validation record). |
-| `tool_name` | `str` | Tool invoked. |
+| `tool_name` | `str` | Configured primary tool for the step. Remains stable when a fallback runs. |
 | `inputs` | `dict` | Validated inputs passed to the tool. |
 | `outputs` | `dict \| None` | Validated outputs, or `None` on failure. |
 | `error_type` | `str \| None` | Exception class name on failure. |
@@ -29,6 +29,8 @@ across releases.
 | `success` | `bool` | Step status. |
 | `started_at` / `ended_at` | `datetime` | UTC timestamps. |
 | `duration_ms` | `float` | Wall-clock duration in milliseconds. |
+| `fallback_used` | `bool` | Whether the step attempted its configured `on_error` fallback. |
+| `fallback_tool_name` | `str \| None` | Name of the fallback target, or `None` when no fallback ran. |
 
 ## Serialization
 

--- a/docs/concepts/tools-and-flows.md
+++ b/docs/concepts/tools-and-flows.md
@@ -64,7 +64,7 @@ graph = DAGFlow(
 | `tool_name` | Name of the tool to invoke at this step. |
 | `input_mapping` | `dict[str, Any]` — see below. |
 | `retry_policy` | Optional `RetryPolicy` (delegated to `tenacity`). |
-| `on_error` | Optional fallback strategy (`skip`, `fallback_tool`). |
+| `on_error` | Error policy: `fail`, `skip`, or `fallback:<tool_name>`. |
 
 ### `input_mapping` semantics
 
@@ -76,6 +76,26 @@ graph = DAGFlow(
 
 The accumulated context starts as the `initial_input` dict and grows as each step's
 validated outputs are merged in.
+
+### Fallback semantics
+
+`on_error="fallback:<tool_name>"` runs the named fallback after the primary
+tool exhausts its attempts. The fallback receives the same resolved input
+dictionary that was passed to the primary tool, then `Tool.run` or
+`Tool.run_async` validates that dictionary against the fallback's own input
+schema before its callable runs.
+
+`compile_flow()` applies the same contract statically: the fallback must be
+registered, every mapped target must exist on its input schema, required
+fields must be supplied, and mapped types must be compatible. These are
+blocking compilation errors because the fallback would deterministically fail
+whenever recovery was needed.
+
+In the execution trace, `StepRecord.tool_name` remains the primary tool so a
+step keeps one stable identity across runs. `fallback_used=True` records that
+recovery was attempted, and `fallback_tool_name` identifies the target. A
+fallback schema failure is a `SchemaValidationError` attributed to the
+fallback tool.
 
 ## `FlowRegistry` and `FlowExecutor`
 

--- a/tests/fixtures/public_api.json
+++ b/tests/fixtures/public_api.json
@@ -1280,6 +1280,7 @@
         "error_code": "str | NoneType",
         "error_message": "str | NoneType",
         "error_type": "str | NoneType",
+        "fallback_tool_name": "str | NoneType",
         "fallback_used": "bool",
         "flow_name": "str | NoneType",
         "inputs": "dict[str, Any]",

--- a/tests/test_artifact_versioning.py
+++ b/tests/test_artifact_versioning.py
@@ -42,7 +42,7 @@ from chainweaver.tools import Tool
 def test_version_constants_are_pinned() -> None:
     """The current artifact versions are pinned so a bump is a deliberate edit."""
     assert FLOW_FORMAT_VERSION == "1"
-    assert TRACE_SCHEMA_VERSION == "1"
+    assert TRACE_SCHEMA_VERSION == "1.1"
     assert SNAPSHOT_VERSION == "1"
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -506,3 +506,115 @@ class TestMissingRequiredInput:
         # Optional input field `value` should not produce a missing_required_input
         # error — but the `_dummy` mapping target is unknown.
         assert not any(e.issue_type == "missing_required_input" for e in result.errors)
+
+
+class TestFallbackInputCompatibility:
+    def test_compatible_fallback_compiles(self) -> None:
+        tools = _make_tools()
+        flow = Flow(
+            name="fallback_ok",
+            description="Compatible fallback.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    on_error="fallback:double",
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+
+        result = compile_flow(flow, tools)
+
+        assert result.success is True
+        assert not any(error.issue_type.startswith("fallback_") for error in result.errors)
+
+    def test_missing_fallback_tool_is_error(self) -> None:
+        flow = Flow(
+            name="fallback_missing",
+            description="Missing fallback.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    on_error="fallback:missing",
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+
+        result = compile_flow(flow, _make_tools())
+
+        error = next(
+            error for error in result.errors if error.issue_type == "missing_fallback_tool"
+        )
+        assert result.success is False
+        assert error.tool_name == "missing"
+
+    def test_fallback_type_mismatch_is_error(self) -> None:
+        class TextNumberInput(BaseModel):
+            number: str
+
+        tools = _make_tools()
+        tools["backup"] = Tool(
+            name="backup",
+            description="Requires text.",
+            input_schema=TextNumberInput,
+            output_schema=ValueOutput,
+            fn=lambda inp: {"value": len(inp.number)},
+        )
+        flow = Flow(
+            name="fallback_type",
+            description="Fallback type mismatch.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    on_error="fallback:backup",
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+
+        result = compile_flow(flow, tools)
+
+        error = next(
+            error for error in result.errors if error.issue_type == "fallback_type_mismatch"
+        )
+        assert result.success is False
+        assert error.tool_name == "backup"
+        assert error.field_name == "number"
+
+    def test_fallback_mapping_shape_is_checked(self) -> None:
+        class TextInput(BaseModel):
+            text: str
+
+        tools = _make_tools()
+        tools["backup"] = Tool(
+            name="backup",
+            description="Requires text.",
+            input_schema=TextInput,
+            output_schema=ValueOutput,
+            fn=lambda inp: {"value": len(inp.text)},
+        )
+        flow = Flow(
+            name="fallback_shape",
+            description="Fallback mapping mismatch.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    on_error="fallback:backup",
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+
+        result = compile_flow(flow, tools)
+
+        issue_types = {error.issue_type for error in result.errors}
+        assert result.success is False
+        assert issue_types >= {
+            "fallback_unknown_target_key",
+            "fallback_missing_required_input",
+        }

--- a/tests/test_executor_async.py
+++ b/tests/test_executor_async.py
@@ -383,7 +383,68 @@ class TestExecuteFlowAsyncFallback:
         assert result.final_output["value"] == 8  # backup: 7 + 1
         assert len(result.execution_log) == 1
         assert result.execution_log[0].fallback_used is True
+        assert result.execution_log[0].fallback_tool_name == "backup"
         assert result.execution_log[0].success is True
+
+    async def test_fallback_input_validation_names_fallback_tool(self) -> None:
+        class _BackupInput(BaseModel):
+            text: str
+
+        called = False
+
+        async def _fail(inp: _Inp) -> dict[str, Any]:
+            raise RuntimeError("primary down")
+
+        async def _backup(inp: _BackupInput) -> dict[str, Any]:
+            nonlocal called
+            called = True
+            return {"value": len(inp.text)}
+
+        registry = FlowRegistry()
+        registry.register_flow(
+            Flow(
+                name="fb_invalid",
+                version="1.0.0",
+                description="",
+                steps=[
+                    FlowStep(
+                        tool_name="primary",
+                        input_mapping={"n": "n"},
+                        on_error="fallback:backup",
+                    ),
+                ],
+            )
+        )
+        executor = FlowExecutor(registry=registry)
+        executor.register_tool(
+            Tool(
+                name="primary",
+                description="",
+                input_schema=_Inp,
+                output_schema=_Out,
+                fn=_fail,
+            )
+        )
+        executor.register_tool(
+            Tool(
+                name="backup",
+                description="",
+                input_schema=_BackupInput,
+                output_schema=_Out,
+                fn=_backup,
+            )
+        )
+
+        result = await executor.execute_flow_async("fb_invalid", {"n": 7})
+
+        assert result.success is False
+        record = result.execution_log[0]
+        assert called is False
+        assert record.tool_name == "primary"
+        assert record.fallback_tool_name == "backup"
+        assert record.error_type == "SchemaValidationError"
+        assert record.error_message is not None
+        assert "tool 'backup'" in record.error_message
 
 
 class TestExecuteFlowAsyncEventLoopUnblocked:

--- a/tests/test_release_tooling.py
+++ b/tests/test_release_tooling.py
@@ -77,7 +77,10 @@ def test_prepare_release_updates_all_governed_references(
 
     changelog = (release_tree / "CHANGELOG.md").read_text(encoding="utf-8")
     assert f"## [Unreleased]\n\n## [{target}] - 2026-06-09" in changelog
-    assert f"[{target}]: https://github.com/dgenio/ChainWeaver/compare/v{current}...v{target}" in changelog
+    assert (
+        f"[{target}]: https://github.com/dgenio/ChainWeaver/compare/v{current}...v{target}"
+        in changelog
+    )
 
 
 @pytest.mark.parametrize("target", ["0.12.1", "0.12.0", "v0.12.2", "0.12"])

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from helpers import NumberInput, ValueOutput
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from chainweaver.executor import FlowExecutor
 from chainweaver.flow import Flow, FlowStep, RetryPolicy
@@ -257,6 +257,43 @@ class TestOnErrorFallback:
         assert any("intermittent failure" in msg for msg in record.retry_errors)
         # Successful fallback must be flagged for profile aggregation (issue #176).
         assert record.fallback_used is True
+        assert record.fallback_tool_name == "alt"
+
+    def test_fallback_input_validation_names_fallback_tool(self) -> None:
+        class TextInput(BaseModel):
+            text: str
+
+        called = False
+
+        def _backup(inp: TextInput) -> dict[str, Any]:
+            nonlocal called
+            called = True
+            return {"value": len(inp.text)}
+
+        primary = _make_tool("primary", _Counter(fail_until_attempt=10))
+        backup = Tool(
+            name="backup",
+            description="Requires text.",
+            input_schema=TextInput,
+            output_schema=ValueOutput,
+            fn=_backup,
+        )
+        ex = _build_executor(
+            primary,
+            on_error="fallback:backup",
+            extra_tools=(backup,),
+        )
+
+        result = ex.execute_flow("retry_flow", {"number": 7})
+
+        assert result.success is False
+        record = result.execution_log[0]
+        assert called is False
+        assert record.tool_name == "primary"
+        assert record.fallback_tool_name == "backup"
+        assert record.error_type == "SchemaValidationError"
+        assert record.error_message is not None
+        assert "tool 'backup'" in record.error_message
 
     def test_fallback_failure_still_marked_fallback_used(self) -> None:
         # Fallback tool exists but also fails — record must reflect that
@@ -283,6 +320,7 @@ class TestOnErrorFallback:
         assert result.success is False
         record = result.execution_log[0]
         assert record.error_type == "ToolNotFoundError"
+        assert record.fallback_tool_name == "does_not_exist"
         # The policy invoked the fallback path even though the tool was
         # missing — surface that distinction so profile aggregates can
         # separate "fallback configured but unusable" from "no fallback".


### PR DESCRIPTION
## Summary

Fix fallback handling so the fallback tool's own input contract is validated and correctly attributed in traces.

Before this change, `compile_flow()` accepted incompatible or missing fallback tools, and runtime fallback schema failures were reported as failures of the primary tool. After this change, compilation blocks deterministic fallback incompatibilities, while runtime traces preserve the primary step identity in `tool_name` and expose the attempted fallback through `fallback_tool_name`.

## Changes

- Add compile-time checks for missing fallback tools, unknown mapped fields, incompatible mapped types, and missing required fallback inputs.
- Add `StepRecord.fallback_tool_name` for sync and async fallback attempts, including successful, failed, and missing fallbacks.
- Attribute fallback validation and execution errors to the fallback tool while keeping `StepRecord.tool_name` stable as the configured primary tool.
- Bump the additive trace schema version from `1` to `1.1` and update the public API snapshot, docs, agent guidance, and changelog.
- Add focused sync, async, compiler, and artifact-version regression coverage.
- Apply Ruff's formatter-only wrap to `tests/test_release_tooling.py`; the current `main` CI lint job already fails on that untouched line.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
  - `All checks passed!`
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
  - `231 files already formatted`
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
  - `Success: no issues found in 194 source files`
- [x] All existing tests pass (`python -m pytest tests/ -v`)
  - `1679 passed, 1 skipped, 1 warning`; total coverage `92.74%`
- [x] New tests added for new functionality
  - Focused suite: `82 passed`
  - The 9 selected regression tests fail against unmodified `HEAD` and pass with this commit.
- [x] Strict docs build passes (`python -m mkdocs build --strict --site-dir site`)
  - Documentation built successfully; only existing informational nav/link notices were reported.

## Related Issues

Closes #338

## Tradeoffs / Risks

- `fallback_tool_name` is an additive serialized trace field, so `TRACE_SCHEMA_VERSION` advances to `1.1` while remaining major-version compatible.
- Fallback output-schema compatibility, fallback-specific retry/cache/safety behavior, and unrelated async DAG fallback behavior remain out of scope.

## Checklist

- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented
- [x] No secrets or credentials included