### PR TITLE
Fix fallback safety-gate bypass, async skip diagnostics, and unenforced retry-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fallback safety-gate bypass, async skip-diagnostics loss, and
+  unenforced retry-safety in `FlowExecutor`** (#486, #487, #488): three
+  step-failure-handling correctness bugs found by the same audit pass and
+  fixed together since they share one root cause — `ToolSafetyContract`
+  guarantees enforced on the primary tool invocation were not consistently
+  enforced on its alternate paths. `on_error="fallback:<tool>"` now routes
+  the fallback tool through the same execution-time safety gate as the
+  primary (#356) in both lanes — a fallback declaring
+  `requires_approval=True` or exceeding `max_side_effect_level` is refused
+  rather than run ungated, and on the sync lane a side-effecting fallback
+  with no `dry_run_fn` is stubbed rather than invoked under `dry_run=True`
+  (#357); the async lane has no dry-run mode to mirror (#486). The async
+  lane's `on_error="skip"` path now records the wrapped
+  `error_type`/`error_message` on the resulting `StepRecord`, matching the
+  sync lane instead of silently discarding the diagnostics (#487). Under
+  `strict_safety=True`, a `RetryPolicy` attached to a step whose tool
+  declares `safe_to_retry=False` (or is non-idempotent and side-effecting)
+  is no longer honoured — the tool runs once rather than risk duplicating
+  an uncertain side effect on retry; `compile_flow()` also emits a
+  non-blocking `unsafe_retry` `CompilationWarning` for this combination
+  regardless of `strict_safety` (#488).
+
 - **Executor determinism import-contract hardening** (#430): the guard in
   `tests/test_executor_import_contract.py` now rejects obvious literal dynamic
   import patterns (`__import__("random")`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is no longer honoured — the tool runs once rather than risk duplicating
   an uncertain side effect on retry; `compile_flow()` also emits a
   non-blocking `unsafe_retry` `CompilationWarning` for this combination
-  regardless of `strict_safety` (#488).
+  regardless of `strict_safety` (#488). The async fallback path also now
+  preserves the primary failure in `retry_errors` even when it arrives
+  empty (a streaming-tool failure bypasses `_invoke_tool_async`'s own
+  accumulation), so a successful fallback after a streaming failure no
+  longer loses the recovery root-cause from the trace.
 
 - **Executor determinism import-contract hardening** (#430): the guard in
   `tests/test_executor_import_contract.py` now rejects obvious literal dynamic

--- a/chainweaver/compiler.py
+++ b/chainweaver/compiler.py
@@ -364,6 +364,33 @@ def _validate_step(
 
     tool = tools[step.tool_name]
     tool_input_fields = _get_model_fields(tool.input_schema)
+
+    # 0. Retry-safety advisory (issue #488): a ``RetryPolicy`` attached to a
+    # step whose tool's safety contract says a failed call must not be
+    # retried risks silently duplicating a side effect on transient
+    # failures.  Non-blocking — the executor additionally refuses the retry
+    # outright when ``strict_safety=True``.
+    if step.retry is not None and step.retry.max_retries > 0:
+        contract = tool.safety
+        unsafe = not contract.safe_to_retry or (not contract.idempotent and not contract.read_only)
+        if unsafe:
+            warnings.append(
+                CompilationWarning(
+                    step_index=step_index,
+                    tool_name=step.tool_name,
+                    field_name=None,
+                    issue_type="unsafe_retry",
+                    detail=(
+                        f"Step {step_index} ('{step.tool_name}') has a RetryPolicy "
+                        f"but the tool's safety contract declares "
+                        f"safe_to_retry={contract.safe_to_retry}, "
+                        f"idempotent={contract.idempotent}, "
+                        f"read_only={contract.read_only} — retrying a failed call "
+                        "may duplicate a side effect."
+                    ),
+                )
+            )
+
     fallback_tool: Tool | None = None
     if step.on_error.startswith("fallback:"):
         fallback_name = step.on_error[len("fallback:") :]

--- a/chainweaver/executor.py
+++ b/chainweaver/executor.py
@@ -2502,6 +2502,7 @@ class FlowExecutor:
             cached: bool = False,
             fallback_used: bool = False,
             fallback_tool_name: str | None = None,
+            approval: ApprovalRecord | None = None,
         ) -> StepRecord:
             err_type, err_msg = (None, None) if error is None else _exc_to_strings(error)
             retry_count = max(0, tool_attempts[0] - 1)
@@ -2522,7 +2523,9 @@ class FlowExecutor:
                 cached=cached,
                 fallback_used=fallback_used,
                 fallback_tool_name=fallback_tool_name,
-                approval=approval_record,
+                # A fallback-path safety-gate decision (issue #486) takes
+                # precedence over the primary gate's decision when both ran.
+                approval=approval if approval is not None else approval_record,
             )
 
         def _finish(record: StepRecord) -> StepRecord:
@@ -2729,6 +2732,9 @@ class FlowExecutor:
                     wrapped_error=wrapped,
                     retry_errors=retry_errors,
                     make_record=_record,
+                    flow_name=flow_name,
+                    trace_id=trace_id,
+                    step_id=getattr(step, "step_id", None),
                 )
             )
 
@@ -2855,6 +2861,9 @@ class FlowExecutor:
                 wrapped_error=wrapped,
                 retry_errors=retry_errors,
                 make_record=record_fn,
+                flow_name=flow_name,
+                trace_id=trace_id,
+                step_id=getattr(step, "step_id", None),
             )
 
         log_step_end(
@@ -3006,14 +3015,21 @@ class FlowExecutor:
 
         Applies the same backoff schedule via :func:`asyncio.sleep`
         instead of tenacity's blocking ``time.sleep``, so retries don't
-        starve the calling event loop.
+        starve the calling event loop. Honours the same ``strict_safety``
+        retry-suppression rule as the sync lane (issue #488).
         """
-        if policy is None:
+        if policy is None or (self._strict_safety and self._retry_disallowed_by_contract(tool)):
             attempts[0] += 1
             try:
                 return await tool.run_async(inputs)
             except Exception as exc:
-                retry_errors.append(str(exc))
+                if policy is not None:
+                    retry_errors.append(
+                        f"{exc} (retry suppressed: tool '{tool.name}' safety "
+                        "contract disallows unsafe retry under strict_safety=True)"
+                    )
+                else:
+                    retry_errors.append(str(exc))
                 raise
 
         retryable = policy.resolved_retryable_errors()
@@ -3045,12 +3061,20 @@ class FlowExecutor:
         wrapped_error: Exception,
         retry_errors: list[str],
         make_record: Callable[..., StepRecord],
+        flow_name: str,
+        trace_id: str,
+        step_id: str | None = None,
     ) -> StepRecord:
         """Async counterpart to :meth:`_apply_on_error`.
 
-        Identical fail / skip behaviour to the sync path; the
-        ``fallback:<tool_name>`` branch dispatches the fallback tool
-        via :meth:`Tool.run_async` so async fallbacks compose.
+        Identical fail / skip behaviour to the sync path — including,
+        as of issue #487, recording the wrapped error on a ``"skip"``
+        outcome rather than silently dropping it.  The
+        ``fallback:<tool_name>`` branch dispatches the fallback tool via
+        :meth:`Tool.run_async` so async fallbacks compose, and — as of
+        issue #486 — clears the same execution-time safety gate the
+        primary tool did before running (the async lane has no dry-run
+        mode, so unlike the sync path there is no dry-run stub here).
         """
         on_error = step.on_error
         if on_error == "fail":
@@ -3066,7 +3090,7 @@ class FlowExecutor:
             return make_record(
                 inputs=inputs,
                 outputs={},
-                error=None,
+                error=wrapped_error,
                 success=True,
                 skipped=True,
                 retry_errors=retry_errors,
@@ -3089,6 +3113,31 @@ class FlowExecutor:
                     fallback_used=True,
                     fallback_tool_name=fb_name,
                 )
+
+            gate_error, fallback_approval = self._evaluate_safety_gate(
+                step=step,
+                tool=fb_tool,
+                step_index=step_index,
+                inputs=inputs,
+                flow_name=flow_name,
+                trace_id=trace_id,
+                step_id=step_id,
+            )
+            if gate_error is not None:
+                log_step_error(_logger, step_index, step.display_name, gate_error)
+                retry_errors.append(f"fallback '{fb_name}' refused by safety gate: {gate_error}")
+                return make_record(
+                    inputs=inputs,
+                    outputs=None,
+                    error=gate_error,
+                    success=False,
+                    skipped=False,
+                    retry_errors=retry_errors,
+                    fallback_used=True,
+                    fallback_tool_name=fb_name,
+                    approval=fallback_approval,
+                )
+
             try:
                 outputs = await fb_tool.run_async(inputs)
             except Exception as exc:
@@ -3103,6 +3152,7 @@ class FlowExecutor:
                     retry_errors=retry_errors,
                     fallback_used=True,
                     fallback_tool_name=fb_name,
+                    approval=fallback_approval,
                 )
             return make_record(
                 inputs=inputs,
@@ -3113,6 +3163,7 @@ class FlowExecutor:
                 retry_errors=retry_errors,
                 fallback_used=True,
                 fallback_tool_name=fb_name,
+                approval=fallback_approval,
             )
         # Unrecognised on_error → treat as fail.
         return make_record(
@@ -4662,6 +4713,7 @@ class FlowExecutor:
             cached: bool = False,
             fallback_used: bool = False,
             fallback_tool_name: str | None = None,
+            approval: ApprovalRecord | None = None,
         ) -> StepRecord:
             err_type, err_msg = (None, None) if error is None else _exc_to_strings(error)
             # ``retry_count`` = retries beyond the initial invocation.
@@ -4686,7 +4738,11 @@ class FlowExecutor:
                 cached=cached,
                 fallback_used=fallback_used,
                 fallback_tool_name=fallback_tool_name,
-                approval=approval_record,
+                # A fallback-path safety-gate decision (issue #486) takes
+                # precedence over the primary gate's decision when both ran —
+                # the fallback's approval is the one that actually gated
+                # execution of the tool whose outputs/error this record carries.
+                approval=approval if approval is not None else approval_record,
                 decision=decision_record,
             )
 
@@ -4912,6 +4968,9 @@ class FlowExecutor:
                     wrapped_error=wrapped,
                     retry_errors=retry_errors,
                     make_record=_record,
+                    flow_name=flow_name,
+                    trace_id=trace_id,
+                    step_id=step_id,
                 )
             )
 
@@ -5124,6 +5183,22 @@ class FlowExecutor:
             retry_errors=[],
         )
 
+    def _retry_disallowed_by_contract(self, tool: Tool) -> bool:
+        """Whether *tool*'s safety contract forbids retrying a failed call.
+
+        ``True`` when the contract explicitly marks the tool unsafe to retry
+        (``safe_to_retry=False``), or when it is both non-idempotent and
+        side-effecting (issue #488): retrying a non-idempotent side-effecting
+        tool after a failure of unknown effect (did the charge go through
+        before it errored?) risks duplicating the side effect. A
+        non-idempotent but read-only tool is unaffected — nothing external
+        changes state to duplicate.
+        """
+        contract = tool.safety
+        if not contract.safe_to_retry:
+            return True
+        return not contract.idempotent and not contract.read_only
+
     def _invoke_tool(
         self,
         tool: Tool,
@@ -5140,13 +5215,25 @@ class FlowExecutor:
         without conflating it with on-error decorations.  The final
         exception (after exhaustion or a non-retryable error) is re-raised;
         the caller is responsible for wrapping it.
+
+        Under ``strict_safety=True`` (issue #356), a *policy* attached to a
+        tool whose safety contract disallows retry (issue #488) is not
+        honoured: the tool is invoked exactly once, matching ``policy=None``
+        behaviour, rather than silently risking a duplicated side effect on
+        a retried non-idempotent call.
         """
-        if policy is None:
+        if policy is None or (self._strict_safety and self._retry_disallowed_by_contract(tool)):
             attempts[0] += 1
             try:
                 return tool.run(inputs)
             except Exception as exc:
-                retry_errors.append(str(exc))
+                if policy is not None:
+                    retry_errors.append(
+                        f"{exc} (retry suppressed: tool '{tool.name}' safety "
+                        "contract disallows unsafe retry under strict_safety=True)"
+                    )
+                else:
+                    retry_errors.append(str(exc))
                 raise
 
         def _wait_fn(retry_state: Any) -> float:
@@ -5205,6 +5292,9 @@ class FlowExecutor:
         wrapped_error: Exception,
         retry_errors: list[str],
         make_record: Callable[..., StepRecord],
+        flow_name: str,
+        trace_id: str,
+        step_id: str | None = None,
     ) -> StepRecord:
         """Apply the step's ``on_error`` policy and return a final record.
 
@@ -5212,9 +5302,15 @@ class FlowExecutor:
         - ``"skip"``: return a successful, ``skipped=True`` record with
           empty outputs so the flow continues without merging anything.
         - ``"fallback:<tool_name>"``: invoke the named tool with the same
-          inputs.  If it succeeds, return a successful record using its
-          outputs.  If it fails, return a failed record carrying the
-          fallback's exception (the original error stays in ``retry_errors``).
+          inputs, subject to the same execution-time safety gate and
+          dry-run handling as the primary tool (issue #486) — a fallback
+          declaring ``requires_approval`` or exceeding
+          ``max_side_effect_level`` is refused rather than run ungated, and
+          a side-effecting fallback is stubbed (never actually invoked)
+          under ``dry_run=True``.  If it succeeds, return a successful
+          record using its outputs.  If it fails, return a failed record
+          carrying the fallback's exception (the original error stays in
+          ``retry_errors``).
         """
         on_error = step.on_error
         if on_error == "fail":
@@ -5256,6 +5352,64 @@ class FlowExecutor:
                 fallback_tool_name=fallback_name,
             )
 
+        combined_retry_errors = [*retry_errors, str(wrapped_error)]
+
+        gate_error, fallback_approval = self._evaluate_safety_gate(
+            step=step,
+            tool=fallback_tool,
+            step_index=step_index,
+            inputs=inputs,
+            flow_name=flow_name,
+            trace_id=trace_id,
+            step_id=step_id,
+        )
+        if gate_error is not None:
+            log_step_error(_logger, step_index, step.display_name, gate_error)
+            return make_record(
+                inputs=inputs,
+                outputs=None,
+                error=gate_error,
+                success=False,
+                skipped=False,
+                retry_errors=combined_retry_errors,
+                fallback_used=True,
+                fallback_tool_name=fallback_name,
+                approval=fallback_approval,
+            )
+
+        if self._local.dry_run:
+
+            def _fallback_dry_record(
+                *,
+                inputs: dict[str, Any],
+                outputs: dict[str, Any] | None,
+                error: Exception | None,
+                success: bool,
+                skipped: bool,
+                retry_errors: list[str],
+            ) -> StepRecord:
+                return make_record(
+                    inputs=inputs,
+                    outputs=outputs,
+                    error=error,
+                    success=success,
+                    skipped=skipped,
+                    retry_errors=combined_retry_errors,
+                    fallback_used=True,
+                    fallback_tool_name=fallback_name,
+                    approval=fallback_approval,
+                )
+
+            dry_record = self._dry_run_step(
+                step=step,
+                tool=fallback_tool,
+                step_index=step_index,
+                inputs=inputs,
+                record_fn=_fallback_dry_record,
+            )
+            if dry_record is not None:
+                return dry_record
+
         try:
             outputs = fallback_tool.run(inputs)
         except Exception as fallback_exc:
@@ -5268,9 +5422,10 @@ class FlowExecutor:
                 error=wrapped,
                 success=False,
                 skipped=False,
-                retry_errors=[*retry_errors, str(wrapped_error)],
+                retry_errors=combined_retry_errors,
                 fallback_used=True,
                 fallback_tool_name=fallback_name,
+                approval=fallback_approval,
             )
 
         return make_record(
@@ -5279,9 +5434,10 @@ class FlowExecutor:
             error=None,
             success=True,
             skipped=False,
-            retry_errors=[*retry_errors, str(wrapped_error)],
+            retry_errors=combined_retry_errors,
             fallback_used=True,
             fallback_tool_name=fallback_name,
+            approval=fallback_approval,
         )
 
     # ------------------------------------------------------------------

--- a/chainweaver/executor.py
+++ b/chainweaver/executor.py
@@ -3099,6 +3099,12 @@ class FlowExecutor:
         prefix = "fallback:"
         if on_error.startswith(prefix):
             fb_name = on_error[len(prefix) :]
+            # Preserve the primary failure in the trace even when
+            # retry_errors arrives empty (e.g. a streaming-tool failure
+            # bypasses _invoke_tool_async's own accumulation) — mirrors the
+            # sync lane's combined_retry_errors so a successful fallback
+            # doesn't erase the recovery root-cause from the record.
+            retry_errors.append(str(wrapped_error))
             try:
                 fb_tool = self.get_tool(fb_name)
             except ToolNotFoundError as exc:

--- a/docs/security.md
+++ b/docs/security.md
@@ -109,6 +109,18 @@ executor = FlowExecutor(
   itself, so the no-LLM / no-network / no-randomness invariants are preserved
   (the same model as `decision_callback`).  Enforcement applies on both the sync
   and async lanes.
+* A step's `on_error="fallback:<tool_name>"` target is subject to the **same
+  gate** as the primary tool (issue #486) — a fallback declaring
+  `requires_approval=True` or exceeding `max_side_effect_level` is refused,
+  not run ungated, and a side-effecting fallback with no `dry_run_fn` is
+  stubbed rather than invoked under `dry_run=True` (sync lane only — the async
+  lane has no dry-run mode).
+* A `RetryPolicy` attached to a step whose tool declares `safe_to_retry=False`
+  (or is non-idempotent and side-effecting) is **not honoured** under
+  `strict_safety=True` (issue #488): the tool is invoked once, not retried,
+  to avoid duplicating an uncertain side effect. `compile_flow` additionally
+  emits a non-blocking `unsafe_retry` warning for this combination regardless
+  of `strict_safety`.
 
 ## Dry-run rehearsals (#357)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,7 +7,8 @@ from typing import Any, Union
 from pydantic import BaseModel
 
 from chainweaver.compiler import CompilationResult, compile_flow
-from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep
+from chainweaver.contracts import SideEffectLevel, ToolSafetyContract
+from chainweaver.flow import DAGFlow, DAGFlowStep, Flow, FlowStep, RetryPolicy
 from chainweaver.tools import Tool
 
 # ---------------------------------------------------------------------------
@@ -125,6 +126,127 @@ class TestValidFlow:
         )
         result = compile_flow(flow, tools)
         assert result.success is True
+
+
+class TestUnsafeRetryAdvisory:
+    """``RetryPolicy`` against an unsafe-to-retry contract is a warning (#488)."""
+
+    def test_safe_to_retry_false_warns(self) -> None:
+        tools = _make_tools()
+        tools["double"] = Tool(
+            name="double",
+            description="Doubles, but not safe to retry.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_double_fn,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.EXTERNAL, safe_to_retry=False),
+        )
+        flow = Flow(
+            name="unsafe_retry",
+            description="Retries a tool that declares it unsafe to retry.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    retry=RetryPolicy(max_retries=2, backoff_seconds=0.0),
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+        result = compile_flow(flow, tools)
+        assert result.success is True  # advisory only, not blocking
+        warning = next(w for w in result.warnings if w.issue_type == "unsafe_retry")
+        assert warning.tool_name == "double"
+        assert warning.step_index == 0
+
+    def test_non_idempotent_side_effecting_warns(self) -> None:
+        tools = _make_tools()
+        tools["double"] = Tool(
+            name="double",
+            description="Doubles, non-idempotent side effect.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_double_fn,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.WRITE, idempotent=False),
+        )
+        flow = Flow(
+            name="unsafe_retry_non_idempotent",
+            description="Retries a non-idempotent, side-effecting tool.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    retry=RetryPolicy(max_retries=2, backoff_seconds=0.0),
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+        result = compile_flow(flow, tools)
+        assert any(w.issue_type == "unsafe_retry" for w in result.warnings)
+
+    def test_non_idempotent_read_only_does_not_warn(self) -> None:
+        # Non-idempotent but read-only: nothing external to duplicate.
+        tools = _make_tools()
+        tools["double"] = Tool(
+            name="double",
+            description="Doubles, non-idempotent but read-only.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_double_fn,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.READ, idempotent=False),
+        )
+        flow = Flow(
+            name="safe_retry_read_only",
+            description="Retries a non-idempotent read-only tool.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    retry=RetryPolicy(max_retries=2, backoff_seconds=0.0),
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+        result = compile_flow(flow, tools)
+        assert not any(w.issue_type == "unsafe_retry" for w in result.warnings)
+
+    def test_default_safety_contract_does_not_warn(self) -> None:
+        # The default ToolSafetyContract is maximally permissive
+        # (safe_to_retry=True, idempotent=True) — no advisory expected.
+        tools = _make_tools()
+        flow = Flow(
+            name="default_safe_retry",
+            description="Retries a tool with the default safety contract.",
+            steps=[
+                FlowStep(
+                    tool_name="double",
+                    input_mapping={"number": "number"},
+                    retry=RetryPolicy(max_retries=2, backoff_seconds=0.0),
+                )
+            ],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+        result = compile_flow(flow, tools)
+        assert not any(w.issue_type == "unsafe_retry" for w in result.warnings)
+
+    def test_no_retry_policy_no_warning_even_if_unsafe(self) -> None:
+        tools = _make_tools()
+        tools["double"] = Tool(
+            name="double",
+            description="Unsafe to retry, but no RetryPolicy attached.",
+            input_schema=NumberInput,
+            output_schema=ValueOutput,
+            fn=_double_fn,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.EXTERNAL, safe_to_retry=False),
+        )
+        flow = Flow(
+            name="unsafe_no_retry_policy",
+            description="No retry attached at all.",
+            steps=[FlowStep(tool_name="double", input_mapping={"number": "number"})],
+            input_schema_ref=Flow.schema_ref_from(NumberInput),
+        )
+        result = compile_flow(flow, tools)
+        assert not any(w.issue_type == "unsafe_retry" for w in result.warnings)
 
 
 class TestMissingTool:

--- a/tests/test_execution_safety.py
+++ b/tests/test_execution_safety.py
@@ -77,6 +77,43 @@ def _single_step_executor(tool: Tool, **executor_kwargs: Any) -> FlowExecutor:
     return executor
 
 
+def _failing_tool(name: str) -> Tool:
+    """A tool that always raises, for exercising on_error='fallback:...' paths."""
+
+    def fn(inp: _In) -> dict[str, Any]:
+        raise RuntimeError(f"{name} always fails")
+
+    return Tool(
+        name=name,
+        description=f"{name} tool.",
+        input_schema=_In,
+        output_schema=_Out,
+        fn=fn,
+        safety=ToolSafetyContract(side_effects=SideEffectLevel.READ),
+    )
+
+
+def _fallback_executor(primary: Tool, fallback: Tool, **executor_kwargs: Any) -> FlowExecutor:
+    registry = FlowRegistry()
+    registry.register_flow(
+        Flow(
+            name="f",
+            description="d",
+            steps=[
+                FlowStep(
+                    tool_name=primary.name,
+                    input_mapping={},
+                    on_error=f"fallback:{fallback.name}",
+                )
+            ],
+        )
+    )
+    executor = FlowExecutor(registry, **executor_kwargs)
+    executor.register_tool(primary)
+    executor.register_tool(fallback)
+    return executor
+
+
 # ---------------------------------------------------------------------------
 # #356 — approval enforcement
 # ---------------------------------------------------------------------------
@@ -295,3 +332,99 @@ class TestDryRun:
         executor = _single_step_executor(tool)
         result = executor.execute_flow("f", {"x": 1})
         assert result.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# #486 — fallback tools go through the same safety gate as the primary
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackSafetyGate:
+    def test_fallback_requiring_approval_is_denied_without_callback(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.WRITE, requires_approval=True)
+        executor = _fallback_executor(primary, fallback, strict_safety=True)
+        result = executor.execute_flow("f", {"x": 1})
+        assert result.success is False
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.fallback_tool_name == "fallback"
+        assert record.error_type == "ApprovalDeniedError"
+        assert record.approval is not None
+        assert record.approval.decision is ApprovalDecision.DENY
+
+    def test_fallback_approved_via_callback_runs(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.WRITE, requires_approval=True)
+        executor = _fallback_executor(
+            primary, fallback, approval_callback=lambda ctx: ApprovalDecision.APPROVE
+        )
+        result = executor.execute_flow("f", {"x": 1})
+        assert result.success is True
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.approval is not None
+        assert record.approval.decision is ApprovalDecision.APPROVE
+        assert result.final_output == {"x": 1, "y": 2}
+
+    def test_fallback_exceeding_side_effect_ceiling_is_refused(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.DESTRUCTIVE)
+        executor = _fallback_executor(
+            primary, fallback, max_side_effect_level=SideEffectLevel.READ
+        )
+        result = executor.execute_flow("f", {"x": 1})
+        assert result.success is False
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.error_type == "SafetyCeilingError"
+
+    def test_fallback_within_ceiling_runs(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.READ)
+        executor = _fallback_executor(
+            primary, fallback, max_side_effect_level=SideEffectLevel.WRITE
+        )
+        result = executor.execute_flow("f", {"x": 1})
+        assert result.success is True
+        assert result.execution_log[0].fallback_used is True
+
+    def test_fallback_side_effecting_step_stubbed_under_dry_run(self) -> None:
+        # A side-effecting fallback with no dry_run_fn is stubbed (skipped),
+        # never actually invoked — mirrors the primary's #357 behaviour.
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.WRITE)
+        executor = _fallback_executor(primary, fallback)
+        result = executor.execute_flow("f", {"x": 1}, dry_run=True)
+        assert result.dry_run is True
+        assert result.success is True
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.skipped is True
+        assert result.final_output == {"x": 1}
+
+    def test_fallback_read_only_actually_runs_under_dry_run(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.READ)
+        executor = _fallback_executor(primary, fallback)
+        result = executor.execute_flow("f", {"x": 1}, dry_run=True)
+        assert result.dry_run is True
+        assert result.success is True
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.skipped is False
+        assert result.final_output == {"x": 1, "y": 2}
+
+    def test_fallback_safety_gate_enforced_on_async_lane(self) -> None:
+        primary = _failing_tool("primary")
+        fallback = _make_tool("fallback", SideEffectLevel.WRITE, requires_approval=True)
+        executor = _fallback_executor(
+            primary, fallback, approval_callback=lambda ctx: ApprovalDecision.DENY
+        )
+        result = asyncio.run(executor.execute_flow_async("f", {"x": 1}))
+        assert result.success is False
+        record = result.execution_log[0]
+        assert record.fallback_used is True
+        assert record.error_type == "ApprovalDeniedError"
+        assert record.approval is not None
+        assert record.approval.decision is ApprovalDecision.DENY

--- a/tests/test_executor_async_parity.py
+++ b/tests/test_executor_async_parity.py
@@ -272,3 +272,41 @@ async def test_async_subflow_deadline_forwarded_into_subflow() -> None:
         await ex.execute_flow_async("parent", {"n": 1}, deadline=deadline)
     # The cancellation is re-anchored to the parent flow.
     assert excinfo.value.flow_name == "parent"
+
+
+# --------------------------------------------------------------------------
+# Async on_error="skip" diagnostics parity (#487)
+# --------------------------------------------------------------------------
+
+
+async def test_async_skip_records_error_diagnostics_like_sync() -> None:
+    """A skipped step's failure must be recorded on the async lane, matching
+    the sync lane's ``TestOnErrorSkip.test_skip_continues_with_empty_outputs``
+    (``tests/test_retry.py``) instead of silently dropping the diagnostics.
+    """
+
+    async def _explode(inp: _NIn) -> dict[str, Any]:
+        raise RuntimeError("async skip failure")
+
+    registry = FlowRegistry()
+    registry.register_flow(
+        Flow(
+            name="skip_async",
+            version="1.0.0",
+            description="",
+            steps=[FlowStep(tool_name="bad", input_mapping={"n": "n"}, on_error="skip")],
+        )
+    )
+    ex = FlowExecutor(registry=registry)
+    ex.register_tool(
+        Tool(name="bad", description="", input_schema=_NIn, output_schema=_Out, fn=_explode)
+    )
+
+    result = await ex.execute_flow_async("skip_async", {"n": 1})
+    assert result.success is True
+    record = result.execution_log[0]
+    assert record.skipped is True
+    assert record.outputs == {}
+    assert record.error_type == "FlowExecutionError"
+    assert record.error_message is not None
+    assert "async skip failure" in record.error_message

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -9,6 +10,7 @@ import pytest
 from helpers import NumberInput, ValueOutput
 from pydantic import BaseModel, ValidationError
 
+from chainweaver.contracts import SideEffectLevel, ToolSafetyContract
 from chainweaver.executor import FlowExecutor
 from chainweaver.flow import Flow, FlowStep, RetryPolicy
 from chainweaver.registry import FlowRegistry
@@ -108,6 +110,7 @@ def _build_executor(
     retry: RetryPolicy | None = None,
     on_error: str = "fail",
     extra_tools: tuple[Tool, ...] = (),
+    **executor_kwargs: Any,
 ) -> FlowExecutor:
     flow = Flow(
         name="retry_flow",
@@ -124,20 +127,21 @@ def _build_executor(
     )
     registry = FlowRegistry()
     registry.register_flow(flow)
-    ex = FlowExecutor(registry=registry)
+    ex = FlowExecutor(registry=registry, **executor_kwargs)
     ex.register_tool(tool)
     for extra in extra_tools:
         ex.register_tool(extra)
     return ex
 
 
-def _make_tool(name: str, fn: Any) -> Tool:
+def _make_tool(name: str, fn: Any, *, safety: ToolSafetyContract | None = None) -> Tool:
     return Tool(
         name=name,
         description=f"{name} tool.",
         input_schema=NumberInput,
         output_schema=ValueOutput,
         fn=fn,
+        safety=safety,
     )
 
 
@@ -384,3 +388,108 @@ class TestBackoffTiming:
         # Two sleeps of 50ms each.  Allow generous lower bound (90ms) to
         # avoid timer flakiness.
         assert elapsed >= 0.09
+
+
+class TestUnsafeRetrySuppression:
+    """``strict_safety`` suppresses retry for a contract that disallows it (#488)."""
+
+    def test_strict_safety_suppresses_retry_when_not_safe_to_retry(self) -> None:
+        counter = _Counter(fail_until_attempt=10)  # always fails
+        tool = _make_tool(
+            "charge",
+            counter,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.EXTERNAL, safe_to_retry=False),
+        )
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+            strict_safety=True,
+        )
+        result = ex.execute_flow("retry_flow", {"number": 1})
+        assert result.success is False
+        # Exactly one attempt — the retry policy was not honoured.
+        assert counter.attempts == 1
+        record = result.execution_log[0]
+        assert record.retry_count == 0
+        assert "retry suppressed" in record.retry_errors[0]
+
+    def test_strict_safety_suppresses_non_idempotent_side_effecting_tool(self) -> None:
+        counter = _Counter(fail_until_attempt=10)
+        tool = _make_tool(
+            "charge",
+            counter,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.WRITE, idempotent=False),
+        )
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+            strict_safety=True,
+        )
+        result = ex.execute_flow("retry_flow", {"number": 1})
+        assert result.success is False
+        assert counter.attempts == 1
+
+    def test_strict_safety_allows_retry_for_non_idempotent_read_only_tool(self) -> None:
+        # Non-idempotent but read-only (e.g. a clock read): nothing external
+        # changes state to duplicate, so retry is unaffected.
+        counter = _Counter(fail_until_attempt=1)
+        tool = _make_tool(
+            "flaky_read",
+            counter,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.READ, idempotent=False),
+        )
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+            strict_safety=True,
+        )
+        result = ex.execute_flow("retry_flow", {"number": 4})
+        assert result.success is True
+        assert counter.attempts == 2
+
+    def test_non_strict_safety_still_retries_unsafe_tool(self) -> None:
+        # strict_safety defaults to False: retry suppression is opt-in, so
+        # the pre-#488 permissive behaviour is unchanged outside strict mode.
+        counter = _Counter(fail_until_attempt=10)
+        tool = _make_tool(
+            "charge",
+            counter,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.EXTERNAL, safe_to_retry=False),
+        )
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+        )
+        result = ex.execute_flow("retry_flow", {"number": 1})
+        assert result.success is False
+        assert counter.attempts == 4  # initial + 3 retries, unaffected
+
+    def test_strict_safety_retries_normal_tool_unaffected(self) -> None:
+        # A tool with the default (safe) contract still retries normally
+        # under strict_safety=True.
+        counter = _Counter(fail_until_attempt=1)
+        tool = _make_tool("flaky", counter)
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+            strict_safety=True,
+        )
+        result = ex.execute_flow("retry_flow", {"number": 4})
+        assert result.success is True
+        assert counter.attempts == 2
+
+    def test_strict_safety_suppression_on_async_lane(self) -> None:
+        counter = _Counter(fail_until_attempt=10)
+        tool = _make_tool(
+            "charge",
+            counter,
+            safety=ToolSafetyContract(side_effects=SideEffectLevel.EXTERNAL, safe_to_retry=False),
+        )
+        ex = _build_executor(
+            tool,
+            retry=RetryPolicy(max_retries=3, backoff_seconds=0.0, backoff_multiplier=1.0),
+            strict_safety=True,
+        )
+        result = asyncio.run(ex.execute_flow_async("retry_flow", {"number": 1}))
+        assert result.success is False
+        assert counter.attempts == 1

--- a/tests/test_streaming_tools.py
+++ b/tests/test_streaming_tools.py
@@ -206,6 +206,61 @@ async def test_streaming_tool_without_terminal_chunk_fails_step() -> None:
     assert result.success is False
 
 
+async def test_streaming_failure_fallback_preserves_primary_error() -> None:
+    """A successful ``on_error="fallback:..."`` after a streaming-tool
+    failure must not lose the primary failure from ``retry_errors`` — a
+    streaming step bypasses ``_invoke_tool_async``'s own retry_errors
+    accumulation entirely, so the fallback branch is the only place left
+    that can record it (issue #486 review follow-up).
+    """
+
+    async def _boom(inp: _Query) -> AsyncIterator[ToolChunk]:
+        raise RuntimeError("stream boom")
+        yield  # pragma: no cover - unreachable; keeps this an async generator
+
+    registry = FlowRegistry()
+    registry.register_flow(
+        Flow(
+            name="gen_flow_fallback",
+            version="1.0.0",
+            description="",
+            steps=[
+                FlowStep(
+                    tool_name="generate",
+                    input_mapping={"prompt": "prompt"},
+                    on_error="fallback:backup",
+                )
+            ],
+        )
+    )
+    ex = FlowExecutor(registry=registry)
+    ex.register_tool(
+        StreamingTool(
+            name="generate",
+            description="Stream a completion.",
+            input_schema=_Query,
+            output_schema=_Completion,
+            stream_fn=_boom,
+        )
+    )
+    ex.register_tool(
+        Tool(
+            name="backup",
+            description="Non-streaming fallback.",
+            input_schema=_Query,
+            output_schema=_Completion,
+            fn=lambda inp: {"text": "fallback text"},
+        )
+    )
+
+    result = await ex.execute_flow_async("gen_flow_fallback", {"prompt": "hi"})
+    assert result.success is True
+    record = result.execution_log[0]
+    assert record.fallback_used is True
+    assert record.outputs == {"text": "fallback text"}
+    assert any("stream boom" in msg for msg in record.retry_errors)
+
+
 async def test_chunk_after_terminal_is_rejected() -> None:
     async def _extra_after_final(inp: _Query) -> AsyncIterator[ToolChunk]:
         yield ToolChunk(data={"text": "done"}, is_final=True)


### PR DESCRIPTION
## Summary

Three step-failure-handling correctness bugs in `FlowExecutor`, found together by the same repository audit pass and fixed together because they share one root cause: `ToolSafetyContract` guarantees enforced on the primary tool invocation were not consistently enforced on its alternate paths (fallback, skip-diagnostics, retry).

## Changes

- **#486 — Fallback tools bypass execution-time safety gates and can run real side effects under dry_run.** `on_error="fallback:<tool>"` now routes the fallback tool through the same `_evaluate_safety_gate` as the primary tool, in both the sync and async lanes — a fallback declaring `requires_approval=True` or exceeding `max_side_effect_level` is refused rather than run ungated. On the sync lane, a side-effecting fallback with no `dry_run_fn` is stubbed (never invoked) under `dry_run=True`, mirroring the primary's `#357` behavior; the async lane has no dry-run mode to mirror.
- **#487 — Async on_error="skip" drops error diagnostics from the trace.** The async lane's `on_error="skip"` path now records the wrapped `error_type`/`error_message` on the resulting `StepRecord`, matching the sync lane instead of silently recording `error=None`.
- **#488 — Retry machinery never consults ToolSafetyContract.safe_to_retry / idempotent.** Under `strict_safety=True`, a `RetryPolicy` attached to a step whose tool declares `safe_to_retry=False` (or is non-idempotent and side-effecting) is no longer honoured — the tool runs once rather than risk duplicating an uncertain side effect on retry. `compile_flow()` also emits a non-blocking `unsafe_retry` `CompilationWarning` for this combination regardless of `strict_safety`.

Two deliberate, evidence-backed deviations from the issues' literal wording (documented in the PR, not silent): #486's "honor dry_run in both lanes" is narrowed to the sync lane only (the async lane has no dry-run mode at all); #488's enforcement suppresses the *retry* rather than refusing to run the step at all, matching the issue's own "refuse to retry" wording rather than a louder "refuse to execute."

Out of scope, deliberately: #489 (extract a lane-agnostic step engine into `chainweaver/_execution/`) is the structural fix that would prevent this bug class recurring — it's a large decomposition and stays a separate follow-up rather than being bundled here.

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
- [x] All existing tests pass (`python -m pytest tests/ -v`) — 2098 passed, 1 skipped (pre-existing, unrelated), 93.02% coverage
- [x] New tests added for new functionality — 19 new tests across `tests/test_execution_safety.py` (7), `tests/test_executor_async_parity.py` (1), `tests/test_retry.py` (6), `tests/test_compiler.py` (5); each verified fail-first against the pre-fix code and pass after

## Issues closed by this PR

Closes #486
Closes #487
Closes #488

## Related Issues

Related to #489 (executor decomposition — the structural follow-up this bug class motivates)

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented — none; no new public symbols were added
- [x] No secrets or credentials included


---
_Generated by [Claude Code](https://claude.ai/code/session_01A8ELqFZurhwLRvy8KMzAk8)_