### PR TITLE
test: harden executor import contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,12 @@ changes. The executor is deterministic by design.
 2. No network I/O.
 3. No randomness.
 
+These invariants are mechanically enforced by
+`tests/test_executor_import_contract.py` over `executor.py` and
+`chainweaver/_execution/`, including direct imports, transitive in-repo reach,
+and obvious literal dynamic imports; see
+[invariants.md](docs/agent-context/invariants.md).
+
 **Package-wide:**
 4. All exceptions inherit from `ChainWeaverError` with relevant context
    attributes (`tool_name`, `step_index`, `detail` where applicable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Executor determinism import-contract hardening** (#430): the guard in
+  `tests/test_executor_import_contract.py` now rejects obvious literal dynamic
+  import patterns (`__import__("random")`,
+  `importlib.import_module("openai")`, including simple aliases) in
+  `executor.py` and `chainweaver/_execution/`, closing a bypass around the
+  existing #354 direct-import and import-closure checks.
+
 - **Run-scoped state is now isolated per asyncio task** (#336): the executor's
   run-scoped markers (injected `dynamic_params`, `active_flow_version`, the
   replay/resume flags, and the `stream_flow` event collector) moved from a

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -52,7 +52,7 @@ They are non-negotiable.
 Network I/O and randomness are allowed in **tool functions** — the executor
 only manages the data flow between tools.
 
-### Automated enforcement (since #354)
+### Automated enforcement (since #354; dynamic-import hardening #430)
 
 The three hard invariants are mechanically enforced by
 `tests/test_executor_import_contract.py`, which runs as part of the normal
@@ -65,13 +65,19 @@ The three hard invariants are mechanically enforced by
   the in-repo modules already marked "banned from executor.py" in the repo map
   (`compiler_llm`, `optimizer`, `observer`, `traces`, `lessons`, `service`,
   `_offline_llm`).
+- **Literal dynamic import patterns** — the same execution modules reject
+  reviewable bypasses such as `__import__("random")`,
+  `importlib.import_module("openai")`, and simple aliases when the target is
+  a string literal. The check intentionally does not evaluate runtime-built
+  strings; those should not appear in executor code.
 - **Transitive in-repo reach** — following `chainweaver.*` imports out of the
   execution modules, none of the deterministic-execution closure may reach a
   banned in-repo module, so a helper cannot smuggle an LLM proposer onto the
   execution path indirectly.
 
-A PR that adds `import random` (or any banned import) to the execution modules
-fails this test with a message pointing back at this document.
+A PR that adds `import random`, `__import__("random")`, or any banned import
+to the execution modules fails this test with a message pointing back at this
+document.
 
 **Carve-outs:** `uuid` is the single reviewed exception, for the trace-id
 carve-out above. It is kept deliberately *off* the banned list (rather than

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -68,8 +68,11 @@ The three hard invariants are mechanically enforced by
 - **Literal dynamic import patterns** — the same execution modules reject
   reviewable bypasses such as `__import__("random")`,
   `importlib.import_module("openai")`, and simple aliases when the target is
-  a string literal. The check intentionally does not evaluate runtime-built
-  strings; those should not appear in executor code.
+  a string literal. Relative `importlib.import_module(".optimizer",
+  package="chainweaver")` literals are resolved against their literal
+  `package` argument before classification, so a leading dot cannot hide a
+  banned in-repo module. The check intentionally does not evaluate
+  runtime-built strings; those should not appear in executor code.
 - **Transitive in-repo reach** — following `chainweaver.*` imports out of the
   execution modules, none of the deterministic-execution closure may reach a
   banned in-repo module, so a helper cannot smuggle an LLM proposer onto the

--- a/tests/test_executor_import_contract.py
+++ b/tests/test_executor_import_contract.py
@@ -17,6 +17,9 @@ The check has three layers:
 2. **Literal dynamic imports** — obvious bypasses such as
    ``__import__("random")`` and ``importlib.import_module("openai")`` are
    rejected when the target is a string literal, including simple aliases.
+   Relative ``importlib.import_module(".optimizer", package="chainweaver")``
+   literals are resolved against their literal ``package`` argument before
+   classification, so a leading dot cannot hide a banned in-repo module.
 3. **Transitive in-repo reach** — following ``chainweaver.*`` imports from the
    execution modules, none of the deterministic-execution closure may reach a
    banned in-repo source of nondeterminism / LLM behavior (``compiler_llm``,
@@ -238,12 +241,57 @@ def _literal_import_name(node: ast.Call) -> str | None:
     return None
 
 
+def _literal_package_name(node: ast.Call) -> str | None:
+    """Return the literal ``package`` argument to a relative dynamic import call."""
+    if (
+        len(node.args) > 1
+        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1].value, str)
+    ):
+        return node.args[1].value
+    for keyword in node.keywords:
+        if (
+            keyword.arg == "package"
+            and isinstance(keyword.value, ast.Constant)
+            and isinstance(keyword.value.value, str)
+        ):
+            return keyword.value.value
+    return None
+
+
+def _resolve_relative_literal(name: str, package: str | None) -> str | None:
+    """Resolve a relative ``importlib.import_module`` literal to its absolute form.
+
+    Mirrors :func:`importlib._bootstrap._resolve_name`: the leading dots on
+    *name* are resolved against *package* the same way Python resolves them at
+    runtime, so a relative literal (``".optimizer"`` with
+    ``package="chainweaver"``) cannot dodge classification by hiding the banned
+    module name behind a dot. Returns ``None`` when *package* is missing or the
+    relative reference climbs above the top-level package — both are
+    unresolvable, so there is nothing to classify.
+    """
+    level = len(name) - len(name.lstrip("."))
+    if level == 0:
+        return name
+    if not package:
+        return None
+    remainder = name[level:]
+    bits = package.rsplit(".", level - 1)
+    if len(bits) < level:
+        return None
+    base = bits[0]
+    return f"{base}.{remainder}" if remainder else base
+
+
 def _collect_dynamic_imports(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return literal dynamic import targets found in *tree*.
 
     The contract intentionally covers reviewable, AST-visible bypasses only:
     ``__import__("random")``, ``importlib.import_module("openai")``, and simple
-    aliases of those helpers. It does not try to evaluate runtime-built strings.
+    aliases of those helpers. Relative ``importlib.import_module`` literals
+    (e.g. ``".optimizer"`` with ``package="chainweaver"``) are resolved to
+    their absolute dotted form before classification. It does not try to
+    evaluate runtime-built strings.
     """
     aliases = _dynamic_import_aliases(tree)
     external: set[str] = set()
@@ -261,6 +309,10 @@ def _collect_dynamic_imports(tree: ast.AST) -> tuple[set[str], set[str]]:
         module = _literal_import_name(node)
         if module is None:
             continue
+        if module.startswith(".") and call_name == "importlib.import_module":
+            module = _resolve_relative_literal(module, _literal_package_name(node))
+            if module is None:
+                continue
         external_root, inrepo_module = _classify_import_target(module)
         if external_root is not None:
             external.add(external_root)
@@ -363,6 +415,9 @@ builtin_import("chainweaver.optimizer")
 load_module(name="chainweaver.compiler_llm.helpers")
 module_name = "secrets"
 __import__(module_name)
+load_module(".optimizer", package="chainweaver")
+load_module(name=".compiler_llm", package="chainweaver")
+load_module("..observer", package="chainweaver.sub")
 """
     )
 
@@ -373,6 +428,22 @@ __import__(module_name)
     assert "chainweaver.optimizer" in inrepo
     assert "chainweaver.compiler_llm.helpers" in inrepo
     assert _matches_banned_inrepo("chainweaver.compiler_llm.helpers")
+    # Relative importlib.import_module literals resolve against `package` instead
+    # of leaking through as a spurious external root (see PR #482 review).
+    assert "chainweaver.optimizer" in inrepo
+    assert "chainweaver.compiler_llm" in inrepo
+    assert "chainweaver.observer" in inrepo
+    assert "" not in external
+
+
+def test_resolve_relative_literal_matches_importlib_semantics() -> None:
+    """Directly exercise the relative-literal resolver against known cases."""
+    assert _resolve_relative_literal("random", None) == "random"
+    assert _resolve_relative_literal(".optimizer", "chainweaver") == "chainweaver.optimizer"
+    assert _resolve_relative_literal("..observer", "chainweaver.sub") == "chainweaver.observer"
+    assert _resolve_relative_literal(".", "chainweaver") == "chainweaver"
+    assert _resolve_relative_literal(".optimizer", None) is None
+    assert _resolve_relative_literal("...too.deep", "chainweaver") is None
 
 
 def test_banned_lists_are_documented_and_consistent() -> None:

--- a/tests/test_executor_import_contract.py
+++ b/tests/test_executor_import_contract.py
@@ -7,14 +7,17 @@ as the contributor base (human and automated) grows.  This module gives them a
 mechanical, *static* CI check so a regression fails ``pytest`` with a message
 pointing at the invariants doc.
 
-The check has two layers:
+The check has three layers:
 
 1. **Direct imports** — the execution modules (``executor.py`` plus everything
    under the ``chainweaver/_execution`` package) must not import any banned
    module. Entropy/IO-adjacent names the executor legitimately needs (``uuid``
    for trace ids) are reviewed carve-outs kept deliberately *off* the banned
    list rather than re-permitted after the fact.
-2. **Transitive in-repo reach** — following ``chainweaver.*`` imports from the
+2. **Literal dynamic imports** — obvious bypasses such as
+   ``__import__("random")`` and ``importlib.import_module("openai")`` are
+   rejected when the target is a string literal, including simple aliases.
+3. **Transitive in-repo reach** — following ``chainweaver.*`` imports from the
    execution modules, none of the deterministic-execution closure may reach a
    banned in-repo source of nondeterminism / LLM behavior (``compiler_llm``,
    ``optimizer``, ``observer``, ``traces``, ``lessons``, ``service``,
@@ -170,6 +173,113 @@ def _collect_imports(path: Path) -> tuple[set[str], set[str]]:
     return external, inrepo
 
 
+def _classify_import_target(module: str) -> tuple[str | None, str | None]:
+    """Return ``(external_root, inrepo_module)`` for a dotted module target."""
+    root = module.split(".")[0]
+    if root == "chainweaver":
+        return None, module
+    return root, None
+
+
+def _call_name(node: ast.AST) -> str | None:
+    """Resolve a simple call target to a dotted name."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        value = _call_name(node.value)
+        if value is None:
+            return None
+        return f"{value}.{node.attr}"
+    return None
+
+
+def _dynamic_import_aliases(tree: ast.AST) -> dict[str, str]:
+    """Collect simple aliases for supported dynamic-import helpers."""
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in {"builtins", "importlib"}:
+                    aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module in {"builtins", "importlib"}:
+            for alias in node.names:
+                if node.module == "builtins" and alias.name == "__import__":
+                    aliases[alias.asname or alias.name] = "builtins.__import__"
+                elif node.module == "importlib" and alias.name == "import_module":
+                    aliases[alias.asname or alias.name] = "importlib.import_module"
+    return aliases
+
+
+def _resolve_call_name(call_name: str | None, aliases: dict[str, str]) -> str | None:
+    """Apply simple import aliases to a dotted call name."""
+    if call_name is None:
+        return None
+    head, sep, tail = call_name.partition(".")
+    if head in aliases:
+        return aliases[head] + (sep + tail if sep else "")
+    return call_name
+
+
+def _literal_import_name(node: ast.Call) -> str | None:
+    """Return the literal module name passed to a dynamic import call."""
+    if (
+        node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        return node.args[0].value
+    for keyword in node.keywords:
+        if (
+            keyword.arg == "name"
+            and isinstance(keyword.value, ast.Constant)
+            and isinstance(keyword.value.value, str)
+        ):
+            return keyword.value.value
+    return None
+
+
+def _collect_dynamic_imports(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return literal dynamic import targets found in *tree*.
+
+    The contract intentionally covers reviewable, AST-visible bypasses only:
+    ``__import__("random")``, ``importlib.import_module("openai")``, and simple
+    aliases of those helpers. It does not try to evaluate runtime-built strings.
+    """
+    aliases = _dynamic_import_aliases(tree)
+    external: set[str] = set()
+    inrepo: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _resolve_call_name(_call_name(node.func), aliases)
+        if call_name not in {
+            "__import__",
+            "builtins.__import__",
+            "importlib.import_module",
+        }:
+            continue
+        module = _literal_import_name(node)
+        if module is None:
+            continue
+        external_root, inrepo_module = _classify_import_target(module)
+        if external_root is not None:
+            external.add(external_root)
+        if inrepo_module is not None:
+            inrepo.add(inrepo_module)
+    return external, inrepo
+
+
+def _collect_dynamic_imports_from_path(path: Path) -> tuple[set[str], set[str]]:
+    """Return literal dynamic import targets in *path*."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return _collect_dynamic_imports(tree)
+
+
+def _matches_banned_inrepo(module: str) -> bool:
+    """Return true when *module* is banned or is a child of a banned module."""
+    return any(module == banned or module.startswith(f"{banned}.") for banned in BANNED_INREPO)
+
+
 def test_execution_modules_have_no_banned_direct_imports() -> None:
     """``executor.py`` and ``_execution/*`` import nothing on the banned lists."""
     violations: list[str] = []
@@ -178,11 +288,27 @@ def test_execution_modules_have_no_banned_direct_imports() -> None:
         rel = path.relative_to(_PKG_ROOT.parent)
         for name in sorted(external & BANNED_EXTERNAL):
             violations.append(f"{rel}: banned external import '{name}'")
-        for name in sorted(inrepo & BANNED_INREPO):
+        for name in sorted(module for module in inrepo if _matches_banned_inrepo(module)):
             violations.append(f"{rel}: banned in-repo import '{name}'")
     assert not violations, (
         "Execution-path determinism invariants violated (see "
         f"{_INVARIANTS_DOC}):\n  " + "\n  ".join(violations)
+    )
+
+
+def test_execution_modules_have_no_banned_dynamic_imports() -> None:
+    """``executor.py`` and ``_execution/*`` cannot hide banned imports dynamically."""
+    violations: list[str] = []
+    for path in _execution_module_paths():
+        external, inrepo = _collect_dynamic_imports_from_path(path)
+        rel = path.relative_to(_PKG_ROOT.parent)
+        for name in sorted(external & BANNED_EXTERNAL):
+            violations.append(f"{rel}: banned dynamic external import '{name}'")
+        for name in sorted(module for module in inrepo if _matches_banned_inrepo(module)):
+            violations.append(f"{rel}: banned dynamic in-repo import '{name}'")
+    assert not violations, (
+        "Execution-path determinism invariants violated via dynamic imports "
+        f"(see {_INVARIANTS_DOC}):\n  " + "\n  ".join(violations)
     )
 
 
@@ -205,7 +331,7 @@ def test_execution_closure_never_reaches_banned_inrepo_modules() -> None:
         if module in seen:
             continue
         seen.add(module)
-        if module in BANNED_INREPO:
+        if _matches_banned_inrepo(module):
             offending.append(module)
             continue  # Don't descend into a banned module.
         module_path = _module_to_path(module)
@@ -218,6 +344,35 @@ def test_execution_closure_never_reaches_banned_inrepo_modules() -> None:
         "Banned in-repo modules are reachable from the deterministic execution "
         f"path (see {_INVARIANTS_DOC}):\n  " + "\n  ".join(sorted(offending))
     )
+
+
+def test_dynamic_import_detector_flags_literal_banned_modules() -> None:
+    """Self-test the dynamic-import detector without mutating execution modules."""
+    tree = ast.parse(
+        """
+import builtins as builtins_alias
+import importlib as loader
+from builtins import __import__ as builtin_import
+from importlib import import_module as load_module
+
+__import__("random")
+builtins_alias.__import__("anthropic")
+loader.import_module("requests")
+load_module("openai")
+builtin_import("chainweaver.optimizer")
+load_module(name="chainweaver.compiler_llm.helpers")
+module_name = "secrets"
+__import__(module_name)
+"""
+    )
+
+    external, inrepo = _collect_dynamic_imports(tree)
+
+    assert {"random", "anthropic", "requests", "openai"} <= external
+    assert "secrets" not in external
+    assert "chainweaver.optimizer" in inrepo
+    assert "chainweaver.compiler_llm.helpers" in inrepo
+    assert _matches_banned_inrepo("chainweaver.compiler_llm.helpers")
 
 
 def test_banned_lists_are_documented_and_consistent() -> None:


### PR DESCRIPTION
## Summary

Hardens the executor determinism import contract for #430 by extending the existing #354 guard to catch literal dynamic-import bypasses — including relative `importlib.import_module` references — so the executor / `_execution` boundary stays protected against LLM, network, and randomness imports without adding dependencies or a separate CI job.

## Changes

- `tests/test_executor_import_contract.py`: add AST detection for `__import__("...")`, `importlib.import_module("...")`, and simple aliases when the target is a string literal, including relative literals (e.g. `importlib.import_module(".optimizer", package="chainweaver")`) resolved against their `package` argument the same way CPython resolves them at runtime; treat banned in-repo submodules as banned too; add self-tests covering both the absolute-literal and relative-resolution cases.
- `docs/agent-context/invariants.md`: document the dynamic-import hardening, its relative-literal resolution, and its deliberate string-literal scope.
- `AGENTS.md`: point agents at the mechanical import-contract enforcement.
- `CHANGELOG.md`: record the #430 hardening under Unreleased / Fixed.

## Why

#430 asks for CI protection of the executor invariants: no LLM calls, no network I/O, and no randomness in `executor.py` / `_execution`. PR #384 already added direct-import and transitive in-repo reach checks; this PR closes the remaining reviewable bypass where a banned module could be imported dynamically via a literal string — including a relative literal, which an earlier version of the detector missed by classifying the target from the dotted string's first component without first resolving leading dots against the call's `package` argument.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`) — `All checks passed!`
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`) — `233 files already formatted`
- [x] Type checking passes (`python -m mypy chainweaver/`) — `Success: no issues found in 81 source files`
- [x] All existing tests pass (`python -m pytest tests/ -v`) — `1706 passed, 1 skipped`; coverage `92.74%`
- [x] New tests added for new functionality — `python -m pytest tests/test_executor_import_contract.py -v --no-cov` collected 6 tests, `6 passed`

## Tradeoffs / risks

- The dynamic-import detector intentionally covers literal, AST-visible patterns only, including relative `importlib.import_module` literals resolved against a literal `package` argument. It does not evaluate runtime-built strings; executor code should not use runtime-built imports.
- No runtime behavior, public API, dependency, or package metadata changes.

## Scope notes

- Changes are limited to #430 import-contract hardening and docs/changelog alignment.
- #378 remains separate: this PR does not broaden base-package dependency scanning.

## Related Issues

Closes #430

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented (N/A: no public API changes)
- [x] No secrets or credentials included
