### PR TITLE
docs: resolve documentation drift and add contributor onramp + CI gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,21 @@
 - [ ] All existing tests pass (`python -m pytest tests/ -v`)
 - [ ] New tests added for new functionality
 
+## Issues closed by this PR
+
+<!--
+List the issue(s) this PR closes, one per line, using a closing keyword so
+GitHub auto-closes them on merge (e.g. `Closes #123`). Prefer one primary
+issue per PR (see CONTRIBUTING.md § PR process). This field is the source of
+truth for what the PR resolves — especially when the branch name can't carry
+the issue number (e.g. tool-generated `claude/<task>` branches).
+-->
+
+Closes #
+
 ## Related Issues
+
+<!-- Issues this PR relates to but does NOT close. -->
 
 
 ## Checklist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,10 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
-      # These four invocations are the canonical commands from AGENTS.md §7,
-      # verbatim (same scope, same flags) so local pre-commit == CI.
+      # The first three steps are the static-analysis commands from
+      # AGENTS.md §7, verbatim (same scope, same flags) so local pre-commit
+      # == CI; §7's fourth canonical command, pytest, runs in the test
+      # matrix above. The banned-vocabulary check (#466) is additive.
       - name: Lint with Ruff
         run: ruff check chainweaver/ tests/ examples/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,9 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
-      # Lint / format / mypy are stable across OSes and Pythons, so we run
-      # them once (the canonical Python 3.10 on ubuntu-latest leg) to keep
-      # the matrix fast and the gating signal unambiguous.
-      - name: Lint with Ruff
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
-        run: ruff check chainweaver/ tests/ examples/
-
-      - name: Check formatting with Ruff
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
-        run: ruff format --check chainweaver/ tests/ examples/
-
-      - name: Type check with mypy
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
-        run: python -m mypy chainweaver/ tests/
-
+      # Lint / format / mypy / workflow + vocabulary checks live in the
+      # dedicated `lint` job below so the static-analysis signal is a single
+      # unambiguous gate, independent of the OS/Python test matrix.
       - name: Run tests
         run: python -m pytest tests/ -v
 
@@ -66,6 +54,46 @@ jobs:
       - name: Run notebooks (nbmake)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: python -m pytest --nbmake notebooks/ --no-cov -v
