### PR TITLE
Release v0.14.0

### DIFF
--- a/.github/actions/chainweaver/README.md
+++ b/.github/actions/chainweaver/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
         with:
           directory: flows/
 ```
@@ -29,7 +29,7 @@ jobs:
 | `directory` | `.` | Directory scanned recursively for flow files. |
 | `annotations` | `true` | Emit GitHub `::error` annotations for each invalid flow file. Annotations are file-scoped — the flow serializer reports structural errors per file without line numbers. |
 | `python-version` | `3.10` | Python version used to install and run `chainweaver`. Must be one of ChainWeaver's supported versions (3.10–3.14). |
-| `chainweaver-version` | `0.13.0` | Exact version of `chainweaver` to install from PyPI (passed through to `pip install "chainweaver==<version>"`). Pinned by default; pass an empty string for the latest published version. |
+| `chainweaver-version` | `0.14.0` | Exact version of `chainweaver` to install from PyPI (passed through to `pip install "chainweaver==<version>"`). Pinned by default; pass an empty string for the latest published version. |
 | `extra-args` | `""` | Additional arguments appended verbatim to the invocation (e.g. `--quiet`). |
 
 ### Outputs
@@ -51,7 +51,7 @@ summary. Set `annotations: false` to disable.
 ### Validate every flow under `flows/`
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
   with:
     directory: flows/
 ```
@@ -59,7 +59,7 @@ summary. Set `annotations: false` to disable.
 ### Forward the result to a downstream step
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
   id: cw
   continue-on-error: true
   with:
@@ -72,15 +72,15 @@ summary. Set `annotations: false` to disable.
 ### Pin to a specific ChainWeaver release
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
   with:
-    chainweaver-version: "0.13.0"
+    chainweaver-version: "0.14.0"
 ```
 
 ### Track the latest release instead
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
   with:
     chainweaver-version: ""  # falls through to ``pip install chainweaver``
 ```
@@ -89,7 +89,7 @@ summary. Set `annotations: false` to disable.
 
 This action lives inside the `dgenio/ChainWeaver` repository, so it is
 versioned with the package. Pin to a ChainWeaver release tag
-(`@v0.13.0`) rather than `@main` to avoid implicit upgrades.
+(`@v0.14.0`) rather than `@main` to avoid implicit upgrades.
 
 The `chainweaver-version` input default matches the action's tag — both
 are bumped in lockstep when a new ChainWeaver release ships. If you

--- a/.github/actions/chainweaver/action.yml
+++ b/.github/actions/chainweaver/action.yml
@@ -27,7 +27,7 @@ inputs:
       Pinned by default to a known-good release; pass an empty string
       to install the latest published version.
     required: false
-    default: "0.13.0"
+    default: "0.14.0"
   extra-args:
     description: |
       Additional arguments appended verbatim to the ``chainweaver``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-12
+
 ### Added
 
 - **Input-stage content-safety guardrails** (#317): a new
@@ -1525,7 +1527,8 @@ flow.input_schema   # → MyInput (resolves the ref lazily)
 This file starts at 0.4.0.  See the git history for the contents of the
 0.1.0 and 0.2.0 releases.
 
-[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/dgenio/ChainWeaver/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/dgenio/ChainWeaver/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/dgenio/ChainWeaver/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/dgenio/ChainWeaver/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/dgenio/ChainWeaver/compare/v0.11.0...v0.12.0

--- a/chainweaver/__init__.py
+++ b/chainweaver/__init__.py
@@ -325,7 +325,7 @@ ExecutionSnapshot.model_rebuild(_types_namespace=_forward_namespace)
 # applications can configure logging centrally without interference.
 logging.getLogger("chainweaver").addHandler(logging.NullHandler())
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 __all__ = [
     "BUILTIN_PROPERTIES",

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+      - uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
         with:
           directory: flows/
 ```
@@ -51,7 +51,7 @@ structural errors per file, not per line.
 | `directory` | `.` | Directory scanned recursively for flow files. |
 | `annotations` | `true` | Emit `::error` annotations for invalid files. Set `false` to disable. |
 | `python-version` | `3.10` | Python used to install and run `chainweaver` (3.10–3.14). |
-| `chainweaver-version` | `0.13.0` | Exact PyPI version to install. Pass `""` for the latest published release. |
+| `chainweaver-version` | `0.14.0` | Exact PyPI version to install. Pass `""` for the latest published release. |
 | `extra-args` | `""` | Extra args appended verbatim (e.g. `--quiet`). |
 
 ## Outputs
@@ -64,7 +64,7 @@ To branch on the result without failing the job, set `continue-on-error: true`
 on the action step and inspect `exit-code`:
 
 ```yaml
-- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.13.0
+- uses: dgenio/ChainWeaver/.github/actions/chainweaver@v0.14.0
   id: cw
   continue-on-error: true
   with:
@@ -76,7 +76,7 @@ on the action step and inspect `exit-code`:
 
 ## Versioning
 
-Pin to a ChainWeaver release tag (`@v0.13.0`) rather than `@main` to avoid
+Pin to a ChainWeaver release tag (`@v0.14.0`) rather than `@main` to avoid
 implicit upgrades. The `chainweaver-version` input default tracks the action's
 tag; both move in lockstep on each release.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dgenio/chainweaver",
   "title": "ChainWeaver",
   "description": "Expose deterministic ChainWeaver flows as MCP tools without LLM calls between steps.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "repository": {
     "url": "https://github.com/dgenio/ChainWeaver",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "chainweaver",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary

- Bump package version 0.13.0 → 0.14.0 via `scripts/release.py prepare 0.14.0`
- Promotes `CHANGELOG.md` `## [Unreleased]` to `## [0.14.0] - 2026-07-12`
- Updates `server.json`, `.github/actions/chainweaver/action.yml`, `.github/actions/chainweaver/README.md`, `docs/github-action.md` version references

## Testing

- [x] Linting passes (`ruff check chainweaver/ tests/ examples/`)
- [x] Formatting check passes (`ruff format --check chainweaver/ tests/ examples/`)
- [x] Type checking passes (`python -m mypy chainweaver/ tests/`)
- [x] All existing tests pass (`python -m pytest tests/ -q` — 2212 passed, 1 skipped)
- [x] `scripts/release.py check --expected-version 0.14.0` — no drift

## Issues closed by this PR

N/A — release-preparation PR.

## Checklist
- [x] Code follows project conventions (see `AGENTS.md` and `docs/agent-context/`)
- [x] Public API changes are documented (none in this PR — metadata only)
- [x] No secrets or credentials included

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuJ4ETDxUpWMdofZQWjAhY)_