### PR TITLE
feat(cli): add doctor vscode/claude/opencode workspace inspectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ chainweaver/
 ├── viz.py             ASCII + Mermaid + DOT renderers for Flow/ExecutionResult
 ├── serialization.py   YAML + JSON encode/decode for Flow and DAGFlow
 ├── schemas.py         JSON Schema export for .flow.json / .flow.yaml files (#135, #139)
-├── cli/               typer-based CLI command package (#333): inspect/viz (ascii/dot/mermaid + --result overlay, #392), explain (deterministic LLM-free review render, #420), init (project scaffolder, #441), validate/check/dump-schema, run/serve, profile, diff, attest, suggest, record, flows (promote/ignore/list), traces (mine/draft-flows/backtest), doctor (--check-drift / --preflight / --profile first-run, #442), fuzz, service
+├── cli/               typer-based CLI command package (#333): inspect/viz (ascii/dot/mermaid + --result overlay, #392), explain (deterministic LLM-free review render, #420), init (project scaffolder, #441), validate/check/dump-schema, run/serve, profile, diff, attest, suggest, record, flows (promote/ignore/list), traces (mine/draft-flows/backtest), doctor group (`doctor flow` --check-drift / --preflight / --profile first-run #442; `doctor vscode|claude|opencode` read-only coding-agent workspace inspectors #264/#270/#275), fuzz, service
 │   ├── __init__.py    Wires the command submodules, defines the ``main`` entry point, re-exports the stable surface (``app``, ``set_default_registry`` …)
 │   ├── _shared.py     Typer ``app`` / sub-apps, registry state, shared flow/result loading, error→exit-code handling, ``--format json`` envelope, and flow-resolution/discovery (#381, #440)
 │   └── <command>.py   One module per command group; each registers on the shared ``app`` at import time

--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,10 @@ chainweaver inspect my_flow --discover-dir flows/ --format json
 chainweaver flows list --discover-dir flows/
 
 # Check that your environment is ready before running anything.
-chainweaver doctor --profile first-run
+chainweaver doctor flow --profile first-run
+
+# Inspect a coding-agent workspace's MCP / observe setup (read-only).
+chainweaver doctor vscode --workspace .
 
 # Install tab-completion for your shell (bash/zsh/fish).
 chainweaver --install-completion
@@ -1148,7 +1151,7 @@ chainweaver flows promote candidates/suggested__fetch__validate.flow.yaml --to a
 chainweaver service --tools my_pkg.tools --trace trace.jsonl
 
 # Check saved flows for tool schema drift against the live registry.
-chainweaver doctor flows/ --check-drift --tools my_pkg.tools
+chainweaver doctor flow flows/ --check-drift --tools my_pkg.tools
 
 # Property-based fuzzing: generate cases, check invariants, save/minimize failures.
 chainweaver fuzz flows/etl.flow.yaml --tools my_pkg.tools \

--- a/chainweaver/cli/doctor.py
+++ b/chainweaver/cli/doctor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import importlib.util
+import json
+import re
 import sys
 import tempfile
 from enum import Enum
@@ -29,6 +31,20 @@ from chainweaver.executor import FlowExecutor
 from chainweaver.flow import DAGFlow, Flow
 from chainweaver.registry import FlowRegistry
 from chainweaver.tools import Tool
+
+# ``doctor`` is a command *group*: ``doctor flow`` runs flow diagnostics
+# (drift / preflight / first-run readiness) and ``doctor {vscode,claude,opencode}``
+# inspect a workspace's coding-agent integration (issues #264 / #270 / #275).
+doctor_app = typer.Typer(
+    name="doctor",
+    help=(
+        "Diagnose flows and inspect coding-agent setup. "
+        "Use 'doctor flow' for flow drift/preflight/readiness checks and "
+        "'doctor vscode|claude|opencode' to inspect a workspace's MCP / observe setup."
+    ),
+    no_args_is_help=True,
+)
+app.add_typer(doctor_app, name="doctor")
 
 
 def _doctor_check_drift(
@@ -358,6 +374,474 @@ def _run_first_run_profile(fmt: OutputFormat) -> None:
         raise typer.Exit(code=1)
 
 
+# ---------------------------------------------------------------------------
+# Coding-agent workspace inspectors (issues #264 / #270 / #275)
+#
+# These commands are *read-only*: they inspect a workspace and report what is
+# configured for the observe → suggest → compile workflow. They never modify
+# files. ``--fix-dry-run`` prints the config that *would* be written (so the
+# actual config-writing helpers, issues #269 / #271 / #277, stay separate).
+# ---------------------------------------------------------------------------
+
+# A configured MCP server is treated as a ChainWeaver FlowServer when its key
+# or its (serialised) spec mentions this token — a deliberately loose heuristic
+# since users name the server freely.
+_FLOWSERVER_HINT = "chainweaver"
+
+_VSCODE_FLOWSERVER_SNIPPET = """{
+  "servers": {
+    "chainweaver": {
+      "command": "chainweaver",
+      "args": ["serve", "<flow-file-or-dir>", "--tools", "<your.tools.module>"]
+    }
+  }
+}"""
+
+_CLAUDE_FLOWSERVER_SNIPPET = """{
+  "mcpServers": {
+    "chainweaver": {
+      "command": "chainweaver",
+      "args": ["serve", "<flow-file-or-dir>", "--tools", "<your.tools.module>"]
+    }
+  }
+}"""
+
+_OPENCODE_FLOWSERVER_SNIPPET = """{
+  "mcp": {
+    "chainweaver": {
+      "command": "chainweaver",
+      "args": ["serve", "<flow-file-or-dir>", "--tools", "<your.tools.module>"]
+    }
+  }
+}"""
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    """Strip ``//`` line and ``/* */`` block comments from JSONC text.
+
+    Deliberately simple — good enough for editor config files, which do not, in
+    practice, embed comment markers inside string literals.
+    """
+    no_block = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"(?m)//.*$", "", no_block)
+
+
+def _load_json_config(path: Path) -> tuple[bool, dict[str, Any] | None, str | None]:
+    """Read a JSON / JSONC config file.
+
+    Returns ``(present, parsed_or_None, parse_error_or_None)``.  A JSONC file
+    (``//`` or ``/* */`` comments, used by some editors) is retried after a
+    best-effort comment strip so it still parses.
+    """
+    if not path.is_file():
+        return False, None, None
+    text = path.read_text(encoding="utf-8")
+    try:
+        return True, json.loads(text), None
+    except json.JSONDecodeError:
+        try:
+            return True, json.loads(_strip_jsonc_comments(text)), None
+        except json.JSONDecodeError as exc:
+            return True, None, exc.msg
+
+
+def _find_flowserver(servers: dict[str, Any]) -> str | None:
+    """Return the name of the first MCP server that looks like a FlowServer."""
+    for name, spec in servers.items():
+        if _FLOWSERVER_HINT in name.lower():
+            return name
+        if isinstance(spec, dict) and _FLOWSERVER_HINT in json.dumps(spec).lower():
+            return name
+    return None
+
+
+def _flowserver_check(servers: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Build the 'ChainWeaver FlowServer' check (and recommendation if missing)."""
+    name = _find_flowserver(servers)
+    if name is not None:
+        return (
+            {
+                "name": "ChainWeaver FlowServer",
+                "status": "ok",
+                "detail": f"server '{name}' looks like a ChainWeaver FlowServer",
+            },
+            [],
+        )
+    return (
+        {
+            "name": "ChainWeaver FlowServer",
+            "status": "missing",
+            "detail": "no ChainWeaver FlowServer among the configured MCP servers",
+        },
+        ["Expose reviewed macro-flows by adding a ChainWeaver FlowServer MCP server."],
+    )
+
+
+def _mcp_config_checks(
+    label: str,
+    config_path: Path,
+    *,
+    servers_key: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Inspect one MCP config file: presence, server count, FlowServer presence.
+
+    *servers_key* is the editor-specific key holding the server map
+    (``servers`` for VS Code, ``mcpServers`` for Claude Code, ``mcp`` for
+    OpenCode).
+    """
+    present, data, parse_error = _load_json_config(config_path)
+    if not present:
+        return (
+            [{"name": f"{label} MCP config", "status": "missing", "detail": f"no {config_path}"}],
+            [f"Create {config_path} with a ChainWeaver FlowServer MCP server entry."],
+        )
+    if parse_error is not None:
+        return (
+            [
+                {
+                    "name": f"{label} MCP config",
+                    "status": "missing",
+                    "detail": f"{config_path} is not valid JSON: {parse_error}",
+                }
+            ],
+            [],
+        )
+    raw = data.get(servers_key) if isinstance(data, dict) else None
+    servers = raw if isinstance(raw, dict) else {}
+    checks = [
+        {
+            "name": f"{label} MCP config",
+            "status": "ok",
+            "detail": f"{config_path} configures {len(servers)} MCP server(s)",
+        }
+    ]
+    flowserver_check, recs = _flowserver_check(servers)
+    checks.append(flowserver_check)
+    return checks, recs
+
+
+def _trace_dir_check(workspace: Path) -> dict[str, Any]:
+    """Report whether ``.chainweaver/traces/`` exists and holds trace files."""
+    trace_dir = workspace / ".chainweaver" / "traces"
+    if not trace_dir.is_dir():
+        return {
+            "name": "trace capture",
+            "status": "missing",
+            "detail": f"no trace directory at {trace_dir}",
+        }
+    files = [p for p in trace_dir.rglob("*") if p.is_file()]
+    return {
+        "name": "trace capture",
+        "status": "ok" if files else "info",
+        "detail": (
+            f"{len(files)} trace file(s) under {trace_dir}"
+            if files
+            else f"{trace_dir} exists but holds no trace files yet"
+        ),
+    }
+
+
+def _active_flows_check(workspace: Path) -> dict[str, Any]:
+    """Report how many flow files are discoverable to expose as macro-tools."""
+    flow_files = _iter_flow_files(workspace)
+    return {
+        "name": "macro-flows",
+        "status": "ok" if flow_files else "missing",
+        "detail": (
+            f"{len(flow_files)} flow file(s) discovered"
+            if flow_files
+            else "no .flow.{yaml,yml,json} files found to expose as macro-tools"
+        ),
+    }
+
+
+def _editor_report(
+    editor: str,
+    workspace: Path,
+    *,
+    checks: list[dict[str, Any]],
+    recommendations: list[str],
+    fix_dry_run: bool,
+    snippet: str,
+    snippet_path: Path,
+) -> dict[str, Any]:
+    """Assemble the common editor-report envelope shared by every inspector."""
+    proposed: list[dict[str, Any]] = []
+    if fix_dry_run:
+        proposed.append(
+            {"path": str(snippet_path), "action": "add ChainWeaver FlowServer", "snippet": snippet}
+        )
+    return {
+        "editor": editor,
+        "workspace": str(workspace),
+        "ok": True,
+        "checks": checks,
+        "recommendations": recommendations,
+        "proposed_changes": proposed,
+    }
+
+
+def _vscode_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
+    """Inspect a VS Code / GitHub Copilot workspace (issue #264)."""
+    mcp_path = workspace / ".vscode" / "mcp.json"
+    checks, recommendations = _mcp_config_checks("VS Code", mcp_path, servers_key="servers")
+    checks.append(_trace_dir_check(workspace))
+    checks.append(_active_flows_check(workspace))
+    return _editor_report(
+        "vscode",
+        workspace,
+        checks=checks,
+        recommendations=recommendations,
+        fix_dry_run=fix_dry_run,
+        snippet=_VSCODE_FLOWSERVER_SNIPPET,
+        snippet_path=mcp_path,
+    )
+
+
+def _claude_hooks_check(workspace: Path) -> dict[str, Any]:
+    """Report whether a PostToolUse observe hook is configured for Claude Code."""
+    for rel in (".claude/settings.json", ".claude/settings.local.json"):
+        present, data, _ = _load_json_config(workspace / rel)
+        if (
+            present
+            and isinstance(data, dict)
+            and "hooks" in data
+            and "posttooluse" in json.dumps(data.get("hooks")).lower()
+        ):
+            return {
+                "name": "observe hooks",
+                "status": "ok",
+                "detail": f"PostToolUse hook configured in {rel}",
+            }
+    return {
+        "name": "observe hooks",
+        "status": "missing",
+        "detail": "no PostToolUse hook in .claude/settings*.json for passive trace capture",
+    }
+
+
+def _claude_scope_check(workspace: Path) -> dict[str, Any]:
+    """Summarise which Claude Code config scopes exist in the workspace."""
+    present = [
+        rel
+        for rel in (".mcp.json", ".claude/settings.json", ".claude/settings.local.json")
+        if (workspace / rel).is_file()
+    ]
+    return {
+        "name": "config scope",
+        "status": "ok" if present else "info",
+        "detail": ("present: " + ", ".join(present))
+        if present
+        else "no project (.mcp.json) or local (.claude/settings*.json) config found",
+    }
+
+
+def _claude_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
+    """Inspect a Claude Code workspace (issue #270)."""
+    mcp_path = workspace / ".mcp.json"
+    checks, recommendations = _mcp_config_checks("Claude Code", mcp_path, servers_key="mcpServers")
+    checks.append(_claude_scope_check(workspace))
+    hooks_check = _claude_hooks_check(workspace)
+    checks.append(hooks_check)
+    if hooks_check["status"] == "missing":
+        recommendations.append(
+            "Add a PostToolUse hook in .claude/settings.json to passively capture tool traces."
+        )
+    checks.append(_trace_dir_check(workspace))
+    checks.append(_active_flows_check(workspace))
+    return _editor_report(
+        "claude",
+        workspace,
+        checks=checks,
+        recommendations=recommendations,
+        fix_dry_run=fix_dry_run,
+        snippet=_CLAUDE_FLOWSERVER_SNIPPET,
+        snippet_path=mcp_path,
+    )
+
+
+_OPENCODE_CONFIG_NAMES = ("opencode.json", "opencode.jsonc", ".opencode.json")
+
+
+def _opencode_config_path(workspace: Path) -> Path:
+    """Return the first existing OpenCode config path, else the canonical default."""
+    for name in _OPENCODE_CONFIG_NAMES:
+        candidate = workspace / name
+        if candidate.is_file():
+            return candidate
+    return workspace / _OPENCODE_CONFIG_NAMES[0]
+
+
+def _opencode_plugin_check(workspace: Path, config: dict[str, Any] | None) -> dict[str, Any]:
+    """Report whether an OpenCode ChainWeaver plugin is configured."""
+    plugin_dir = workspace / ".opencode" / "plugin"
+    if plugin_dir.is_dir() and any(plugin_dir.iterdir()):
+        return {
+            "name": "OpenCode plugin",
+            "status": "ok",
+            "detail": f"plugin files present under {plugin_dir}",
+        }
+    if isinstance(config, dict) and config.get("plugin"):
+        return {
+            "name": "OpenCode plugin",
+            "status": "ok",
+            "detail": "a 'plugin' entry is declared in the OpenCode config",
+        }
+    return {
+        "name": "OpenCode plugin",
+        "status": "missing",
+        "detail": "no ChainWeaver OpenCode plugin (.opencode/plugin/) or config 'plugin' entry",
+    }
+
+
+def _opencode_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
+    """Inspect an OpenCode workspace (issue #275)."""
+    config_path = _opencode_config_path(workspace)
+    _, config, _ = _load_json_config(config_path)
+    checks, recommendations = _mcp_config_checks("OpenCode", config_path, servers_key="mcp")
+    plugin_check = _opencode_plugin_check(workspace, config)
+    checks.append(plugin_check)
+    if plugin_check["status"] == "missing":
+        recommendations.append(
+            "Add a ChainWeaver OpenCode plugin to normalise tool-execution events into traces."
+        )
+    flow_files = _iter_flow_files(workspace)
+    checks.append(_active_flows_check(workspace))
+    if flow_files:
+        checks.append(
+            {
+                "name": "tool-name collisions",
+                "status": "info",
+                "detail": (
+                    "verify generated macro-tool names do not collide with built-in/custom "
+                    "OpenCode tool names before exposing them"
+                ),
+            }
+        )
+    checks.append(_trace_dir_check(workspace))
+    return _editor_report(
+        "opencode",
+        workspace,
+        checks=checks,
+        recommendations=recommendations,
+        fix_dry_run=fix_dry_run,
+        snippet=_OPENCODE_FLOWSERVER_SNIPPET,
+        snippet_path=config_path,
+    )
+
+
+def _format_editor_table(report: dict[str, Any]) -> str:
+    """Render an editor inspection report as a human-readable table."""
+    marks = {"ok": "OK  ", "missing": "MISS", "info": "INFO"}
+    lines = [
+        f"ChainWeaver doctor — {report['editor']} ({report['workspace']})",
+        "─" * 70,
+    ]
+    for check in report["checks"]:
+        lines.append(f" [{marks.get(check['status'], '?   ')}] {check['name']}: {check['detail']}")
+    if report["recommendations"]:
+        lines.append("")
+        lines.append("Recommendations:")
+        lines.extend(f"  • {rec}" for rec in report["recommendations"])
+    if report["proposed_changes"]:
+        lines.append("")
+        lines.append("Proposed changes (dry run — no files were modified):")
+        for change in report["proposed_changes"]:
+            lines.append(f"  ~ {change['action']} → {change['path']}")
+            lines.extend(f"      {line}" for line in change["snippet"].splitlines())
+    return "\n".join(lines)
+
+
+def _run_editor_doctor(report: dict[str, Any], fmt: OutputFormat) -> None:
+    """Emit an editor inspection *report* in the requested format."""
+    if fmt is OutputFormat.JSON:
+        _emit_json(report)
+    else:
+        typer.echo(_format_editor_table(report))
+
+
+def _validate_workspace(workspace: Path) -> None:
+    """Exit with code 2 if *workspace* is missing or not a directory."""
+    if not workspace.exists():
+        typer.echo(f"chainweaver: workspace not found: {workspace}", err=True)
+        raise typer.Exit(code=2)
+    if not workspace.is_dir():
+        typer.echo(f"chainweaver: not a directory: {workspace}", err=True)
+        raise typer.Exit(code=2)
+
+
+_WORKSPACE_OPTION = typer.Option(
+    Path("."),
+    "--workspace",
+    "-w",
+    help="Workspace directory to inspect (default: current directory).",
+)
+_EDITOR_FORMAT_OPTION = typer.Option(
+    OutputFormat.TABLE,
+    "--format",
+    "-f",
+    case_sensitive=False,
+    help="Output format: 'table' (human-readable) or 'json'.",
+)
+_FIX_DRY_RUN_OPTION = typer.Option(
+    False,
+    "--fix-dry-run",
+    help="Also print the config that would fix detected gaps, without modifying any files.",
+)
+
+
+@doctor_app.command("vscode")
+def doctor_vscode(
+    workspace: Path = _WORKSPACE_OPTION,
+    output_format: OutputFormat = _EDITOR_FORMAT_OPTION,
+    fix_dry_run: bool = _FIX_DRY_RUN_OPTION,
+) -> None:
+    """Inspect a VS Code / GitHub Copilot workspace for observe/compile readiness (issue #264).
+
+    Read-only: detects ``.vscode/mcp.json``, counts configured MCP servers,
+    flags whether a ChainWeaver FlowServer is exposed, and checks for a trace
+    directory and discoverable macro-flows. Exit code is ``0`` when the
+    workspace is inspectable (missing config is reported, not an error) and
+    ``2`` when *workspace* does not exist or is not a directory.
+    """
+    _validate_workspace(workspace)
+    _run_editor_doctor(_vscode_report(workspace, fix_dry_run=fix_dry_run), output_format)
+
+
+@doctor_app.command("claude")
+def doctor_claude(
+    workspace: Path = _WORKSPACE_OPTION,
+    output_format: OutputFormat = _EDITOR_FORMAT_OPTION,
+    fix_dry_run: bool = _FIX_DRY_RUN_OPTION,
+) -> None:
+    """Inspect a Claude Code workspace's MCP and hook setup (issue #270).
+
+    Read-only: detects ``.mcp.json`` servers and a ChainWeaver FlowServer,
+    summarises project/local config scope, checks for a PostToolUse observe
+    hook in ``.claude/settings*.json``, and reports trace capture and
+    discoverable macro-flows. Same exit-code contract as ``doctor vscode``.
+    """
+    _validate_workspace(workspace)
+    _run_editor_doctor(_claude_report(workspace, fix_dry_run=fix_dry_run), output_format)
+
+
+@doctor_app.command("opencode")
+def doctor_opencode(
+    workspace: Path = _WORKSPACE_OPTION,
+    output_format: OutputFormat = _EDITOR_FORMAT_OPTION,
+    fix_dry_run: bool = _FIX_DRY_RUN_OPTION,
+) -> None:
+    """Inspect an OpenCode workspace's MCP, plugin, and custom-tool setup (issue #275).
+
+    Read-only: detects the OpenCode config (``opencode.json`` / ``.jsonc``) and
+    its MCP servers, flags a ChainWeaver FlowServer and a ChainWeaver plugin,
+    reports discoverable macro-flows (with a tool-name-collision reminder), and
+    checks trace capture. Same exit-code contract as ``doctor vscode``.
+    """
+    _validate_workspace(workspace)
+    _run_editor_doctor(_opencode_report(workspace, fix_dry_run=fix_dry_run), output_format)
+
+
 _DOCTOR_PATH_ARG = typer.Argument(
     None,
     help="Path to a .flow.* file or a directory of flow files (not required with --profile).",
@@ -397,7 +881,7 @@ _DOCTOR_FORMAT_OPTION = typer.Option(
 )
 
 
-@app.command("doctor")
+@doctor_app.command("flow")
 def doctor_command(
     path: Path | None = _DOCTOR_PATH_ARG,
     check_drift: bool = _DOCTOR_CHECK_DRIFT_OPTION,
@@ -446,7 +930,7 @@ def doctor_command(
 
     if not check_drift and not preflight:
         typer.echo(
-            "chainweaver: 'doctor' requires --check-drift, --preflight, or --profile.",
+            "chainweaver: 'doctor flow' requires --check-drift, --preflight, or --profile.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/chainweaver/cli/doctor.py
+++ b/chainweaver/cli/doctor.py
@@ -549,9 +549,12 @@ def _trace_dir_check(workspace: Path) -> dict[str, Any]:
     }
 
 
-def _active_flows_check(workspace: Path) -> dict[str, Any]:
-    """Report how many flow files are discoverable to expose as macro-tools."""
-    flow_files = _iter_flow_files(workspace)
+def _active_flows_check(flow_files: list[Path]) -> dict[str, Any]:
+    """Report how many flow files are discoverable to expose as macro-tools.
+
+    Takes the already-discovered *flow_files* so a caller scans the workspace
+    once and reuses the result across checks, rather than re-walking it.
+    """
     return {
         "name": "macro-flows",
         "status": "ok" if flow_files else "missing",
@@ -594,7 +597,7 @@ def _vscode_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
     mcp_path = workspace / ".vscode" / "mcp.json"
     checks, recommendations = _mcp_config_checks("VS Code", mcp_path, servers_key="servers")
     checks.append(_trace_dir_check(workspace))
-    checks.append(_active_flows_check(workspace))
+    checks.append(_active_flows_check(_iter_flow_files(workspace)))
     return _editor_report(
         "vscode",
         workspace,
@@ -657,7 +660,7 @@ def _claude_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
             "version control) to passively capture tool traces."
         )
     checks.append(_trace_dir_check(workspace))
-    checks.append(_active_flows_check(workspace))
+    checks.append(_active_flows_check(_iter_flow_files(workspace)))
     return _editor_report(
         "claude",
         workspace,
@@ -724,7 +727,7 @@ def _opencode_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
             "Add a ChainWeaver OpenCode plugin to normalise tool-execution events into traces."
         )
     flow_files = _iter_flow_files(workspace)
-    checks.append(_active_flows_check(workspace))
+    checks.append(_active_flows_check(flow_files))
     if flow_files:
         checks.append(
             {

--- a/chainweaver/cli/doctor.py
+++ b/chainweaver/cli/doctor.py
@@ -416,14 +416,20 @@ _OPENCODE_FLOWSERVER_SNIPPET = """{
 }"""
 
 
+# Matches a JSON string literal (with escapes) OR a block / line comment. The
+# string alternative comes first so comment markers *inside* strings (e.g. the
+# ``//`` in a ``"https://…"`` URL) are matched as part of the string and kept.
+_JSONC_TOKEN = re.compile(r'"(?:\\.|[^"\\])*"|/\*.*?\*/|//[^\n]*', re.DOTALL)
+
+
 def _strip_jsonc_comments(text: str) -> str:
     """Strip ``//`` line and ``/* */`` block comments from JSONC text.
 
-    Deliberately simple — good enough for editor config files, which do not, in
-    practice, embed comment markers inside string literals.
+    String literals are preserved verbatim, so comment markers that appear
+    inside strings (such as ``//`` in a URL) are not removed and valid JSON is
+    never corrupted.
     """
-    no_block = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
-    return re.sub(r"(?m)//.*$", "", no_block)
+    return _JSONC_TOKEN.sub(lambda m: m.group(0) if m.group(0).startswith('"') else "", text)
 
 
 def _load_json_config(path: Path) -> tuple[bool, dict[str, Any] | None, str | None]:
@@ -504,7 +510,7 @@ def _mcp_config_checks(
                     "detail": f"{config_path} is not valid JSON: {parse_error}",
                 }
             ],
-            [],
+            [f"Fix the JSON syntax in {config_path} so its MCP servers can be inspected."],
         )
     raw = data.get(servers_key) if isinstance(data, dict) else None
     servers = raw if isinstance(raw, dict) else {}
@@ -529,13 +535,15 @@ def _trace_dir_check(workspace: Path) -> dict[str, Any]:
             "status": "missing",
             "detail": f"no trace directory at {trace_dir}",
         }
-    files = [p for p in trace_dir.rglob("*") if p.is_file()]
+    # Stream the count rather than materialising every path: trace histories
+    # can be large and we only need "how many" / "any?".
+    file_count = sum(1 for p in trace_dir.rglob("*") if p.is_file())
     return {
         "name": "trace capture",
-        "status": "ok" if files else "info",
+        "status": "ok" if file_count else "info",
         "detail": (
-            f"{len(files)} trace file(s) under {trace_dir}"
-            if files
+            f"{file_count} trace file(s) under {trace_dir}"
+            if file_count
             else f"{trace_dir} exists but holds no trace files yet"
         ),
     }
@@ -645,7 +653,8 @@ def _claude_report(workspace: Path, *, fix_dry_run: bool) -> dict[str, Any]:
     checks.append(hooks_check)
     if hooks_check["status"] == "missing":
         recommendations.append(
-            "Add a PostToolUse hook in .claude/settings.json to passively capture tool traces."
+            "Add a PostToolUse hook in .claude/settings.local.json (local scope, kept out of "
+            "version control) to passively capture tool traces."
         )
     checks.append(_trace_dir_check(workspace))
     checks.append(_active_flows_check(workspace))
@@ -673,24 +682,33 @@ def _opencode_config_path(workspace: Path) -> Path:
 
 
 def _opencode_plugin_check(workspace: Path, config: dict[str, Any] | None) -> dict[str, Any]:
-    """Report whether an OpenCode ChainWeaver plugin is configured."""
+    """Report whether a *ChainWeaver* OpenCode plugin is configured.
+
+    Matching is ChainWeaver-specific so an unrelated plugin does not produce a
+    false-positive "ready" signal: a plugin file under ``.opencode/plugin/``
+    whose name mentions ``chainweaver``, or a ``plugin`` config entry that
+    references ``chainweaver``.
+    """
     plugin_dir = workspace / ".opencode" / "plugin"
-    if plugin_dir.is_dir() and any(plugin_dir.iterdir()):
+    if plugin_dir.is_dir():
+        for entry in plugin_dir.iterdir():
+            if entry.is_file() and _FLOWSERVER_HINT in entry.name.lower():
+                return {
+                    "name": "OpenCode plugin",
+                    "status": "ok",
+                    "detail": f"ChainWeaver plugin file '{entry.name}' present under {plugin_dir}",
+                }
+    plugin_cfg = config.get("plugin") if isinstance(config, dict) else None
+    if plugin_cfg is not None and _FLOWSERVER_HINT in json.dumps(plugin_cfg).lower():
         return {
             "name": "OpenCode plugin",
             "status": "ok",
-            "detail": f"plugin files present under {plugin_dir}",
-        }
-    if isinstance(config, dict) and config.get("plugin"):
-        return {
-            "name": "OpenCode plugin",
-            "status": "ok",
-            "detail": "a 'plugin' entry is declared in the OpenCode config",
+            "detail": "a ChainWeaver 'plugin' entry is declared in the OpenCode config",
         }
     return {
         "name": "OpenCode plugin",
         "status": "missing",
-        "detail": "no ChainWeaver OpenCode plugin (.opencode/plugin/) or config 'plugin' entry",
+        "detail": "no ChainWeaver OpenCode plugin (.opencode/plugin/) or 'plugin' config entry",
     }
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -417,12 +417,34 @@ chainweaver profile trace.json --format json
 
 ### `doctor`
 
+`doctor` is a command **group**. `doctor flow` runs flow diagnostics against the currently registered tools; `doctor vscode` / `doctor claude` / `doctor opencode` inspect a workspace's coding-agent setup for the observe → suggest → compile workflow.
+
+#### `doctor flow`
+
 Diagnose ChainWeaver flows against the currently registered tools. With `--check-drift`, walks every flow file under *path* (single file or recursive directory), imports tools from the modules passed via `--tools`, and reports per-flow `missing_tool` / `schema_mismatch` issues. With `--preflight`, runs structural validation (tool existence and resolvable input mappings). With `--profile first-run`, skips flow analysis and checks **environment readiness** instead — Python version, optional-extra availability (with the exact install command), writable paths, and core import health — for a "is my install ready?" first check (no *path* required).
 
 ```
-chainweaver doctor <path> --check-drift [--tools MODULE...] [--format table|json]
-chainweaver doctor --profile first-run [--format table|json]
+chainweaver doctor flow <path> --check-drift [--tools MODULE...] [--format table|json]
+chainweaver doctor flow --profile first-run [--format table|json]
 ```
+
+#### `doctor vscode` / `doctor claude` / `doctor opencode`
+
+Read-only inspectors that report what a workspace has configured for the observe → suggest → compile workflow and what is missing. They **never modify files**; `--fix-dry-run` prints the config that *would* be written. Each detects the editor's MCP config and whether a ChainWeaver FlowServer is exposed, plus a trace directory (`.chainweaver/traces/`) and discoverable macro-flows. `doctor claude` additionally checks config scope (`.mcp.json` / `.claude/settings*.json`) and a PostToolUse observe hook; `doctor opencode` additionally checks for a ChainWeaver plugin and reminds about tool-name collisions.
+
+```
+chainweaver doctor vscode   [--workspace DIR] [--format table|json] [--fix-dry-run]
+chainweaver doctor claude   [--workspace DIR] [--format table|json] [--fix-dry-run]
+chainweaver doctor opencode [--workspace DIR] [--format table|json] [--fix-dry-run]
+```
+
+| Editor flag | Default | Description |
+|------|---------|-------------|
+| `--workspace` / `-w` | `.` | Workspace directory to inspect. |
+| `--format` / `-f` | `table` | Output format: human-readable table or structured JSON. |
+| `--fix-dry-run` | — | Also print the config that would fix detected gaps, without modifying any files. |
+
+Editor-inspector **exit codes**: `0` when the workspace is inspectable (a missing config is reported as a *finding*, not an error), `2` when `--workspace` is missing or is not a directory.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -486,8 +508,8 @@ copy-paste `install` command.
 **Example**:
 
 ```bash
-chainweaver doctor flows/etl.flow.yaml --check-drift --tools my_pkg.tools
-chainweaver doctor flows/ --check-drift --tools my_pkg.tools --format json
+chainweaver doctor flow flows/etl.flow.yaml --check-drift --tools my_pkg.tools
+chainweaver doctor flow flows/ --check-drift --tools my_pkg.tools --format json
 ```
 
 ---

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -132,7 +132,7 @@ class TestDoctorSurface:
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        exit_code = cli.main(["doctor", str(tmp_path)])
+        exit_code = cli.main(["doctor", "flow", str(tmp_path)])
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "requires --check-drift" in captured.err
@@ -142,7 +142,7 @@ class TestDoctorSurface:
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        exit_code = cli.main(["doctor", "--check-drift", str(tmp_path / "nope")])
+        exit_code = cli.main(["doctor", "flow", "--check-drift", str(tmp_path / "nope")])
         captured = capsys.readouterr()
         assert exit_code == 2
         assert "path not found" in captured.err
@@ -156,6 +156,7 @@ class TestDoctorSurface:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(tmp_path / "doctor.flow.yaml"),
                 "--tools",
@@ -184,6 +185,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(flow_path),
                 "--tools",
@@ -219,6 +221,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(flow_path),
                 "--tools",
@@ -254,6 +257,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(flow_path),
                 "--tools",
@@ -284,6 +288,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(flow_path),
                 "--tools",
@@ -320,6 +325,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(flows_dir),
                 "--tools",
@@ -348,7 +354,9 @@ class TestDoctorCheckDrift:
             flow_path,
             tool_schema_hashes={"double": "deadbeef" * 2},
         )
-        exit_code = cli.main(["doctor", "--check-drift", str(flow_path), "--tools", module])
+        exit_code = cli.main(
+            ["doctor", "flow", "--check-drift", str(flow_path), "--tools", module]
+        )
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "DRIFT" in captured.out
@@ -367,6 +375,7 @@ class TestDoctorCheckDrift:
         exit_code = cli.main(
             [
                 "doctor",
+                "flow",
                 "--check-drift",
                 str(bad_path),
                 "--tools",
@@ -406,7 +415,7 @@ class TestDoctorFirstRunProfile:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        exit_code = cli.main(["doctor", "--profile", "first-run"])
+        exit_code = cli.main(["doctor", "flow", "--profile", "first-run"])
         captured = capsys.readouterr()
         # The running interpreter satisfies the floor, cwd/tempdir are writable,
         # and chainweaver imports — so the profile reports ready.
@@ -418,7 +427,7 @@ class TestDoctorFirstRunProfile:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        exit_code = cli.main(["doctor", "--profile", "first-run", "--format", "json"])
+        exit_code = cli.main(["doctor", "flow", "--profile", "first-run", "--format", "json"])
         captured = capsys.readouterr()
         assert exit_code == 0
         payload = json.loads(captured.out)
@@ -436,7 +445,7 @@ class TestDoctorFirstRunProfile:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         # --profile bypasses the path requirement entirely.
-        exit_code = cli.main(["doctor", "--profile", "first-run"])
+        exit_code = cli.main(["doctor", "flow", "--profile", "first-run"])
         capsys.readouterr()
         assert exit_code == 0
 
@@ -444,7 +453,7 @@ class TestDoctorFirstRunProfile:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        exit_code = cli.main(["doctor", "--check-drift"])
+        exit_code = cli.main(["doctor", "flow", "--check-drift"])
         captured = capsys.readouterr()
         assert exit_code == 2
         assert "flow path is required" in captured.err
@@ -458,7 +467,7 @@ class TestDoctorFirstRunProfile:
         # reports NOT READY and exits 1 — the failure branch the CI env, which
         # is always ready, can never reach on its own.
         monkeypatch.setattr("chainweaver.cli.doctor._check_writable", lambda _path: False)
-        exit_code = cli.main(["doctor", "--profile", "first-run"])
+        exit_code = cli.main(["doctor", "flow", "--profile", "first-run"])
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "NOT READY" in captured.out
@@ -471,7 +480,7 @@ class TestDoctorFirstRunProfile:
         # Same failure, JSON surface: ``ok`` is False and the unwritable cwd
         # is reflected in the structured payload.
         monkeypatch.setattr("chainweaver.cli.doctor._check_writable", lambda _path: False)
-        exit_code = cli.main(["doctor", "--profile", "first-run", "--format", "json"])
+        exit_code = cli.main(["doctor", "flow", "--profile", "first-run", "--format", "json"])
         captured = capsys.readouterr()
         assert exit_code == 1
         payload = json.loads(captured.out)

--- a/tests/test_cli_doctor_editors.py
+++ b/tests/test_cli_doctor_editors.py
@@ -202,7 +202,9 @@ class TestDoctorOpenCode:
     ) -> None:
         _write(tmp_path / "opencode.json", {"mcp": {"chainweaver": _flowserver_spec()}})
         (tmp_path / ".opencode" / "plugin").mkdir(parents=True)
-        (tmp_path / ".opencode" / "plugin" / "cw.js").write_text("// plugin\n", encoding="utf-8")
+        (tmp_path / ".opencode" / "plugin" / "chainweaver-observe.js").write_text(
+            "// plugin\n", encoding="utf-8"
+        )
         # A discoverable flow triggers the tool-name-collision reminder.
         (tmp_path / "etl.flow.yaml").write_text(
             "type: Flow\nname: etl\nversion: '0.1.0'\ndescription: d\nsteps: []\n",
@@ -222,9 +224,11 @@ class TestDoctorOpenCode:
     def test_jsonc_config_with_comments_parses(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        # The config has a real comment *and* a URL string containing "//":
+        # comment stripping must not corrupt the URL inside the string.
         (tmp_path / "opencode.jsonc").write_text(
             '{\n  // project MCP servers\n  "mcp": {"chainweaver": '
-            '{"command": "chainweaver"}}\n}\n',
+            '{"command": "chainweaver", "url": "https://example.test/mcp"}}\n}\n',
             encoding="utf-8",
         )
         exit_code = cli.main(
@@ -248,3 +252,31 @@ class TestDoctorOpenCode:
         by_name = {c["name"]: c for c in report["checks"]}
         assert by_name["OpenCode plugin"]["status"] == "missing"
         assert any("plugin" in rec for rec in report["recommendations"])
+
+    def test_unrelated_plugin_does_not_count_as_chainweaver(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An unrelated plugin must not produce a false-positive "ready" signal.
+        _write(tmp_path / "opencode.json", {"mcp": {}, "plugin": ["some-other-plugin"]})
+        (tmp_path / ".opencode" / "plugin").mkdir(parents=True)
+        (tmp_path / ".opencode" / "plugin" / "unrelated.js").write_text("//\n", encoding="utf-8")
+        exit_code = cli.main(
+            ["doctor", "opencode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["OpenCode plugin"]["status"] == "missing"
+
+    def test_invalid_json_config_recommends_fix(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / "opencode.json").write_text("{ broken", encoding="utf-8")
+        exit_code = cli.main(
+            ["doctor", "opencode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        config_check = next(c for c in report["checks"] if c["name"] == "OpenCode MCP config")
+        assert config_check["status"] == "missing"
+        assert any("JSON syntax" in rec for rec in report["recommendations"])

--- a/tests/test_cli_doctor_editors.py
+++ b/tests/test_cli_doctor_editors.py
@@ -1,0 +1,250 @@
+"""Tests for the ``chainweaver doctor {vscode,claude,opencode}`` inspectors.
+
+These read-only commands (issues #264 / #270 / #275) inspect a workspace and
+report what is configured for the observe → suggest → compile workflow:
+the editor's MCP config, whether a ChainWeaver FlowServer is exposed, trace
+capture, and discoverable macro-flows. They never modify files.
+
+Exit-code contract: ``0`` when the workspace is inspectable (a missing config
+is a *finding*, not a failure) and ``2`` when ``--workspace`` is missing or is
+not a directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chainweaver import cli
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    cli.set_default_registry(None)
+
+
+def _write(path: Path, payload: object) -> None:
+    """Write *payload* as JSON to *path*, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _flowserver_spec() -> dict[str, object]:
+    return {"command": "chainweaver", "args": ["serve", "flows/", "--tools", "my.tools"]}
+
+
+# ---------------------------------------------------------------------------
+# Shared workspace / exit-code contract
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceContract:
+    @pytest.mark.parametrize("editor", ["vscode", "claude", "opencode"])
+    def test_missing_workspace_exits_two(
+        self, editor: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(["doctor", editor, "--workspace", str(tmp_path / "nope")])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "workspace not found" in captured.err
+
+    @pytest.mark.parametrize("editor", ["vscode", "claude", "opencode"])
+    def test_workspace_not_a_directory_exits_two(
+        self, editor: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        file_path = tmp_path / "afile"
+        file_path.write_text("x", encoding="utf-8")
+        exit_code = cli.main(["doctor", editor, "--workspace", str(file_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "not a directory" in captured.err
+
+    @pytest.mark.parametrize("editor", ["vscode", "claude", "opencode"])
+    def test_empty_workspace_is_inspectable_exit_zero(
+        self, editor: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(["doctor", editor, "--workspace", str(tmp_path), "--format", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        report = json.loads(captured.out)
+        assert report["editor"] == editor
+        assert report["ok"] is True
+        # An empty workspace surfaces a missing MCP config and at least one
+        # recommendation, but is not itself a failure.
+        assert any(c["status"] == "missing" for c in report["checks"])
+        assert report["recommendations"]
+
+
+# ---------------------------------------------------------------------------
+# doctor vscode (#264)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorVSCode:
+    def test_detects_flowserver_and_traces(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(
+            tmp_path / ".vscode" / "mcp.json",
+            {"servers": {"chainweaver": _flowserver_spec(), "other": {"command": "x"}}},
+        )
+        (tmp_path / ".chainweaver" / "traces").mkdir(parents=True)
+        (tmp_path / ".chainweaver" / "traces" / "agent.jsonl").write_text("{}\n", encoding="utf-8")
+
+        exit_code = cli.main(
+            ["doctor", "vscode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert "2 MCP server(s)" in by_name["VS Code MCP config"]["detail"]
+        assert by_name["ChainWeaver FlowServer"]["status"] == "ok"
+        assert by_name["trace capture"]["status"] == "ok"
+
+    def test_missing_flowserver_recommended(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(tmp_path / ".vscode" / "mcp.json", {"servers": {"unrelated": {"command": "x"}}})
+        exit_code = cli.main(
+            ["doctor", "vscode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["ChainWeaver FlowServer"]["status"] == "missing"
+        assert any("FlowServer" in rec for rec in report["recommendations"])
+
+    def test_invalid_json_reported_not_crashed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mcp_path = tmp_path / ".vscode" / "mcp.json"
+        mcp_path.parent.mkdir(parents=True)
+        mcp_path.write_text("{ not json", encoding="utf-8")
+        exit_code = cli.main(
+            ["doctor", "vscode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        config_check = next(c for c in report["checks"] if c["name"] == "VS Code MCP config")
+        assert config_check["status"] == "missing"
+        assert "not valid JSON" in config_check["detail"]
+
+    def test_fix_dry_run_emits_proposal_without_writing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(
+            ["doctor", "vscode", "--workspace", str(tmp_path), "--fix-dry-run", "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        assert report["proposed_changes"], "expected a proposed change under --fix-dry-run"
+        # Dry run must not create the config file.
+        assert not (tmp_path / ".vscode" / "mcp.json").exists()
+
+    def test_table_output_renders(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cli.main(["doctor", "vscode", "--workspace", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "ChainWeaver doctor — vscode" in captured.out
+        assert "Recommendations:" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# doctor claude (#270)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorClaude:
+    def test_detects_servers_scope_and_hooks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(tmp_path / ".mcp.json", {"mcpServers": {"chainweaver-flows": _flowserver_spec()}})
+        _write(
+            tmp_path / ".claude" / "settings.json",
+            {"hooks": {"PostToolUse": [{"matcher": "*", "hooks": []}]}},
+        )
+        exit_code = cli.main(
+            ["doctor", "claude", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["ChainWeaver FlowServer"]["status"] == "ok"
+        assert by_name["observe hooks"]["status"] == "ok"
+        assert ".mcp.json" in by_name["config scope"]["detail"]
+
+    def test_missing_hooks_recommended(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(tmp_path / ".mcp.json", {"mcpServers": {}})
+        exit_code = cli.main(
+            ["doctor", "claude", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["observe hooks"]["status"] == "missing"
+        assert any("PostToolUse" in rec for rec in report["recommendations"])
+
+
+# ---------------------------------------------------------------------------
+# doctor opencode (#275)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorOpenCode:
+    def test_detects_servers_plugin_and_collision_note(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(tmp_path / "opencode.json", {"mcp": {"chainweaver": _flowserver_spec()}})
+        (tmp_path / ".opencode" / "plugin").mkdir(parents=True)
+        (tmp_path / ".opencode" / "plugin" / "cw.js").write_text("// plugin\n", encoding="utf-8")
+        # A discoverable flow triggers the tool-name-collision reminder.
+        (tmp_path / "etl.flow.yaml").write_text(
+            "type: Flow\nname: etl\nversion: '0.1.0'\ndescription: d\nsteps: []\n",
+            encoding="utf-8",
+        )
+        exit_code = cli.main(
+            ["doctor", "opencode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["ChainWeaver FlowServer"]["status"] == "ok"
+        assert by_name["OpenCode plugin"]["status"] == "ok"
+        assert by_name["macro-flows"]["status"] == "ok"
+        assert "tool-name collisions" in by_name
+
+    def test_jsonc_config_with_comments_parses(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / "opencode.jsonc").write_text(
+            '{\n  // project MCP servers\n  "mcp": {"chainweaver": '
+            '{"command": "chainweaver"}}\n}\n',
+            encoding="utf-8",
+        )
+        exit_code = cli.main(
+            ["doctor", "opencode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["OpenCode MCP config"]["status"] == "ok"
+        assert by_name["ChainWeaver FlowServer"]["status"] == "ok"
+
+    def test_missing_plugin_recommended(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(tmp_path / "opencode.json", {"mcp": {}})
+        exit_code = cli.main(
+            ["doctor", "opencode", "--workspace", str(tmp_path), "--format", "json"]
+        )
+        report = json.loads(capsys.readouterr().out)
+        assert exit_code == 0
+        by_name = {c["name"]: c for c in report["checks"]}
+        assert by_name["OpenCode plugin"]["status"] == "missing"
+        assert any("plugin" in rec for rec in report["recommendations"])

--- a/tests/test_cli_traces.py
+++ b/tests/test_cli_traces.py
@@ -241,12 +241,12 @@ class TestDoctorPreflight:
     def test_requires_a_mode(self, tmp_path: Path) -> None:
         flow_file = tmp_path / "f.flow.yaml"
         _write_flow(flow_file, Flow(name="f", description="d", steps=[FlowStep(tool_name="a")]))
-        assert cli.main(["doctor", str(flow_file)]) == 1
+        assert cli.main(["doctor", "flow", str(flow_file)]) == 1
 
     def test_both_modes_exit_2(self, tmp_path: Path) -> None:
         flow_file = tmp_path / "f.flow.yaml"
         _write_flow(flow_file, Flow(name="f", description="d", steps=[FlowStep(tool_name="a")]))
-        assert cli.main(["doctor", str(flow_file), "--check-drift", "--preflight"]) == 2
+        assert cli.main(["doctor", "flow", str(flow_file), "--check-drift", "--preflight"]) == 2
 
     def test_valid_flow_is_ok(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str], _tools_module: str
@@ -263,7 +263,9 @@ class TestDoctorPreflight:
                 ],
             ),
         )
-        exit_code = cli.main(["doctor", str(flow_file), "--preflight", "--tools", _tools_module])
+        exit_code = cli.main(
+            ["doctor", "flow", str(flow_file), "--preflight", "--tools", _tools_module]
+        )
         captured = capsys.readouterr()
         assert exit_code == 0
         assert "all 1 flow(s) ok" in captured.out
@@ -276,7 +278,9 @@ class TestDoctorPreflight:
             flow_file,
             Flow(name="bad", description="d", steps=[FlowStep(tool_name="ghost")]),
         )
-        exit_code = cli.main(["doctor", str(flow_file), "--preflight", "--tools", _tools_module])
+        exit_code = cli.main(
+            ["doctor", "flow", str(flow_file), "--preflight", "--tools", _tools_module]
+        )
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "missing_tool" in captured.out
@@ -296,7 +300,9 @@ class TestDoctorPreflight:
                 ],
             ),
         )
-        exit_code = cli.main(["doctor", str(flow_file), "--preflight", "--tools", _tools_module])
+        exit_code = cli.main(
+            ["doctor", "flow", str(flow_file), "--preflight", "--tools", _tools_module]
+        )
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "unresolved_mapping" in captured.out
@@ -310,7 +316,16 @@ class TestDoctorPreflight:
             Flow(name="ok", description="d", steps=[FlowStep(tool_name="fs.search")]),
         )
         cli.main(
-            ["doctor", str(flow_file), "--preflight", "--tools", _tools_module, "--format", "json"]
+            [
+                "doctor",
+                "flow",
+                str(flow_file),
+                "--preflight",
+                "--tools",
+                _tools_module,
+                "--format",
+                "json",
+            ]
         )
         payload = json.loads(capsys.readouterr().out)
         assert payload["flow_count"] == 1
@@ -331,7 +346,9 @@ class TestDoctorPreflight:
                 steps=[FlowStep(tool_name="fs.search", input_mapping={"q": "bogus"})],
             ),
         )
-        exit_code = cli.main(["doctor", str(flow_file), "--preflight", "--tools", _tools_module])
+        exit_code = cli.main(
+            ["doctor", "flow", str(flow_file), "--preflight", "--tools", _tools_module]
+        )
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "unresolved_mapping" in captured.out
@@ -349,5 +366,7 @@ class TestDoctorPreflight:
                 steps=[FlowStep(tool_name="fs.search", input_mapping={"q": "q"})],
             ),
         )
-        exit_code = cli.main(["doctor", str(flow_file), "--preflight", "--tools", _tools_module])
+        exit_code = cli.main(
+            ["doctor", "flow", str(flow_file), "--preflight", "--tools", _tools_module]
+        )
         assert exit_code == 0


### PR DESCRIPTION
## Summary

Adds read-only coding-agent workspace inspectors so first-run users can see whether their editor is set up for the observe → suggest → compile workflow. Implements three issues in one PR (they share a single command scaffold and code area):

- **#264** `chainweaver doctor vscode`
- **#270** `chainweaver doctor claude`
- **#275** `chainweaver doctor opencode`

`doctor` becomes a Typer **command group**: existing flow diagnostics move to `doctor flow` (behaviour unchanged), and the three inspectors are added alongside.

## Changes

- `chainweaver/cli/doctor.py` — convert `doctor` to a sub-app; register existing diagnostics as `doctor flow`; add a shared editor-inspection scaffold (`_load_json_config` with JSONC tolerance, `_find_flowserver`, `_mcp_config_checks`, `_trace_dir_check`, `_active_flows_check`) and `vscode` / `claude` / `opencode` subcommands.
- `tests/test_cli_doctor_editors.py` — new: workspace/exit-code contract + per-editor detection, invalid-JSON handling, JSONC parsing, `--fix-dry-run` (asserts nothing is written).
- `tests/test_cli_doctor.py`, `tests/test_cli_traces.py` — retarget existing invocations to `doctor flow`.
- `docs/cli.md`, `README.md`, `AGENTS.md` — document the group and the new inspectors.

## Behaviour

- **Read-only.** Inspectors never modify files; `--fix-dry-run` prints the config that *would* be written. (Actual config-writing helpers remain the separate issues #269/#271/#277.)
- Each detects the editor's MCP config + ChainWeaver FlowServer exposure, plus `.chainweaver/traces/` and discoverable macro-flows. `claude` also checks config scope and a PostToolUse observe hook; `opencode` also checks for a ChainWeaver plugin and warns about tool-name collisions.
- **Exit codes:** `0` when the workspace is inspectable (a missing config is a *finding*, not a failure); `2` when `--workspace` is missing or not a directory.

## Scope deltas (Mode B — documented)

- Uses the repo-standard `--format table|json` instead of the issues' proposed `--json`, for consistency with every other CLI command (envelope/format conventions).
- `--write-config` / setup helpers are intentionally **out of scope** (tracked separately as #269/#271/#277); these commands stay strictly read-only.

## How verified

- `ruff check chainweaver/ tests/ examples/` — All checks passed
- `ruff format --check chainweaver/ tests/ examples/` — 234 files already formatted
- `python -m mypy chainweaver/ tests/` — Success: no issues found in 197 source files
- `python -m pytest tests/` — **1722 passed, 1 skipped**, total coverage 92.79% (gate 80%); `chainweaver/cli/doctor.py` at 92%
- Manual smoke test: `doctor --help` lists the four subcommands; `doctor vscode` and `doctor claude --fix-dry-run --format json` produce correct reports and write no files.

## Testing
- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`)
- [x] New tests added for new functionality

## Related Issues

Closes #264
Closes #270
Closes #275

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented
- [x] No secrets or credentials included


---
_Generated by [Claude Code](https://claude.ai/code/session_01Yb1Zaif3zqYyBMGyyMXxUp)_