+
+  # Dedicated static-analysis gate (issue #458): lint, format, types, the
+  # banned-vocabulary check (#466), and GitHub Actions workflow linting all
+  # run once on the canonical Python 3.10 / ubuntu lane. Keeping them in one
+  # job — instead of conditional steps buried in the test matrix — makes the
+  # "is the code clean?" signal a single, clearly named check.
+  lint:
+    name: lint, format, types, workflows
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      # These four invocations are the canonical commands from AGENTS.md §7,
+      # verbatim (same scope, same flags) so local pre-commit == CI.
+      - name: Lint with Ruff
+        run: ruff check chainweaver/ tests/ examples/
+
+      - name: Check formatting with Ruff
+        run: ruff format --check chainweaver/ tests/ examples/
+
+      - name: Type check with mypy
+        run: python -m mypy chainweaver/ tests/
+
+      - name: Check banned vocabulary (#466)
+        run: python scripts/check_vocabulary.py
+
+      # actionlint (pinned to match .pre-commit-config.yaml) lints every
+      # workflow; the image bundles shellcheck so `run:` scripts are checked
+      # too. Docker is available on GitHub-hosted ubuntu runners.
+      - name: Lint GitHub Actions workflows (actionlint)
+        run: docker run --rm -v "${PWD}:/repo" --workdir /repo rhysd/actionlint:1.7.7 -color
 
   conformance:
     name: weaver-spec conformance (#91)

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -81,7 +81,7 @@ jobs:
           chmod +x "${RUNNER_TEMP}/mcp-publisher"
 
       - name: Validate MCP registry manifest
-        run: "${RUNNER_TEMP}/mcp-publisher validate server.json"
+        run: '"${RUNNER_TEMP}/mcp-publisher" validate server.json'
 
       - name: Smoke-test released action and package
         id: action-smoke

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,16 @@ repos:
         types: [python]
         pass_filenames: false
 
+      # Banned-vocabulary check (issue #466): flags "pipeline" used as a
+      # flow-synonym in docs/docstrings. Scans its own default scope, so
+      # pass_filenames is false (like the checks above).
+      - id: check-vocabulary
+        name: check vocabulary
+        entry: python scripts/check_vocabulary.py
+        language: system
+        types_or: [python, markdown]
+        pass_filenames: false
+
   # ---------------------------------------------------------------------
   # Generic hygiene.
   # ---------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,12 @@
 #     pre-commit run --all-files
 #
 # Conventions:
-# - The four canonical Python checks (ruff check / ruff format --check / mypy)
-#   are `local` hooks so they invoke exactly the commands documented in
+# - Three of the four canonical checks (ruff check / ruff format --check /
+#   mypy) are `local` hooks so they invoke exactly the commands documented in
 #   AGENTS.md §7 — including the scope `chainweaver/ tests/ examples/`. This
 #   keeps the hook output identical to CI; see lessons-learned.md rule #3
-#   ("commands that don't match CI exactly").
+#   ("commands that don't match CI exactly"). pytest is deliberately NOT a
+#   hook — run it manually or rely on CI.
 # - External hooks are pinned to specific tags. Update them deliberately.
 
 default_language_version:
@@ -23,7 +24,7 @@ default_stages: [pre-commit, manual]
 
 repos:
   # ---------------------------------------------------------------------
-  # Canonical four checks (mirror AGENTS.md §7 verbatim).
+  # Canonical static checks (mirror AGENTS.md §7 verbatim; pytest excluded).
   # ---------------------------------------------------------------------
   - repo: local
     hooks:

--- a/.vocabulary-allowlist.txt
+++ b/.vocabulary-allowlist.txt
@@ -1,0 +1,29 @@
+# Vocabulary allowlist for scripts/check_vocabulary.py (issue #466).
+#
+# The checker bans "pipeline"/"pipelines" used as a synonym for a ChainWeaver
+# *flow*. Each line below is a case-insensitive substring; a flagged match is
+# suppressed when its scanned text segment contains that substring. Keep
+# entries specific so real misuse is still caught.
+#
+# Add an entry ONLY for a genuine non-flow use of the word "pipeline"
+# (a generic software pipeline, a quoted rule definition, etc.) — never to
+# paper over a flow that should just be called a flow.
+
+# The vocabulary rule's own definition rows (AGENTS.md, CONTRIBUTING.md,
+# .github/copilot-instructions.md, review-checklist.md) and the prose that
+# documents the checker itself.
+chain, pipeline
+never "chain"
+`pipeline`/`pipelines`
+
+# Generic software pipelines that are not ChainWeaver flows.
+json pipeline
+review pipeline
+reviewer pipeline
+analysis pipeline
+proposal pipeline
+trace pipeline
+otel pipeline
+evaluation pipeline
+refine-in-place pipeline
+strict pipeline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ changes. The executor is deterministic by design.
 9. Pydantic `BaseModel` for all data schemas (`Flow`, `FlowStep`, I/O contracts).
 10. No secrets, credentials, or PII in code, logs, or tests.
 11. All new code must pass: `ruff check`, `ruff format --check`, `mypy`, `pytest`.
-12. One logical change per PR; all tests must pass before merge.
+12. One primary issue per PR (bundle only genuinely coupled work, and say why); declare closing issues in the PR template; all tests must pass before merge. See [workflows.md § PR conventions](docs/agent-context/workflows.md#pr-conventions).
 
 For the full prohibited-actions list and anti-patterns, see
 [invariants.md](docs/agent-context/invariants.md).
@@ -416,8 +416,11 @@ python -m mypy chainweaver/ tests/
 python -m pytest tests/ -v
 ```
 
-CI runs lint + format + mypy on Python 3.10 / `ubuntu-latest` only; tests
-run across `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11,
+CI runs lint + format + mypy in a dedicated `lint` job on Python 3.10 /
+`ubuntu-latest` (issue #458); that job also runs the banned-vocabulary check
+(`scripts/check_vocabulary.py`, issue #466) and lints the workflows with
+`actionlint`. Tests run across
+`{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11,
 3.12, 3.13, 3.14}` (15 jobs in total). A `floor-deps` job additionally
 installs the minimum declared dependency versions
 (`uv pip install --resolution lowest-direct`) and runs the full suite on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ For AI contributors: also read [`AGENTS.md`](AGENTS.md) and [`docs/agent-context
 ## Table of Contents
 
 - [Dev environment setup](#dev-environment-setup)
+- [Your first contribution](#your-first-contribution)
 - [Pre-commit hooks](#pre-commit-hooks)
 - [Running tests](#running-tests)
 - [Code style](#code-style)
@@ -40,28 +41,70 @@ Python 3.10 or later is required.
 
 ---
 
+## Your first contribution
+
+New here? Start with a curated, well-scoped task rather than a sprawling one.
+
+**Look for these labels on open issues:**
+
+| Label | Who it's for | What it means |
+|-------|--------------|---------------|
+| `good-first-issue` | First-time human contributors | Scoped, low-context, with clear acceptance criteria. |
+| `good-first-ai-issue` | AI agents (Copilot, Claude Code, …) | Same bar, plus enough file/path detail in the body for an agent to act without repo-wide spelunking. |
+
+A task qualifies for either label when it is **scoped** (one logical change),
+**low-context** (no deep architectural background required), and ships with
+**clear acceptance criteria**. Docs fixes, an example or test for an existing
+behavior, and small CLI/output polish are typical starting points.
+
+**Your first change, step by step:**
+
+1. Read [`AGENTS.md`](AGENTS.md) and the per-file-type guidance in
+   [`.github/instructions/`](.github/instructions/) for the area you're
+   touching.
+2. Make the smallest correct change for the issue — resist bundling adjacent
+   fixes (open a follow-up issue instead; see
+   [`workflows.md` § Out-of-scope discoveries](docs/agent-context/workflows.md)).
+3. Run the four validation commands (see [Running tests](#running-tests))
+   until they pass locally.
+4. Open a PR following the [PR process](#pr-process); fill in every template
+   section.
+
+Maintainers curate the labelled pool — if you spot a task that looks
+first-issue sized, mention it on the issue rather than self-assigning a label.
+
+---
+
 ## Pre-commit hooks
 
 ChainWeaver ships a [`.pre-commit-config.yaml`](.pre-commit-config.yaml) that
-mirrors the four CI checks plus a few hygiene hooks. Set it up once per
-clone:
+mirrors **three of the four** validation commands documented in
+[`AGENTS.md` §7](AGENTS.md#7-validation-commands) — `ruff check`,
+`ruff format --check`, and `mypy` — plus a few hygiene hooks, secret
+scanning, and GitHub Actions linting. **`pytest` is *not* a hook**: it is
+excluded to keep commit speed reasonable, so run it manually before pushing
+or rely on CI. Set the hooks up once per clone:
 
 ```bash
+# One-time install (after `pip install -e ".[dev]"`)
 pip install pre-commit
 pre-commit install
 ```
 
-After installation, the hooks run automatically on every `git commit`.
-You can also run them manually against the whole tree:
+After installation, the hooks run automatically on every `git commit`. You
+can also run them against the whole tree (recommended after a rebase):
 
 ```bash
 pre-commit run --all-files
 ```
 
-The hooks invoke exactly the commands documented in
-[`AGENTS.md` §7](AGENTS.md#7-validation-commands) — same scope
-(`chainweaver/ tests/ examples/`), same flags — so a clean local run
-matches a clean CI run.
+The three Python hooks use `language: system` and invoke the canonical
+commands verbatim — same scope (`chainweaver/ tests/ examples/`), same flags
+— so a clean local run matches a clean CI run. If a hook fails, fix the
+underlying issue and re-stage; do **not** bypass it with `--no-verify`.
+
+Hook versions are pinned in `.pre-commit-config.yaml`. Bumping a hook is a
+deliberate change: update the pin in the same PR that benefits from it.
 
 ### Secret scanning
 
@@ -98,25 +141,6 @@ python -m pytest tests/ -v
 ```
 
 CI runs lint + format + mypy on Python 3.10, and tests across Python 3.10–3.14.
-
----
-
-## Pre-commit hooks
-
-A `.pre-commit-config.yaml` at the repo root mirrors three of the four validation commands above (ruff check, ruff format --check, mypy) plus secret scanning. pytest is excluded to keep commit speed reasonable — run it manually before pushing or rely on CI. Hooks use `language: system` so they run from the project venv with the same tool versions.
-
-```bash
-# One-time install (after `pip install -e ".[dev]"`)
-pip install pre-commit
-pre-commit install
-
-# Run all hooks against every tracked file (recommended after a rebase)
-pre-commit run --all-files
-```
-
-Once installed, the hooks run automatically on `git commit`. If a hook fails, fix the underlying issue and re-stage — do not bypass the hook with `--no-verify`.
-
-Hook versions are pinned in `.pre-commit-config.yaml`. Bumping a hook is a deliberate change: update the pin in the same PR that benefits from it.
 
 ---
 
@@ -162,16 +186,27 @@ Use the canonical terms consistently in code, docs, and PR descriptions:
 | **flow** | chain, pipeline |
 | **tool** | function, action (when referring to a `Tool` instance) |
 
+**Automated check.** [`scripts/check_vocabulary.py`](scripts/check_vocabulary.py)
+flags `pipeline`/`pipelines` used as a flow-synonym in Markdown prose and
+Python docstrings/comments, and runs as a pre-commit hook and in CI. Genuine
+non-flow uses of the word (e.g. "JSON pipeline", "review pipeline") are
+exempted in [`.vocabulary-allowlist.txt`](.vocabulary-allowlist.txt); add an
+entry there with care rather than reaching for an LLM-friendly synonym.
+
+**Why not auto-check "chain"?** It is a legitimate domain noun here —
+`ChainAnalyzer.find_chains()` returns *chains* (candidate tool sequences), and
+the builder offers fluent method *chaining*. Auto-banning it would force a
+sprawling allowlist that masks real misuse, so **using "chain" as a synonym
+for a flow remains a human-review item**: reviewers should still catch it.
+
 ---
 
 ## PR process
 
-1. **One logical change per PR.** A PR that implements a feature, adds tests, and updates docs is one logical change. Only split if changes are genuinely unrelated.
-2. **Link the relevant issue** in your PR description under _Related Issues_.
+1. **One primary issue per PR.** A PR that implements one issue's feature, adds its tests, and updates its docs is one logical change. Prefer one issue per PR — smaller PRs review faster, conflict less, and keep `main` green. If a PR must touch several issues because the work is genuinely coupled, say *why* in the PR description.
+2. **Declare the issues this PR closes** in the PR template's _Issues closed by this PR_ field (e.g. `Closes #123`), and link related-but-not-closed issues under _Related Issues_. The closing field is the source of truth when the branch name cannot carry the issue number.
 3. **All tests must pass** before requesting review.
-4. **Branch naming:** `{type}/{issue_number}-{short-description}`
-   - Types: `feat`, `fix`, `docs`, `test`, `refactor`
-   - Example: `feat/55-add-pr-template`
+4. **Branch naming.** Manually created branches use `{type}/{issue_number}-{short-description}` (types: `feat`, `fix`, `docs`, `test`, `refactor`; e.g. `feat/55-add-pr-template`). Tool-generated branches (e.g. the `claude/<task>` branches the AI-agent workflow produces) are accepted as-is — they often can't embed an issue number — **provided the PR declares its closing issue(s)** per step 2. See [`workflows.md` § Branch naming](docs/agent-context/workflows.md#branch-naming) for the canonical rule.
 5. **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/):
    ```
    feat: add timeout guardrails to tool execution

--- a/README.md
+++ b/README.md
@@ -187,10 +187,14 @@ flows, no server) around it.
 | Lean dep set | ✅ 5 runtime pkgs | ❌ heavy | ❌ heavy | ❌ heavy | ❌ very heavy | ❌ heavy |
 | File-serializable flows | ✅ YAML / JSON | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Standalone (no server) | ✅ | ✅ | ✅ | ⚠️ ephemeral mode | ⚠️ needs daemon | ❌ server required |
+| Stateful long-running workflows | ❌ by design | ❌ | ⚠️ partial | ✅ | ✅ | ✅ |
+| Graph branches on LLM output | ❌ by design | ⚠️ limited | ✅ | ✅ N/A | ✅ N/A | ✅ N/A |
 
-See [docs/comparisons.md](docs/comparisons.md) for the full matrix —
-including version pins, citations to each alternative's own docs, and a
-"when to pick which" guide.
+See [docs/comparisons.md](docs/comparisons.md) (also on the
+[hosted site](https://chainweaver.readthedocs.io/en/latest/comparisons/)) for
+the full matrix — version pins, citations to each alternative's own docs, and
+a "when to pick which" guide. Re-evaluated on each minor release of any of the
+projects above.
 
 ---
 
@@ -217,22 +221,10 @@ the nuances; the short version:
   (use Prefect, Dagster, or Temporal).
 - You expect the executor to call an LLM. It deliberately doesn't.
 
-### How ChainWeaver relates to neighbours
-
-| | ChainWeaver | LangChain LCEL | Prefect 3 | Dagster | Temporal | LangGraph |
-|---|---|---|---|---|---|---|
-| LLM-free between steps (by design) | **Yes** | No | N/A | N/A | N/A | No |
-| Pydantic-validated I/O at every step | **Yes** | Partial | No | Partial | No | No |
-| Small runtime dependency set | **Yes** (5 packages) | No | No | No | No | No |
-| File-serializable flow definitions | **Yes** (JSON / YAML) | No | Python | Python | Python | No |
-| Standalone (no server / scheduler) | **Yes** | Yes | No | No | No | Yes |
-| Stateful long-running workflows | No | No | Yes | Yes | Yes | Partial |
-| Graph branches on LLM output | No (by design) | Limited | N/A | N/A | N/A | **Yes** |
-
-The full one-paragraph-per-tool comparison lives at
-[docs/comparisons.md](docs/comparisons.md) and on the
-[hosted site](https://chainweaver.readthedocs.io/en/latest/comparisons/). Re-evaluated
-on each minor release of any of the projects above.
+The framework comparison table above (and the full one-paragraph-per-tool
+matrix in [docs/comparisons.md](docs/comparisons.md)) covers how ChainWeaver
+relates to its neighbours — LangChain, LangGraph, Prefect, Dagster, and
+Temporal.
 
 For the correctness argument behind the design, see
 [docs/data-integrity.md](docs/data-integrity.md).
@@ -1210,6 +1202,10 @@ introspection-friendly).
 ---
 
 ## Development
+
+New contributors: see [**Your first contribution**](CONTRIBUTING.md#your-first-contribution)
+in `CONTRIBUTING.md` for the `good-first-issue` / `good-first-ai-issue` onramp
+and the step-by-step path to your first PR.
 
 ```bash
 # Install with dev dependencies

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -113,14 +113,24 @@ and reruns never move an existing release tag.
 
 ## PR conventions
 
-- One logical change per PR.
+- **One primary issue per PR.** Implementing one issue's feature + its tests +
+  its docs is a single logical change. Only bundle multiple issues when the
+  work is genuinely coupled, and say *why* in the PR description.
+- **Declare closing issues** in the PR template's _Issues closed by this PR_
+  field (`Closes #N`). This field — not the branch name — is the source of
+  truth for what a PR resolves.
 - PR title: imperative mood (e.g., "Add retry logic to executor").
 - Architecture changes → update AGENTS.md repo map + `architecture.md` in the same PR.
 - Coding convention changes → update this file in the same PR.
 
+The contributor-facing version of these rules lives in
+[`CONTRIBUTING.md` § PR process](/CONTRIBUTING.md#pr-process).
+
 ---
 
 ## Branch naming
+
+Manually created branches:
 
 ```
 {type}/{issue_number}-{short-description}
@@ -129,6 +139,12 @@ and reruns never move an existing release tag.
 Types: `feat`, `fix`, `docs`, `test`, `refactor`.
 
 Example: `feat/43-tool-timeout-guardrails`
+
+**Tool-generated branches** (e.g. the `claude/<task-slug>` branches the
+AI-agent workflow produces) often cannot embed an issue number. They are
+accepted as-is — do **not** rename them to satisfy the pattern. The
+authoritative link to the issue is the PR's _Issues closed by this PR_ field
+(see [PR conventions](#pr-conventions)), not the branch name.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,111 @@
+# ChainWeaver examples
+
+Runnable, standalone scripts that demonstrate ChainWeaver's features. Every
+script in this directory runs without a test framework and without live
+external services:
+
+```bash
+pip install -e ".[dev]"      # from the repo root
+python examples/simple_linear_flow.py
+```
+
+Some scripts need an optional extra (noted inline) — e.g. MCP examples need
+`pip install 'chainweaver[mcp]'` and YAML flows need `chainweaver[yaml]`.
+
+> This index is enforced by `tests/test_examples_index.py`: every
+> `examples/*.py` script must appear below, so the list cannot silently rot.
+> Several scripts have a narrated walkthrough under
+> [`docs/cookbook/`](../docs/cookbook/index.md) — linked where one exists.
+
+## Basics
+
+| Script | What it shows |
+|--------|---------------|
+| [`simple_linear_flow.py`](simple_linear_flow.py) | A simple linear flow — the smallest end-to-end example. |
+| [`etl_flow.py`](etl_flow.py) | An extract/transform/load-style flow. |
+| [`builder_flow.py`](builder_flow.py) | Constructing a flow programmatically with `FlowBuilder`. |
+| [`decorator_tool.py`](decorator_tool.py) | Defining a tool with the decorator API. |
+| [`virtual_tool.py`](virtual_tool.py) | Flow-as-Tool: composing a flow so it can be used as a tool. |
+| [`naive_vs_compiled.py`](naive_vs_compiled.py) | Naive LLM-in-the-loop vs. compiled-flow timing comparison ([cookbook](../docs/cookbook/01-naive-to-compiled.md)). |
+
+## Caching & checkpointing
+
+| Script | What it shows |
+|--------|---------------|
+| [`caching.py`](caching.py) | Step-result caching to skip recomputation. |
+| [`checkpoint_resume.py`](checkpoint_resume.py) | Crash-resume checkpointing of a partially executed flow. |
+
+## Streaming
+
+| Script | What it shows |
+|--------|---------------|
+| [`streaming_flow.py`](streaming_flow.py) | Streaming per-step output as a flow executes. |
+
+## Flow discovery & analysis (offline)
+
+| Script | What it shows |
+|--------|---------------|
+| [`chain_analyzer.py`](chain_analyzer.py) | Discovering schema-compatible tool combinations offline with `ChainAnalyzer`. |
+| [`chain_observer.py`](chain_observer.py) | Suggesting compiled flows from runtime tool traces with `ChainObserver`. |
+| [`llm_flow_proposals.py`](llm_flow_proposals.py) | Proposing flows from tool metadata with an offline LLM ([cookbook](../docs/cookbook/offline-llm-flow-proposals.md)). |
+| [`description_optimizer.py`](description_optimizer.py) | Rewriting tool descriptions for discriminability with an offline LLM ([cookbook](../docs/cookbook/offline-description-optimizer.md)). |
+
+## Contrib tools
+
+| Script | What it shows |
+|--------|---------------|
+| [`contrib_map_filter.py`](contrib_map_filter.py) | The `map_list` / `filter_list` contrib tools over sub-flows. |
+| [`contrib_pluck_and_set.py`](contrib_pluck_and_set.py) | The `json_pluck` / `json_set` contrib tools. |
+
+## MCP integration
+
+| Script | What it shows |
+|--------|---------------|
+| [`mcp_adapter.py`](mcp_adapter.py) | Wrapping an inbound MCP tool with `MCPToolAdapter`. |
+| [`mcp_flow_server.py`](mcp_flow_server.py) | Exposing flows over MCP with `FlowServer`. |
+| [`mcp_search_flow.py`](mcp_search_flow.py) | An MCP-style search-and-summarize flow. |
+| [`mcp_style_before_after_demo.py`](mcp_style_before_after_demo.py) | Before/after demo of an MCP-style tool flow ([cookbook](../docs/cookbook/mcp-before-after.md)). |
+
+## Coding-agent workflows
+
+| Script | What it shows |
+|--------|---------------|
+| [`coding_agent_pr_review.py`](coding_agent_pr_review.py) | Deterministic PR-review checklist template. |
+| [`coding_agent_changelog.py`](coding_agent_changelog.py) | Deterministic changelog-generation template. |
+| [`coding_agent_debug_log.py`](coding_agent_debug_log.py) | Deterministic debug-log triage template. |
+| [`coding_agent_macro_flows.py`](coding_agent_macro_flows.py) | Realistic coding-agent macro-flow examples. |
+
+## Cost & observability
+
+| Script | What it shows |
+|--------|---------------|
+| [`otel_export.py`](otel_export.py) | Emitting OpenTelemetry spans per step ([cookbook](../docs/cookbook/03-otel-tracing.md)). |
+
+## Export adapters
+
+| Script | What it shows |
+|--------|---------------|
+| [`export_openai_anthropic.py`](export_openai_anthropic.py) | Exporting a compiled flow to OpenAI / Anthropic / generic-callable shapes. |
+
+## Plugins
+
+| Script | What it shows |
+|--------|---------------|
+| [`plugin_discovery.py`](plugin_discovery.py) | Entry-point plugin discovery. |
+
+## Policy evaluation
+
+| Script | What it shows |
+|--------|---------------|
+| [`skdr_policy_eval_flow.py`](skdr_policy_eval_flow.py) | Offline policy-evaluation workflow using skdr-eval artifacts ([cookbook](../docs/cookbook/policy-eval-skdr.md)). |
+
+## Multi-file examples
+
+These live in their own subdirectories:
+
+| Directory | What it shows |
+|-----------|---------------|
+| [`cookbook/`](cookbook/) | Numbered recipe scripts mirrored by [`docs/cookbook/`](../docs/cookbook/index.md). |
+| [`integrations/`](integrations/) | Framework integration recipes ([LangGraph node](../docs/cookbook/langgraph-node.md), [OpenAI Agents tool](../docs/cookbook/openai-agents-tool.md)). |
+| [`release_readiness_flow/`](release_readiness_flow/) | A release-readiness flow ([cookbook](../docs/cookbook/release-readiness.md)). |
+| [`weaver_stack_golden_path/`](weaver_stack_golden_path/) | End-to-end Weaver Stack interop golden path. |

--- a/scripts/check_vocabulary.py
+++ b/scripts/check_vocabulary.py
@@ -1,0 +1,182 @@
+"""Banned-vocabulary check (issue #466).
+
+ChainWeaver's `CONTRIBUTING.md` mandates the canonical term **flow** (never
+"pipeline"). That rule was enforced only by human reviewers, so the same
+wording correction recurred in review rounds. This check shifts it left: it
+flags "pipeline" used as a flow-synonym in Markdown prose and Python
+docstrings/comments so it is caught before review.
+
+Why only "pipeline" is automated (see issue #466 discussion):
+
+- "chain" is intentionally **not** auto-flagged. It is a first-class domain
+  noun here — ``ChainAnalyzer.find_chains()`` returns *chains* (candidate
+  tool sequences), and ``builder`` uses fluent method *chaining*. Lexically
+  banning it would require allow-listing ~50 legitimate uses, which would gut
+  the check. "chain" misuse stays a human-review item (CONTRIBUTING.md
+  § Vocabulary).
+- "pipeline" has a small, enumerable set of legitimate uses ("JSON pipeline",
+  "review pipeline", ...), so it is a clean, low-noise gate.
+
+Precision (so the repo passes at introduction):
+
+- **Whole-word matches only.**
+- **Python: comments and string/docstring tokens only.** Code identifiers are
+  never inspected.
+- **Markdown: prose lines.**
+- Legitimate non-flow uses live in ``.vocabulary-allowlist.txt`` and the
+  path-prefix exemptions below.
+
+Usage::
+
+    python scripts/check_vocabulary.py                 # scan the default scope
+    python scripts/check_vocabulary.py path/a.md b.py   # scan specific files
+
+Exit status: ``0`` if clean, ``1`` if any violation is found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ALLOWLIST_FILE = _REPO_ROOT / ".vocabulary-allowlist.txt"
+
+# Banned whole words → canonical replacement guidance shown in the message.
+# Deliberately limited to "pipeline" (see module docstring); "chain" is a
+# domain noun here and is left to human review.
+_BANNED: dict[str, str] = {
+    "pipeline": "flow",
+    "pipelines": "flows",
+}
+_BANNED_RE = re.compile(
+    r"\b(" + "|".join(sorted(_BANNED, key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
+# Whole files/trees exempt from the scan:
+#  - this checker, its test, and the allowlist itself (they name the terms);
+#  - CHANGELOG.md (historical record, not living prose);
+#  - benchmarks/ (describe the "naive chaining" anti-pattern ChainWeaver
+#    replaces, and measure "chain length");
+#  - tests/ and scripts/ (fixtures/tooling, outside the shipped-prose surface).
+_EXEMPT_PREFIXES: tuple[str, ...] = (
+    "scripts/",
+    "tests/",
+    "benchmarks/",
+    "CHANGELOG.md",
+    ".vocabulary-allowlist.txt",
+)
+
+# Default scan scope when no files are passed: shipped library code + the
+# user-facing docs/examples prose. Mirrors the spirit of the canonical
+# ``chainweaver/ tests/ examples/`` scope, minus the exempt trees above.
+_DEFAULT_GLOBS: tuple[str, ...] = (
+    "*.md",
+    ".github/**/*.md",
+    "chainweaver/**/*.py",
+    "examples/**/*.py",
+    "examples/**/*.md",
+    "docs/**/*.md",
+)
+
+
+def _load_allowlist() -> list[str]:
+    """Lower-cased exemption substrings from ``.vocabulary-allowlist.txt``.
+
+    A banned match is suppressed when its scanned text segment contains any of
+    these substrings (case-insensitive). Blank lines and ``#`` comments are
+    ignored.
+    """
+    if not _ALLOWLIST_FILE.is_file():
+        return []
+    entries: list[str] = []
+    for raw in _ALLOWLIST_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            entries.append(line.lower())
+    return entries
+
+
+def _is_exempt(rel_path: str) -> bool:
+    return any(rel_path == p or rel_path.startswith(p) for p in _EXEMPT_PREFIXES)
+
+
+def _segments(path: Path) -> list[tuple[int, str]]:
+    """``(lineno, text)`` segments to scan for ``path``.
+
+    Markdown is scanned line by line. Python is scanned token by token,
+    restricted to comments and string literals so code identifiers are never
+    inspected.
+    """
+    if path.suffix == ".md":
+        text = path.read_text(encoding="utf-8")
+        return [(i, line) for i, line in enumerate(text.splitlines(), start=1)]
+
+    segments: list[tuple[int, str]] = []
+    with path.open("rb") as handle:
+        try:
+            for tok in tokenize.tokenize(handle.readline):
+                if tok.type in (tokenize.COMMENT, tokenize.STRING):
+                    segments.append((tok.start[0], tok.string))
+        except (tokenize.TokenError, SyntaxError):
+            # Unparseable Python is a problem for ruff/mypy, not this check.
+            return []
+    return segments
+
+
+def _violations(path: Path, allowlist: list[str]) -> list[tuple[int, str]]:
+    found: list[tuple[int, str]] = []
+    for lineno, text in _segments(path):
+        lowered = text.lower()
+        if any(entry in lowered for entry in allowlist):
+            continue
+        for match in _BANNED_RE.finditer(text):
+            found.append((lineno, match.group(0)))
+    return found
+
+
+def _resolve_targets(argv: list[str]) -> list[Path]:
+    if argv:
+        return [Path(arg) for arg in argv]
+    targets: list[Path] = []
+    for pattern in _DEFAULT_GLOBS:
+        targets.extend(sorted(_REPO_ROOT.glob(pattern)))
+    return targets
+
+
+def main(argv: list[str]) -> int:
+    allowlist = _load_allowlist()
+    failures = 0
+    for path in _resolve_targets(argv):
+        if path.suffix not in (".md", ".py") or not path.is_file():
+            continue
+        try:
+            rel = str(path.resolve().relative_to(_REPO_ROOT))
+        except ValueError:
+            rel = str(path)
+        if _is_exempt(rel):
+            continue
+        for lineno, word in _violations(path, allowlist):
+            failures += 1
+            replacement = _BANNED[word.lower()]
+            print(
+                f"{rel}:{lineno}: banned term {word!r} — use {replacement!r} "
+                f"(add an entry to .vocabulary-allowlist.txt if this is a "
+                f"legitimate non-flow use)"
+            )
+    if failures:
+        print(
+            f"\n{failures} banned-vocabulary use(s) found. "
+            f"Use 'flow'/'tool', or allowlist legitimate uses. "
+            f"See CONTRIBUTING.md § Vocabulary.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_check_vocabulary.py
+++ b/tests/test_check_vocabulary.py
@@ -1,0 +1,84 @@
+"""Tests for the banned-vocabulary checker (issue #466).
+
+Covers the checker's behavior (it flags "pipeline", respects the allowlist,
+leaves "chain" alone, and never inspects Python code identifiers) and acts as
+an anti-drift guard: the repository must currently pass its own check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_vocabulary.py"
+
+
+def _load_checker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_vocabulary", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def test_repo_passes_its_own_check() -> None:
+    """The tree must stay clean so the gate passes at introduction and after."""
+    assert checker.main([]) == 0
+
+
+def test_flags_pipeline_in_markdown(tmp_path: Path) -> None:
+    doc = tmp_path / "note.md"
+    doc.write_text("Run the data pipeline to load rows.\n", encoding="utf-8")
+    violations = checker._violations(doc, [])
+    assert [word for _, word in violations] == ["pipeline"]
+
+
+def test_allowlist_suppresses_legitimate_use(tmp_path: Path) -> None:
+    doc = tmp_path / "note.md"
+    doc.write_text("Round-trips through any JSON pipeline.\n", encoding="utf-8")
+    assert checker._violations(doc, []) != []
+    assert checker._violations(doc, ["json pipeline"]) == []
+
+
+def test_chain_is_not_flagged(tmp_path: Path) -> None:
+    """'chain' is a domain noun here and is intentionally left to human review."""
+    doc = tmp_path / "note.md"
+    doc.write_text("The analyzer returns a chain of tools.\n", encoding="utf-8")
+    assert checker._violations(doc, []) == []
+
+
+def test_whole_word_only(tmp_path: Path) -> None:
+    doc = tmp_path / "note.md"
+    doc.write_text("A pipelined design is fine.\n", encoding="utf-8")
+    assert checker._violations(doc, []) == []
+
+
+def test_python_identifiers_are_ignored_but_comments_are_not(tmp_path: Path) -> None:
+    src = tmp_path / "mod.py"
+    src.write_text(
+        "pipeline = 1  # build the pipeline\n",
+        encoding="utf-8",
+    )
+    # The NAME token `pipeline` is never inspected; only the comment is.
+    lines = {lineno for lineno, _ in checker._violations(src, [])}
+    assert lines == {1}
+
+
+def test_python_docstring_is_scanned(tmp_path: Path) -> None:
+    src = tmp_path / "mod.py"
+    src.write_text('"""Build a pipeline of steps."""\n', encoding="utf-8")
+    assert [word for _, word in checker._violations(src, [])] == ["pipeline"]
+
+
+@pytest.mark.parametrize("argv_word", ["pipeline", "pipelines"])
+def test_main_exit_code(tmp_path: Path, argv_word: str) -> None:
+    doc = tmp_path / "note.md"
+    doc.write_text(f"two {argv_word} here\n", encoding="utf-8")
+    assert checker.main([str(doc)]) == 1

--- a/tests/test_examples_index.py
+++ b/tests/test_examples_index.py
@@ -1,0 +1,47 @@
+"""Anti-drift test for the examples index (#409).
+
+`examples/README.md` is a categorized index of the standalone scripts in
+`examples/`. Without a guard it rots the moment someone adds a script and
+forgets to list it. This test enumerates every root-level ``examples/*.py``
+script and asserts it is referenced in the index, so a newcomer's map of the
+examples directory cannot silently fall behind the directory itself.
+
+Only root-level scripts are enforced. Multi-file examples in subdirectories
+(``cookbook/``, ``integrations/``, ``release_readiness_flow/``,
+``weaver_stack_golden_path/``) are covered by their own narrative sections.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+_INDEX = _EXAMPLES_DIR / "README.md"
+
+
+def _root_example_scripts() -> list[str]:
+    """Filenames of the root-level ``examples/*.py`` scripts, sorted."""
+    return sorted(p.name for p in _EXAMPLES_DIR.glob("*.py"))
+
+
+def test_examples_index_exists() -> None:
+    """The index file must exist (it is the entry point newcomers land on)."""
+    assert _INDEX.is_file(), f"missing examples index: {_INDEX}"
+
+
+def test_there_is_at_least_one_root_example() -> None:
+    """Guard against the enforcement below silently passing on an empty glob."""
+    assert _root_example_scripts(), "no root-level examples/*.py scripts found"
+
+
+@pytest.mark.parametrize("script", _root_example_scripts())
+def test_root_example_is_listed_in_index(script: str) -> None:
+    """Every ``examples/*.py`` script must be referenced in ``examples/README.md``."""
+    index_text = _INDEX.read_text(encoding="utf-8")
+    assert script in index_text, (
+        f"examples/{script} exists but is not listed in examples/README.md. "
+        f"Add it to the appropriate section of the index."
+    )

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -68,7 +68,7 @@ def test_distribution_check_runs_after_successful_publication() -> None:
     assert 'workflows: ["Publish to PyPI"]' in workflow
     assert "github.event.workflow_run.conclusion == 'success'" in workflow
     assert "python scripts/release.py verify-pypi" in workflow
-    assert "mcp-publisher validate server.json" in workflow
+    assert 'mcp-publisher" validate server.json' in workflow
     assert "sha256sum --check -" in workflow
     assert "uses: ./.github/actions/chainweaver" in workflow
     assert "chainweaver-version: ${{ steps.release.outputs.version }}" in workflow

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -68,7 +68,11 @@ def test_distribution_check_runs_after_successful_publication() -> None:
     assert 'workflows: ["Publish to PyPI"]' in workflow
     assert "github.event.workflow_run.conclusion == 'success'" in workflow
     assert "python scripts/release.py verify-pypi" in workflow
-    assert 'mcp-publisher" validate server.json' in workflow
+    # SC2086: the ${RUNNER_TEMP}/mcp-publisher path must be quoted. Assert the full
+    # quoted form (including the opening quote) is present and the unquoted pre-fix
+    # form is gone, so this test fails if the SC2086 fix ever regresses.
+    assert '"${RUNNER_TEMP}/mcp-publisher" validate server.json' in workflow
+    assert "mcp-publisher validate server.json" not in workflow
     assert "sha256sum --check -" in workflow
     assert "uses: ./.github/actions/chainweaver" in workflow
     assert "chainweaver-version: ${{ steps.release.outputs.version }}" in workflow


### PR DESCRIPTION
Addresses a batch of docs/CI triage issues:

- #464: merge the two contradictory "Pre-commit hooks" sections in
  CONTRIBUTING.md into one accurate section (three of four checks; pytest
  excluded).
- #437: add a "Your first contribution" onramp documenting the
  good-first-issue / good-first-ai-issue labels and the first-PR path; link
  it from README's Development section.
- #411: consolidate the two README framework-comparison tables into one
  canonical table with a single link to docs/comparisons.md.
- #409: add a categorized examples/README.md index plus an anti-drift test
  (tests/test_examples_index.py) that fails if a root example is unlisted.
- #466: add scripts/check_vocabulary.py (wired into pre-commit and a new CI
  lint job) flagging "pipeline" used as a flow-synonym, with a documented
  .vocabulary-allowlist.txt; "chain" is intentionally left to human review
  (it is a domain noun: ChainAnalyzer.find_chains).
- #463: clarify one-primary-issue-per-PR scope and reconcile branch naming
  for tool-generated branches (canonical docs + CONTRIBUTING + a new
  "Issues closed by this PR" PR-template field).
- #458: add a dedicated CI `lint` job (ruff, format, mypy, vocabulary,
  actionlint) and fix a pre-existing SC2086 in distribution-check.yml so the
  workflow linter is green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012NgTqeQ7U7NKGxUCLq8fC8